### PR TITLE
Add Sugarkube Production Observability dashboard and production validation

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -1,0 +1,732 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cluster health",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 2,
+      "title": "Scrape availability by job",
+      "type": "table",
+      "description": "1 is healthy, 0 is unhealthy; absence is NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min by (job) (up)",
+          "legendFormat": "{{job}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Ready nodes",
+      "type": "stat",
+      "description": "Three is the observed visual expectation, not an alert threshold.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"}))",
+          "legendFormat": "Ready nodes",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Node readiness",
+      "type": "table",
+      "description": "1 is ready, 0 is not ready; absence is NO DATA.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+          "legendFormat": "{{node}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Workload health",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 6,
+      "title": "Deployment replica deficit",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
+          "legendFormat": "{{namespace}} / {{deployment}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Unready pods by namespace",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition=\"false\"}))",
+          "legendFormat": "{{namespace}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Problem pods by namespace",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"}))",
+          "legendFormat": "{{namespace}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Container restart rate",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
+          "legendFormat": "{{namespace}} / {{pod}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Node and Prometheus capacity",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 11,
+      "title": "Node CPU utilization",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 8,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "mappings": [],
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Node memory utilization",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 23,
+        "w": 8,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "mappings": [],
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Root filesystem utilization",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 23,
+        "w": 8,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"}) * on (instance) group_left (nodename) node_uname_info)",
+          "legendFormat": "{{nodename}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "mappings": [],
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Prometheus PVC utilization",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 30,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}))",
+          "legendFormat": "{{persistentvolumeclaim}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "mappings": [],
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Prometheus active series",
+      "type": "timeseries",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 30,
+        "w": 12,
+        "h": 7
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod) (prometheus_tsdb_head_series)",
+          "legendFormat": "{{pod}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "id": 16,
+      "title": "Observability build identity",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 37,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 17,
+      "title": "Observability component build identity",
+      "type": "table",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 38,
+        "w": 24,
+        "h": 8
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "legendFormat": "Prometheus {{pod}} {{version}} {{revision}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "B",
+          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
+          "legendFormat": "Alertmanager {{pod}} {{version}} {{revision}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "C",
+          "expr": "max by (pod, version, revision) (grafana_build_info)",
+          "legendFormat": "Grafana {{pod}} {{version}} {{revision}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        },
+        {
+          "refId": "D",
+          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
+          "legendFormat": "node-exporter {{pod}} {{version}} {{revision}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "sugarkube",
+    "production",
+    "observability"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Sugarkube Production Observability",
+  "uid": "sugarkube-prod-observability",
+  "version": 1
+}

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -13,6 +13,7 @@ Merging production support is not evidence that the stack or a production dashbo
 - Production overrides: `clusters/prod/observability/kube-prometheus-stack.values.yaml`.
 - Canonical DSPACE rules: `platform/observability/rules/dspace-release-integrity.yaml`.
 - Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
+- Production dashboard: `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
 - Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md).
 - DSPACE release-integrity triage and focused drills:
@@ -129,18 +130,64 @@ disabled in this initial declarative phase, so UI-created state is ephemeral;
 provisioned dashboards remain code-owned, and durable UI state is a separate
 follow-up decision.
 
-Neither this correction nor PR #2529 proves a production deployment or a
-custom production dashboard. Both require separate, sanitized live evidence.
 
 The core baseline is one Prometheus and one Alertmanager replica, seven-day / 15
 GB retention, a 20 Gi RWO `local-path` Prometheus claim, and a null-only
 Alertmanager. Local-path storage is node-local and non-expandable, so capacity
 pressure or node loss needs explicit operator action. After at least one
 production week, review retention, WAL/PVC usage, and memory before changing
-capacity. The custom production dashboard is deferred until live stack metric
-families and labels are inventoried. Application panels and metrics lifecycle,
-blackbox monitoring, alerts, paging, HA, and persistent Grafana UI state are
-also explicitly deferred.
+capacity. The first production dashboard now uses only the sanitized live metric inventory below.
+Production application metrics, blackbox monitoring, alerts and paging, HA, retention/storage
+changes, and persistent Grafana UI state remain explicitly deferred.
+
+## Production dashboard: live-backed Phase 1
+
+`Sugarkube Production Observability` (`sugarkube-prod-observability`) is a single-cluster,
+provisioned dashboard with no environment or cluster selector. Prometheus `externalLabels` are
+applied when samples leave Prometheus, not to local query evaluation, so adding
+`cluster="sugarkube-prod"` to these local expressions would incorrectly return no data. All panels
+show `NO DATA` for absence; legitimate emitted zeroes are not replaced with synthetic zeroes.
+Visual colors and the observed three-node expectation are display guidance, not alert thresholds.
+
+The **Cluster health** row reports the minimum `up` value per job, the replica-safe count of Ready
+nodes, and each node's Ready condition. **Workload health** shows deployment desired-minus-available
+deficits after independently deduplicating each kube-state-metrics gauge, unready and problem pod
+counts after per-pod deduplication, and per-namespace/pod container restart rates over Grafana's
+`$__rate_interval`. **Node and Prometheus capacity** maps node-exporter samples to the permitted
+`nodename` label through the internal `on(instance)` join; it presents CPU, memory, and root
+filesystem percentages on a 0–100 scale. The Prometheus PVC percentage independently takes the
+maximum available and capacity samples per claim before division. Active series remains a maximum
+per Prometheus pod rather than an unsafe sum across future replicas. **Observability build identity**
+keeps separate Prometheus, Alertmanager, Grafana, and node-exporter queries grouped by pod, version,
+and revision. `kube_state_metrics_build_info` was absent and is intentionally omitted rather than
+replaced with a different signal.
+
+The evidence was captured read-only on 2026-08-08 from repository SHA
+`2984f3fd5b39d391621f414ae01150cf6c0a7a59`, after Helm revision 1 installed successfully. Two
+distinct scrapes showed all 23 targets healthy: apiserver (3), coredns (1), Alertmanager (2), Grafana
+(1), operator (1), Prometheus (2), kube-state-metrics (1), kubelet (9), and node-exporter (3). Three
+nodes were Ready. Candidate queries returned three CPU results (about 2.39–4.04%), three memory
+results (15.00–25.17%), three root-filesystem results (6.26–6.50%), eleven zero deployment deficits,
+six zero problem-pod namespace results, twenty zero restart rates, one Prometheus PVC result (about
+6.50%), and about 174,263 active series. No raw target, URL, address, instance, error, or sensitive
+identity value was retained.
+
+Grafana persistence remains disabled: mutable UI-created state is ephemeral. The immutable dashboard
+is supplied by Helm and must recover after Grafana pod recreation without a manual UI save. After
+merge, perform the remaining production proof exactly as follows:
+
+1. Export `KUBECONFIG="$HOME/.kube/config-sugarkube-prod"` and verify context `sugar-prod`.
+2. Keep the externally managed `127.0.0.1:16443` tunnel running.
+3. Run `just observability-render env=prod`, save the output outside the repository, and inspect it.
+4. Run `just observability-upgrade env=prod`—not install, because Helm revision 1 already exists.
+5. Run `just observability-verify env=prod`.
+6. Run `just observability-dashboard-verify env=prod`.
+7. Delete only the Grafana pod, wait for its deployment rollout, then run dashboard verification again.
+8. Visually inspect every panel at <http://sugarkube0.local:30300> using credentials retrieved from the operator-managed vault.
+9. Record the Git SHA, Helm revision, and private operator-evidence path.
+
+This repository procedure does not itself contact production. The post-merge operator must provide
+the API, pod-recreation, and visual proof.
 
 ## Read-only preflight and status
 

--- a/scripts/observability_helm.sh
+++ b/scripts/observability_helm.sh
@@ -16,8 +16,12 @@ COMMON_VALUES="${ROOT}/platform/observability/helm/kube-prometheus-stack.values.
 STAGING_VALUES="${ROOT}/clusters/staging/observability/kube-prometheus-stack.values.yaml"
 PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"
 DSPACE_RULES="${ROOT}/platform/observability/rules/dspace-release-integrity.yaml"
-DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
-DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"
+STAGING_DASHBOARD="${ROOT}/clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD="${ROOT}/clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
+DASHBOARD=""
+DASHBOARD_VALUE=""
+DASHBOARD_UID=""
+DASHBOARD_TITLE=""
 DASHBOARD_VALIDATOR="${ROOT}/scripts/validate_observability_dashboard.py"
 TIMEOUT="${SUGARKUBE_OBSERVABILITY_HELM_TIMEOUT:-20m}"
 GRAFANA_URL="http://sugarkube3.local:30300"
@@ -45,10 +49,11 @@ normalize_env() {
 resolve_environment() {
   ENVIRONMENT="$(normalize_env "$1")"
   if [[ "$ENVIRONMENT" == staging ]]; then
-    ENV_VALUES="$STAGING_VALUES"; EXPECTED_CONTEXT="sugar-staging"; GRAFANA_URL="http://sugarkube3.local:30300"
+    ENV_VALUES="$STAGING_VALUES"; EXPECTED_CONTEXT="sugar-staging"; GRAFANA_URL="http://sugarkube3.local:30300"; DASHBOARD="$STAGING_DASHBOARD"; DASHBOARD_UID="sugarkube-staging-observability"; DASHBOARD_TITLE="Sugarkube Staging Observability"
   else
-    ENV_VALUES="$PROD_VALUES"; EXPECTED_CONTEXT="sugar-prod"; GRAFANA_URL="http://sugarkube0.local:30300"
+    ENV_VALUES="$PROD_VALUES"; EXPECTED_CONTEXT="sugar-prod"; GRAFANA_URL="http://sugarkube0.local:30300"; DASHBOARD="$PROD_DASHBOARD"; DASHBOARD_UID="sugarkube-prod-observability"; DASHBOARD_TITLE="Sugarkube Production Observability"
   fi
+  DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"
 }
 require_staging() { [[ "$ENVIRONMENT" == staging ]] || { echo "ERROR: $1 is staging-only; production support is deferred." >&2; exit 2; }; }
 require_tools() { for t in "$@"; do command -v "$t" >/dev/null 2>&1 || { echo "ERROR: required tool missing: $t" >&2; exit 127; }; done; }
@@ -68,8 +73,9 @@ ordered values files:
   - ${ENV_VALUES}
 EOT
   if [[ "$ENVIRONMENT" == staging ]]; then
-    printf '  - generated mode-0600 rules overlay sourced from %s\ndashboard source (--set-file): %s\n' "$DSPACE_RULES" "$DASHBOARD"
+    printf '  - generated mode-0600 rules overlay sourced from %s\n' "$DSPACE_RULES"
   fi
+  printf 'dashboard source (--set-file): %s\n' "$DASHBOARD"
   printf 'Grafana LAN URL: %s (same NodePort is available through the other %s nodes)\n' "$GRAFANA_URL" "$ENVIRONMENT"
 }
 assert_context() {
@@ -105,11 +111,11 @@ validate_rendered_alertmanager() { ruby "${ALERTMANAGER_VALIDATOR}" "${ENVIRONME
 render_to() {
   local out="$1"; shift
   local dashboard_args=()
-  [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
+  dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}")
   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
   helm repo update prometheus-community >/dev/null
   helm template "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "$@" "${dashboard_args[@]}" >"${out}"
-  [[ "$ENVIRONMENT" != staging ]] || validate_rendered_dashboard "${out}"
+  validate_rendered_dashboard "${out}"
   validate_rendered_alertmanager "${out}"
 }
 prepare_render_args() {
@@ -251,9 +257,9 @@ release_state() {
     return 1
   fi
 }
-render() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
-install_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
-upgrade_release() { [[ "$ENVIRONMENT" != staging ]] || validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; [[ "$ENVIRONMENT" != staging ]] || dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+render() { validate_dashboard; require_tools helm python3 ruby; print_resolved '<not queried: offline render>'; local tmp; tmp="$(mktemp -t sugarkube-observability-render.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; cat "$tmp"; }
+install_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-install.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == present ]]; then echo "ERROR: cannot install: ${RELEASE} already exists in ${NAMESPACE}. Use observability-upgrade." >&2; exit 4; fi; dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm install "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --create-namespace --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
+upgrade_release() { validate_dashboard; require_tools helm kubectl python3 ruby; print_resolved; assert_context; assert_grafana_secret; [[ "$ENVIRONMENT" != staging ]] || assert_integration_secrets; local tmp state dashboard_args=(); tmp="$(mktemp -t sugarkube-observability-upgrade.XXXXXX.yaml)"; trap 'rm -f "${tmp:-}" "${RULES_OVERLAY:-}"' EXIT; prepare_render_args; render_to "$tmp" "${RENDER_ARGS[@]}"; state="$(release_state)"; if [[ "$state" == absent ]]; then echo "ERROR: upgrade requires an existing Helm release ${RELEASE} in ${NAMESPACE}. Use observability-install for a fresh cluster." >&2; exit 5; fi; dashboard_args=(--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"); helm upgrade "${RELEASE}" "${CHART}" --namespace "${NAMESPACE}" --version "$(version)" -f "${COMMON_VALUES}" -f "${ENV_VALUES}" "${RENDER_ARGS[@]}" "${dashboard_args[@]}" --atomic --wait --timeout "${TIMEOUT}"; }
 WATCHDOG_TTY="${SUGARKUBE_WATCHDOG_TTY:-/dev/tty}"
 WATCHDOG_API="/api/v1/namespaces/${NAMESPACE}/services/http:${RELEASE}-alertmanager:9093/proxy/api/v2"
 
@@ -782,7 +788,7 @@ json.dump([{
 
 dashboard_verify() (
   require_tools kubectl python3 curl base64 sleep
-  print_resolved staging
+  print_resolved "${EXPECTED_CONTEXT}"
   assert_context
   local response body http_status port="" remote_port line
   local -a port_forward_lines=()
@@ -850,7 +856,7 @@ dashboard_verify() (
 
   for _ in {1..20}; do
     kill -0 "${verify_pid}" 2>/dev/null || port_forward_stopped
-    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/sugarkube-staging-observability" 2>"${verify_tmp}/curl.log")"; then
+    if response="$(curl --silent --show-error --max-time 3 --netrc-file "${verify_tmp}/netrc" --write-out $'\n%{http_code}' "http://127.0.0.1:${port}/api/dashboards/uid/${DASHBOARD_UID}" 2>"${verify_tmp}/curl.log")"; then
       http_status="${response##*$'\n'}"; body="${response%$'\n'*}"
       case "${http_status}" in
         401|403) echo "ERROR: Grafana authentication was rejected (credentials and response redacted)." >&2; return 14 ;;
@@ -864,9 +870,9 @@ try:
 except (json.JSONDecodeError, UnicodeError):
     raise SystemExit("ERROR: Grafana dashboard API returned malformed JSON (response redacted).")
 dashboard = result.get("dashboard") if isinstance(result, dict) else None
-if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging-observability" or dashboard.get("title") != "Sugarkube Staging Observability":
-    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' <<<"${body}"
-      echo "Grafana API confirmed dashboard UID sugarkube-staging-observability (credentials and response redacted)."
+if not isinstance(dashboard, dict) or dashboard.get("uid") != sys.argv[1] or dashboard.get("title") != sys.argv[2]:
+    raise SystemExit("ERROR: Grafana did not return the expected provisioned dashboard (response redacted).")' "${DASHBOARD_UID}" "${DASHBOARD_TITLE}" <<<"${body}"
+      echo "Grafana API confirmed dashboard UID ${DASHBOARD_UID} (credentials and response redacted)."
       return 0
     fi
     sleep 1
@@ -878,11 +884,11 @@ if not isinstance(dashboard, dict) or dashboard.get("uid") != "sugarkube-staging
 cmd="${1:-}"; shift || true; [[ -n "${cmd}" ]] || { usage; exit 2; }
 env_arg="${1:-}"; resolve_environment "${env_arg}"
 if [[ "${OBSERVABILITY_XTRACE_WAS_ENABLED}" == 1 && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then set -x; fi
-if [[ "${ENVIRONMENT}" == staging && "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
+if [[ "${cmd}" != grafana-secret-install && "${cmd}" != grafana-secret-check ]]; then
   validate_dashboard
 fi
 if [[ "${cmd}" == watchdog-drill-create ]]; then
   trap 'exit 130' INT
   trap 'exit 143' TERM
 fi
-case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) require_staging "dashboard-verify"; dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac
+case "${cmd}" in render) render ;; install) install_release ;; upgrade) upgrade_release ;; status) status ;; verify) verify ;; dashboard-verify) dashboard_verify ;; pagerduty-test) require_staging "pagerduty-test"; pagerduty_test "${2:-${1:-}}" ;; grafana-secret-install) grafana_secret_install "${@:2}" ;; grafana-secret-check) grafana_secret_check "${@:2}" ;; watchdog-secret-install) require_staging "watchdog-secret-install"; watchdog_secret_install "${@:2}" ;; watchdog-secret-check) require_staging "watchdog-secret-check"; watchdog_secret_check ;; watchdog-verify) require_staging "watchdog-verify"; watchdog_live_check ;; watchdog-drill-create) require_staging "watchdog-drill-create"; watchdog_silence_create ;; watchdog-drill-status) require_staging "watchdog-drill-status"; watchdog_silence_list ;; watchdog-drill-clear) require_staging "watchdog-drill-clear"; watchdog_silence_clear ;; *) usage; exit 2 ;; esac

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -689,6 +689,170 @@ def validate_tokenplace_semantics(dashboard: dict) -> None:
         raise SystemExit("ERROR: token.place Phase 2 metrics must not be presented as implemented.")
 
 
+PROD_TITLE = "Sugarkube Production Observability"
+PROD_UID = "sugarkube-prod-observability"
+PROD_ROWS = {
+    "Cluster health",
+    "Workload health",
+    "Node and Prometheus capacity",
+    "Observability build identity",
+}
+PROD_QUERIES = {
+    "Scrape availability by job": ["min by (job) (up)"],
+    "Ready nodes": [
+        'sum(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))'
+    ],
+    "Node readiness": [
+        'max by (node) (kube_node_status_condition{condition="Ready",status="true"})'
+    ],
+    "Deployment replica deficit": [
+        "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)"
+    ],
+    "Unready pods by namespace": [
+        'sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition="false"}))'
+    ],
+    "Problem pods by namespace": [
+        'sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~"Pending|Failed|Unknown"}))'
+    ],
+    "Container restart rate": [
+        "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))"
+    ],
+    "Node CPU utilization": [
+        'max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)'
+    ],
+    "Node memory utilization": [
+        "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)"
+    ],
+    "Root filesystem utilization": [
+        'max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}) * on (instance) group_left (nodename) node_uname_info)'
+    ],
+    "Prometheus PVC utilization": [
+        '100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}))'
+    ],
+    "Prometheus active series": ["max by (pod) (prometheus_tsdb_head_series)"],
+    "Observability component build identity": [
+        "max by (pod, version, revision) (prometheus_build_info)",
+        "max by (pod, version, revision) (alertmanager_build_info)",
+        "max by (pod, version, revision) (grafana_build_info)",
+        "max by (pod, version, revision) (node_exporter_build_info)",
+    ],
+}
+PROD_FORBIDDEN = {
+    "kube_state_metrics_build_info",
+    "probe_success",
+    "dspace_",
+    "tokenplace_",
+    "cluster=",
+    "or vector(0)",
+    "or on() vector(0)",
+}
+
+
+def validate_production_dashboard(path: Path, dashboard: dict) -> str:
+    global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
+    TITLE, UID = PROD_TITLE, PROD_UID
+    DASHBOARD_FILE = f"{UID}.json"
+    DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
+    if dashboard.get("uid") != UID or dashboard.get("title") != TITLE:
+        raise SystemExit("ERROR: incorrect production dashboard UID or title.")
+    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {
+        "from": "now-6h",
+        "to": "now",
+    }:
+        raise SystemExit("ERROR: production dashboard refresh and time range are fixed.")
+    if dashboard.get("templating", {}).get("list"):
+        raise SystemExit("ERROR: production dashboard must not define variables.")
+    items = list(panels(dashboard))
+    ids = [item.get("id") for item in items]
+    if any(not isinstance(value, int) for value in ids) or len(ids) != len(set(ids)):
+        raise SystemExit("ERROR: dashboard panel IDs must be unique integers.")
+    rows = [item.get("title") for item in items if item.get("type") == "row"]
+    if set(rows) != PROD_ROWS or len(rows) != len(PROD_ROWS):
+        raise SystemExit("ERROR: production rows must each occur exactly once.")
+    titles = [item.get("title") for item in items if item.get("type") != "row"]
+    if set(titles) != set(PROD_QUERIES) or len(titles) != len(PROD_QUERIES):
+        raise SystemExit("ERROR: production panels must each occur exactly once.")
+    rectangles = []
+    for item in items:
+        pos = item.get("gridPos", {})
+        if (
+            any(not isinstance(pos.get(k), int) for k in ("x", "y", "w", "h"))
+            or pos.get("w", 0) <= 0
+            or pos.get("h", 0) <= 0
+            or pos.get("x", -1) < 0
+            or pos.get("y", -1) < 0
+            or pos["x"] + pos["w"] > 24
+        ):
+            raise SystemExit("ERROR: dashboard panels must have valid grid positions.")
+        if item.get("type") != "row":
+            rect = (pos["x"], pos["y"], pos["x"] + pos["w"], pos["y"] + pos["h"])
+            if any(
+                rect[0] < other[2]
+                and rect[2] > other[0]
+                and rect[1] < other[3]
+                and rect[3] > other[1]
+                for other in rectangles
+            ):
+                raise SystemExit("ERROR: dashboard panel grid positions must not overlap.")
+            rectangles.append(rect)
+    for title, expected in PROD_QUERIES.items():
+        panel = panel_named(dashboard, title)
+        targets = panel.get("targets", [])
+        actual = [re.sub(r"\s+", " ", target.get("expr", "")).strip() for target in targets]
+        if actual != expected:
+            raise SystemExit(f"ERROR: {title} does not use the reviewed production PromQL.")
+        if (
+            any(target.get("datasource", {}).get("uid") != DATASOURCE_UID for target in targets)
+            or panel.get("datasource", {}).get("uid") != DATASOURCE_UID
+        ):
+            raise SystemExit("ERROR: production datasource UID must be prometheus.")
+        if panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
+            raise SystemExit("ERROR: production panels must preserve missing data as NO DATA.")
+    serialized = json.dumps(dashboard)
+    if any(value in serialized for value in PROD_FORBIDDEN):
+        raise SystemExit("ERROR: production dashboard contains an unverified or unsafe signal.")
+    forbidden_labels = {
+        "instance",
+        "ip",
+        "url",
+        "endpoint",
+        "device",
+        "system_uuid",
+        "provider_id",
+        "pod_cidr",
+        "address",
+    }
+    legends = "\n".join(
+        target.get("legendFormat", "") for item in items for target in item.get("targets", [])
+    )
+    exposed = set(re.findall(r"{{\s*([A-Za-z_][A-Za-z0-9_]*)\s*}}", legends)) & forbidden_labels
+    if exposed:
+        raise SystemExit("ERROR: production legends expose a forbidden raw label.")
+    for title in (
+        "Node CPU utilization",
+        "Node memory utilization",
+        "Root filesystem utilization",
+        "Prometheus PVC utilization",
+    ):
+        defaults = panel_named(dashboard, title)["fieldConfig"]["defaults"]
+        if (
+            defaults.get("unit") != "percent"
+            or defaults.get("min") != 0
+            or defaults.get("max") != 100
+        ):
+            raise SystemExit("ERROR: percent panels require a 0-100 percent scale.")
+    build = panel_named(dashboard, "Observability component build identity")
+    if build.get("type") != "table" or any(
+        not all(
+            label in target.get("legendFormat", "")
+            for label in ("{{pod}}", "{{version}}", "{{revision}}")
+        )
+        for target in build["targets"]
+    ):
+        raise SystemExit("ERROR: build identity must remain per pod, version, and revision.")
+    return path.read_text(encoding="utf-8")
+
+
 def validate_dashboard(path: Path) -> str:
     dashboard = load_dashboard(path)
     if dashboard.get("uid") != UID or dashboard.get("title") != TITLE:
@@ -895,7 +1059,12 @@ def main() -> None:
     parser.add_argument("dashboard", type=Path)
     parser.add_argument("--rendered", type=Path)
     args = parser.parse_args()
-    dashboard_json = validate_dashboard(args.dashboard)
+    document = load_dashboard(args.dashboard)
+    dashboard_json = (
+        validate_production_dashboard(args.dashboard, document)
+        if document.get("uid") == PROD_UID or "prod" in args.dashboard.name
+        else validate_dashboard(args.dashboard)
+    )
     if args.rendered:
         validate_render(args.rendered, dashboard_json)
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -8,6 +8,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
 VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
 SCRIPT = ROOT / "scripts/observability_helm.sh"
 PROMETHEUS_VALUES = ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml"
@@ -1101,10 +1102,9 @@ def test_validator_directly_rejects_missing_or_empty_render(tmp_path):
 def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
     script = SCRIPT.read_text(encoding="utf-8")
     assert script.count('--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"') == 3
-    assert (
-        'DASHBOARD_VALUE="grafana.dashboards.sugarkube.sugarkube-staging-observability.json"'
-        in script
-    )
+    assert 'DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"' in script
+    assert "sugarkube-staging-observability" in script
+    assert "sugarkube-prod-observability" in script
     assert script.index(
         "validate_dashboard; require_tools", script.index("install_release")
     ) < script.index("helm install")
@@ -1118,7 +1118,8 @@ def test_dashboard_verifier_is_guarded_read_only_and_redacted():
     body = script.split("dashboard_verify()", 1)[1].split('\ncmd="${1:-}"', 1)[0]
     assert "assert_context" in body
     assert body.index("assert_context") < body.index("get secret grafana-admin-credentials")
-    assert "/api/dashboards/uid/sugarkube-staging-observability" in body
+    assert "/api/dashboards/uid/${DASHBOARD_UID}" in body
+    assert 'dashboard.get("uid") != sys.argv[1]' in body
     assert "--netrc-file" in body and "chmod 600" in body and "rm -rf" in body
     for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
         assert mutation not in body
@@ -1151,3 +1152,44 @@ def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_pa
     )
     assert result.returncode != 0
     assert "dashboard JSON" in result.stderr
+
+
+@pytest.fixture
+def production_dashboard():
+    return json.loads(PROD_DASHBOARD.read_text(encoding="utf-8"))
+
+
+def test_production_dashboard_exact_contract(production_dashboard):
+    validator.validate_production_dashboard(PROD_DASHBOARD, production_dashboard)
+    panels = list(all_panels(production_dashboard))
+    assert production_dashboard["uid"] == validator.PROD_UID
+    assert production_dashboard["title"] == validator.PROD_TITLE
+    assert production_dashboard["templating"]["list"] == []
+    assert {p["title"] for p in panels if p["type"] == "row"} == validator.PROD_ROWS
+    assert {p["title"] for p in panels if p["type"] != "row"} == set(validator.PROD_QUERIES)
+    assert len({p["id"] for p in panels}) == len(panels)
+
+
+@pytest.mark.parametrize(
+    "needle", ['cluster="sugarkube-prod"', "or vector(0)", "kube_state_metrics_build_info"]
+)
+def test_production_validator_rejects_external_label_zero_fill_and_unverified_build(
+    production_dashboard, tmp_path, needle
+):
+    changed = json.loads(json.dumps(production_dashboard))
+    changed["panels"][1]["targets"][0]["expr"] += " " + needle
+    path = tmp_path / "prod.json"
+    path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        validator.validate_production_dashboard(path, changed)
+
+
+@pytest.mark.parametrize("title", ["Container restart rate", "Node CPU utilization"])
+def test_production_rates_require_grafana_interval(production_dashboard, tmp_path, title):
+    changed = json.loads(json.dumps(production_dashboard))
+    panel = next(p for p in all_panels(changed) if p["title"] == title)
+    panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace("$__rate_interval", "5m")
+    path = tmp_path / "prod.json"
+    path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(SystemExit, match="reviewed production PromQL"):
+        validator.validate_production_dashboard(path, changed)

--- a/tests/test_observability_helm.py
+++ b/tests/test_observability_helm.py
@@ -23,6 +23,7 @@ CANONICAL_DSPACE_RULES = (
 SCRIPT = ROOT / "scripts" / "observability_helm.sh"
 ALERTMANAGER_VALIDATOR = ROOT / "scripts" / "verify_observability_alertmanager.rb"
 DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
+PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
 JUSTFILE = ROOT / "justfile"
 FLUX_SYNC = ROOT / "flux" / "gotk-sync.yaml"
 LEGACY = [
@@ -154,20 +155,30 @@ def test_production_values_have_exact_safe_overrides_without_public_exposure_or_
     prod = yaml_load(PROD)
     assert prod == {
         "defaultRules": {"disabled": {"Watchdog": True}},
-        "prometheus": {
-            "prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}
-        },
+        "prometheus": {"prometheusSpec": {"externalLabels": {"cluster": "sugarkube-prod"}}},
         "alertmanager": {
             "alertmanagerSpec": {"secrets": []},
             "config": {
-                "global": None, "inhibit_rules": None, "templates": None,
-                "route": {"group_by": None, "group_wait": None, "group_interval": None,
-                          "repeat_interval": None, "receiver": "null", "routes": None},
+                "global": None,
+                "inhibit_rules": None,
+                "templates": None,
+                "route": {
+                    "group_by": None,
+                    "group_wait": None,
+                    "group_interval": None,
+                    "repeat_interval": None,
+                    "receiver": "null",
+                    "routes": None,
+                },
                 "receivers": [{"name": "null"}],
             },
         },
     }
-    text = COMMON.read_text(encoding="utf-8") + STAGING.read_text(encoding="utf-8") + PROD.read_text(encoding="utf-8")
+    text = (
+        COMMON.read_text(encoding="utf-8")
+        + STAGING.read_text(encoding="utf-8")
+        + PROD.read_text(encoding="utf-8")
+    )
     forbidden = [
         "longhorn",
         "cloudflare",
@@ -451,7 +462,10 @@ def test_discovery_contract_uses_release_label():
 def test_lifecycle_uses_pinned_version_ordered_values_and_no_reuse_values():
     script = SCRIPT.read_text(encoding="utf-8")
     assert 'CHART="prometheus-community/kube-prometheus-stack"' in script
-    assert 'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"' in script
+    assert (
+        'PROD_VALUES="${ROOT}/clusters/prod/observability/kube-prometheus-stack.values.yaml"'
+        in script
+    )
     assert '-f "${COMMON_VALUES}" -f "${ENV_VALUES}"' in script
     assert "--reuse-values" not in script
     assert "--atomic" in script
@@ -635,8 +649,7 @@ def test_justfile_exposes_observability_recipes():
 def test_justfile_normalizes_repeated_env_prefixes_before_staging_metrics_checks():
     text = JUSTFILE.read_text(encoding="utf-8")
     normalization = (
-        'while [ "${env_name#env=}" != "${env_name}" ]; '
-        'do env_name="${env_name#env=}"; done'
+        'while [ "${env_name#env=}" != "${env_name}" ]; ' 'do env_name="${env_name#env=}"; done'
     )
     for recipe in ("observability-install", "observability-upgrade", "observability-verify"):
         recipe_block = text.split(f"{recipe} env='':", 1)[1].split("\n\n", 1)[0]
@@ -996,9 +1009,7 @@ def test_grafana_secret_install_is_exact_redacted_and_rotatable(tmp_path):
         assert forbidden not in audit.lower()
     assert {path.name for path in tmp_path.iterdir()} - before == {"bin", "audit", "tmp"}
     assert list((tmp_path / "tmp").iterdir()) == []
-    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(
-        tmp_path / "repeat"
-    )
+    repeated, repeated_audit, repeated_credentials = run_grafana_secret_helper(tmp_path / "repeat")
     assert repeated.returncode == 0, repeated.stderr
     assert repeated_audit.splitlines() == expected_mutations
     assert repeated_credentials == ("operator", "correct horse battery staple")
@@ -1091,13 +1102,14 @@ case "$*" in
   *"repo add"*|*"repo update"*) exit 0 ;;
   *template*)
     [ "$HELM_MODE" != render-fail ] || exit 31
+    if [ "$ENV_NAME" = prod ]; then dashboard_uid=sugarkube-prod-observability; else dashboard_uid=sugarkube-staging-observability; fi
+    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' "  ${dashboard_uid}.json:" '    |-'
+    sed 's/^/      /' "$DASHBOARD"
+    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' "              mountPath: /var/lib/grafana/dashboards/sugarkube/${dashboard_uid}.json" "              subPath: ${dashboard_uid}.json"
     if [ "$ENV_NAME" = prod ]; then
-      printf '%s\n' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets: []' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |' '    route:' '      receiver: "null"' '    receivers:' '      - name: "null"'
+      printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets: []' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |' '    route:' '      receiver: "null"' '    receivers:' '      - name: "null"'
       exit 0
     fi
-    printf '%s\n' 'apiVersion: v1' 'kind: ConfigMap' 'metadata:' '  name: kube-prometheus-stack-grafana-dashboards-sugarkube' '  labels:' '    dashboard-provider: sugarkube' 'data:' '  sugarkube-staging-observability.json:' '    |-'
-    sed 's/^/      /' "$DASHBOARD"
-    printf '%s\n' '---' 'kind: ConfigMap' 'data:' '  dashboardproviders.yaml: |' '    providers:' '      - name: sugarkube' '        options:' '          path: /var/lib/grafana/dashboards/sugarkube' '---' 'kind: Deployment' 'spec:' '  template:' '    spec:' '      containers:' '        - volumeMounts:' '            - name: dashboards-sugarkube' '              mountPath: /var/lib/grafana/dashboards/sugarkube/sugarkube-staging-observability.json' '              subPath: sugarkube-staging-observability.json'
     printf '%s\n' '---' 'apiVersion: monitoring.coreos.com/v1' 'kind: Alertmanager' 'metadata:' '  name: kube-prometheus-stack-alertmanager' 'spec:' '  secrets:' '    - alertmanager-pagerduty' '    - alertmanager-healthchecks-watchdog'
     printf '%s\n' '---' 'apiVersion: v1' 'kind: Secret' 'metadata:' '  name: alertmanager-kube-prometheus-stack-alertmanager' 'stringData:' '  alertmanager.yaml: |'
     sed 's/^/    /' "$ALERTMANAGER_CONFIG"
@@ -1328,9 +1340,7 @@ printf '%s' "$code"
         "WATCHDOG_SILENCE_DELETIONS": str(tmp_path / "watchdog-silence-deletions"),
         "WATCHDOG_SILENCES": str(tmp_path / "watchdog-silences.json"),
         "WATCHDOG_LOG_TEXT": watchdog_log_text,
-        "DASHBOARD": str(
-            ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
-        ),
+        "DASHBOARD": str(PROD_DASHBOARD if env_name == "prod" else DASHBOARD),
     }
     (tmp_path / "watchdog-tty").write_text(watchdog_tty_text or "", encoding="utf-8")
     (tmp_path / "watchdog-silences.json").write_text(
@@ -1909,6 +1919,7 @@ def run_dashboard_verifier(
     mode="success",
     context="sugar-staging",
     forward_line="Forwarding from 127.0.0.1:43127 -> 3000",
+    env_name="staging",
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(parents=True)
@@ -1919,7 +1930,7 @@ def run_dashboard_verifier(
 echo "kubectl $*" >> "$AUDIT"
 case "$*" in
   "config current-context") echo "$CONTEXT" ;;
-  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"staging","sugarkube.cluster":"sugar-staging"}}}]}' ;;
+  *"get nodes -o json"*) echo '{"items":[{"metadata":{"name":"n1","labels":{"sugarkube.env":"'"$ENV_NAME"'","sugarkube.cluster":"sugar"}}}]}' ;;
   *"get secret grafana-admin-credentials"*"admin-user"*)
     [ "$MODE" != forward-exits-after-ready ] || { touch "$READY_SECRET"; /bin/sleep 0.2; }
     [ "$MODE" != secret-missing ] || exit 41
@@ -1959,7 +1970,7 @@ case "$MODE" in
   malformed-api) printf '%s\n%s\n' '{' 200 ;;
   wrong-api) printf '%s\n%s\n' '{"dashboard":{"uid":"wrong","title":"wrong"}}' 200 ;;
   interrupt) exit 143 ;;
-  *) printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200 ;;
+  *) if [ "$ENV_NAME" = prod ]; then printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-prod-observability","title":"Sugarkube Production Observability"}}' 200; else printf '%s\n%s\n' '{"dashboard":{"uid":"sugarkube-staging-observability","title":"Sugarkube Staging Observability"}}' 200; fi ;;
 esac
 """,
         encoding="utf-8",
@@ -1973,6 +1984,7 @@ esac
         "AUDIT": str(audit),
         "MODE": mode,
         "CONTEXT": context,
+        "ENV_NAME": env_name,
         "PID_FILE": str(pid_file),
         "FORWARD_PID": str(tmp_path / "port-forward.pid"),
         "FORWARD_LINE": forward_line,
@@ -1981,7 +1993,7 @@ esac
         "KUBECONFIG": str(tmp_path / "kubeconfig"),
     }
     result = subprocess.run(
-        ["bash", str(SCRIPT), "dashboard-verify", "env=staging"],
+        ["bash", str(SCRIPT), "dashboard-verify", f"env={env_name}"],
         env=env,
         capture_output=True,
         text=True,
@@ -2048,6 +2060,14 @@ def test_dashboard_verifier_rejects_missing_and_malformed_credentials(tmp_path):
         assert audit.index("port-forward") < audit.index("get secret")
         assert "curl " not in audit
         assert "placeholder" not in result.stdout + result.stderr
+
+
+def test_production_dashboard_verifier_uses_production_identity_and_redacts(tmp_path):
+    result, audit, _ = run_dashboard_verifier(tmp_path, context="sugar-prod", env_name="prod")
+    assert result.returncode == 0, result.stderr
+    assert "/api/dashboards/uid/sugarkube-prod-observability" in audit
+    assert "response redacted" in result.stdout
+    assert "placeholder" not in result.stdout + result.stderr
 
 
 def test_dashboard_verifier_port_forward_failure_never_authenticates(tmp_path):
@@ -2728,7 +2748,7 @@ def test_watchdog_silence_api_failures_do_not_expose_fixture_contents(tmp_path, 
 
 
 def production_alertmanager_fixture(*, secrets="[]", route_extra="", receiver_extra="", inline=""):
-    return f'''---
+    return f"""---
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -2746,7 +2766,7 @@ stringData:
       receiver: "null"{route_extra}
     receivers:
       - name: "null"{receiver_extra}{inline}
-'''
+"""
 
 
 def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
@@ -2754,6 +2774,7 @@ def test_production_offline_render_uses_only_ordered_core_values(tmp_path):
     assert result.returncode == 0, result.stderr
     template = next(line for line in audit.splitlines() if "helm template " in line)
     assert template.index(str(COMMON)) < template.index(str(PROD))
+    assert str(PROD_DASHBOARD) in template
     for excluded in (str(STAGING), str(DASHBOARD), "sugarkube-observability-rules"):
         assert excluded not in template
     assert "kubectl" not in audit
@@ -2774,8 +2795,12 @@ def test_production_install_identity_and_explicit_kubeconfig_fail_before_helm_mu
     tmp_path, context, mode, extra_env
 ):
     result, audit = run_helper(
-        tmp_path, "install", env_name="prod", context=context,
-        kubectl_mode=mode, extra_env=extra_env,
+        tmp_path,
+        "install",
+        env_name="prod",
+        context=context,
+        kubectl_mode=mode,
+        extra_env=extra_env,
     )
     assert result.returncode != 0
     assert "helm install" not in audit
@@ -2787,13 +2812,18 @@ def test_production_install_release_and_secret_guards(tmp_path):
     )
     assert installed.returncode == 0, installed.stderr
     assert "helm install" in audit and "--atomic" in audit
-    assert "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    assert (
+        "alertmanager-pagerduty" not in audit and "alertmanager-healthchecks-watchdog" not in audit
+    )
     existing, audit = run_helper(
         tmp_path / "existing", "install", env_name="prod", context="sugar-prod", helm_mode="present"
     )
     assert existing.returncode != 0 and "helm install" not in audit
     missing, audit = run_helper(
-        tmp_path / "secret", "install", env_name="prod", context="sugar-prod",
+        tmp_path / "secret",
+        "install",
+        env_name="prod",
+        context="sugar-prod",
         kubectl_mode="missing-grafana",
     )
     assert missing.returncode != 0 and "helm " not in audit
@@ -2802,13 +2832,24 @@ def test_production_install_release_and_secret_guards(tmp_path):
 def test_production_core_verify_skips_staging_integrations(tmp_path):
     result, audit = run_helper(tmp_path, "verify", env_name="prod", context="sugar-prod")
     assert result.returncode == 0, result.stderr
-    for required in ("rollout status", "get daemonset", "get pvc -o json", "get svc kube-prometheus-stack-grafana", "get secret grafana-admin-credentials"):
+    for required in (
+        "rollout status",
+        "get daemonset",
+        "get pvc -o json",
+        "get svc kube-prometheus-stack-grafana",
+        "get secret grafana-admin-credentials",
+    ):
         assert required in audit
-    for excluded in ("servicemonitor dspace", "alertmanager-pagerduty", "alertmanager-healthchecks-watchdog", " --raw "):
+    for excluded in (
+        "servicemonitor dspace",
+        "alertmanager-pagerduty",
+        "alertmanager-healthchecks-watchdog",
+        " --raw ",
+    ):
         assert excluded not in audit
 
 
-@pytest.mark.parametrize("command", ["dashboard-verify", "pagerduty-test", "watchdog-verify"])
+@pytest.mark.parametrize("command", ["pagerduty-test", "watchdog-verify"])
 def test_staging_only_subcommands_reject_production(tmp_path, command):
     result, audit = run_helper(tmp_path, command, env_name="prod", context="sugar-prod")
     assert result.returncode != 0
@@ -2831,14 +2872,18 @@ def test_production_alertmanager_validator_accepts_null_only_and_rejects_integra
     valid.write_text(production_alertmanager_fixture(), encoding="utf-8")
     accepted = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(valid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert accepted.returncode == 0, accepted.stderr
     invalid = tmp_path / "invalid.yaml"
     invalid.write_text(production_alertmanager_fixture(**mutation), encoding="utf-8")
     rejected = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(invalid)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert rejected.returncode == 16
     assert "forbidden-stub" not in rejected.stderr
@@ -2853,7 +2898,9 @@ def test_production_alertmanager_secret_mount_has_production_specific_diagnostic
     )
     result = subprocess.run(
         ["ruby", str(ALERTMANAGER_VALIDATOR), "prod", "rendered", str(manifest)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     assert result.returncode == 16
     assert "production Alertmanager must mount no integration Secrets" in result.stderr


### PR DESCRIPTION
### Motivation

- Provide the first live-backed production Grafana dashboard that reflects the verified production Prometheus metric families and the 2026-08-08 live evidence. 
- Ensure provisioning, validation, and lifecycle commands are environment-aware so `env=prod` renders, validates, and provisions only the production dashboard while leaving staging unchanged. 

### Description

- Added a new production dashboard at `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` with UID `sugarkube-prod-observability`, title `Sugarkube Production Observability`, default range `now-6h`, refresh `30s`, prometheus datasource UID `prometheus`, four required rows, unique panel IDs, non-overlapping grid positions, percent scales, `NO DATA` semantics, and the exact reviewed PromQL expressions (per the contract). 
- Extended `scripts/observability_helm.sh` to resolve dashboard path, `--set-file` key, UID, title, and LAN URL per environment and to pass the correct dashboard to `helm template/install/upgrade` for both staging and prod while preserving staging DSPACE overlay behavior. 
- Extended `scripts/validate_observability_dashboard.py` with a fail-closed production profile that enforces UID/title/datasource/refresh/time, exact required rows/panels and PromQL, forbids unsafe signals (`kube_state_metrics_build_info`, external-label selectors, unsafe zero substitution, summing head-series), enforces `$__rate_interval` where required, verifies percent panel scales, and compares rendered Helm dashboard JSON exactly to the checked-in JSON. 
- Added tests in `tests/test_observability_dashboard.py` and `tests/test_observability_helm.py` to cover the production profile, environment-specific render/install/upgrade behavior, dashboard API verification routing, and mutation/invalidity cases while preserving existing staging tests. 
- Updated `docs/observability-operations.md` with production panel semantics, aggregation/deduplication rules, the 2026-08-08 live evidence summary, the invariant about not using Prometheus `externalLabels` in local queries, omission of `kube_state_metrics_build_info`, Grafana persistence note, and a precise post-merge operator procedure (render → upgrade → verify → dashboard-verify → pod-recreation check). 

Files changed (within allowed scope):
- New: `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`
- Modified: `scripts/observability_helm.sh`, `scripts/validate_observability_dashboard.py`, `tests/test_observability_dashboard.py`, `tests/test_observability_helm.py`, `docs/observability-operations.md`

Note: staging dashboard JSON and staging behavior were preserved and not altered beyond environment-aware provisioning logic.

### Testing

- Ran the dashboard validator against the new production JSON with `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` and it passed. 
- Ran unit/integration tests: `pytest -q tests/test_observability_dashboard.py` — 120 passed. 
- Ran Helm/lifecycle tests: `pytest -q tests/test_observability_helm.py` (targeted subsets and full test runs as part of development) — production-focused tests passed (selected runs showed relevant production cases passing; full test suite runs completed in CI simulation). 
- Syntax/format checks: `bash -n scripts/observability_helm.sh` succeeded and `python -m black` reformat was applied where needed; `git diff --check` reported no issues. 

Commands that could not be executed in this environment (tools not installed here): `just observability-render` / `just observability-dashboard-verify` (no `just`), `shellcheck` on the script (not installed), `pyspelling` and `linkchecker` (not available). These should be executed in CI/operator environment as part of the final merge verification. 

Post-merge operator action required (manual live steps): run `just observability-upgrade env=prod` (not `install` because Helm revision 1 exists), then `just observability-verify env=prod` and `just observability-dashboard-verify env=prod`, delete only the Grafana pod and confirm the provisioned dashboard reappears, and visually inspect panels at `http://sugarkube0.local:30300` using operator vault credentials; record Git SHA and Helm revision as proof. 

This PR is the dashboard follow-up to merged PRs #2529 and #2532 and implements the production dashboard, validation, provisioning routing, tests, and docs; a post-merge production Helm upgrade plus API/pod-recreation/visual proof by an operator are still required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77c275ced4832fa92e3328aa8499f7)