### PR TITLE
Fix tokenless Cloudflare Tunnel upgrade under nounset

### DIFF
--- a/justfile
+++ b/justfile
@@ -528,25 +528,6 @@ kubeconfig-staging:
 kubeconfig-prod:
     just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env env=prod
 
-origin_cert_guidance := """
-  NOTE: cloudflared is still behaving like a locally-managed tunnel (looking for cert.pem / credentials.json).
-  This happens when the connector token is invalid for remote-managed mode or the tunnel itself is not set to
-  config_src="cloudflare".
-
-  Please verify all of the following:
-    - Copy the connector token from the Cloudflare dashboard snippet that looks like:
-
-        cloudflared tunnel --no-autoupdate run --token <TOKEN>
-
-      Copy only <TOKEN> into CF_TUNNEL_TOKEN (not an Access service token, not the full command).
-    - In the dashboard/API, confirm the tunnel is remote-managed (config_src="cloudflare"), not a locally-managed
-      tunnel created solely with cert.pem + credentials.json. Recreate the tunnel via the remote-managed guide if needed.
-    - After correcting the token/tunnel, run:
-
-        just cf-tunnel-reset
-        just cf-tunnel-install env=dev token="$CF_TUNNEL_TOKEN"
-"""
-
 cf-tunnel-install env='dev' token='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
@@ -567,7 +548,26 @@ cf-tunnel-install env='dev' token='':
 
     export KUBECONFIG="${HOME}/.kube/config"
 
-    origin_cert_guidance="{{ origin_cert_guidance }}"
+    print_origin_cert_guidance() {
+    cat >&2 <<'ORIGIN_CERT_GUIDANCE'
+    NOTE: cloudflared is still behaving like a locally-managed tunnel (looking for cert.pem / credentials.json).
+    This happens when the connector token is invalid for remote-managed mode or the tunnel itself is not set to
+    config_src="cloudflare".
+
+    Please verify all of the following:
+      - Copy the connector token from the Cloudflare dashboard snippet that looks like:
+
+          cloudflared tunnel --no-autoupdate run --token <TOKEN>
+
+        Copy only <TOKEN> into CF_TUNNEL_TOKEN (not an Access service token, not the full command).
+      - In the dashboard/API, confirm the tunnel is remote-managed (config_src="cloudflare"), not a locally-managed
+        tunnel created solely with cert.pem + credentials.json. Recreate the tunnel via the remote-managed guide if needed.
+      - After correcting the token/tunnel, run:
+
+          just cf-tunnel-reset
+          just cf-tunnel-install env=dev  # uses "$CF_TUNNEL_TOKEN"
+    ORIGIN_CERT_GUIDANCE
+    }
 
     kubectl get namespace cloudflare >/dev/null 2>&1 || kubectl create namespace cloudflare
 
@@ -702,7 +702,7 @@ cf-tunnel-install env='dev' token='':
     # synchronize their restart backoff. Leave the live rollout intact for owner diagnosis.
     logs=$(kubectl -n cloudflare logs deploy/cloudflare-tunnel --tail=50 2>/dev/null || true)
     if printf '%s' "${logs}" | grep -Eq "Cannot determine default origin certificate path|client didn't specify origincert path"; then
-        printf '%s\n' "${origin_cert_guidance}" >&2
+        print_origin_cert_guidance
     fi
     exit 1
     fi
@@ -752,7 +752,26 @@ cf-tunnel-debug:
 
     export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 
-    origin_cert_guidance="{{ origin_cert_guidance }}"
+    print_origin_cert_guidance() {
+    cat >&2 <<'ORIGIN_CERT_GUIDANCE'
+    NOTE: cloudflared is still behaving like a locally-managed tunnel (looking for cert.pem / credentials.json).
+    This happens when the connector token is invalid for remote-managed mode or the tunnel itself is not set to
+    config_src="cloudflare".
+
+    Please verify all of the following:
+      - Copy the connector token from the Cloudflare dashboard snippet that looks like:
+
+          cloudflared tunnel --no-autoupdate run --token <TOKEN>
+
+        Copy only <TOKEN> into CF_TUNNEL_TOKEN (not an Access service token, not the full command).
+      - In the dashboard/API, confirm the tunnel is remote-managed (config_src="cloudflare"), not a locally-managed
+        tunnel created solely with cert.pem + credentials.json. Recreate the tunnel via the remote-managed guide if needed.
+      - After correcting the token/tunnel, run:
+
+          just cf-tunnel-reset
+          just cf-tunnel-install env=dev  # uses "$CF_TUNNEL_TOKEN"
+    ORIGIN_CERT_GUIDANCE
+    }
 
     echo "=== Helm release ==="
     helm -n cloudflare status cloudflare-tunnel || echo "No Helm release."
@@ -777,7 +796,7 @@ cf-tunnel-debug:
         printf '%s\n' "${logs}"
 
         if printf '%s' "${logs}" | grep -Eq "Cannot determine default origin certificate path|client didn't specify origincert path"; then
-            printf '%s\n' "${origin_cert_guidance}" >&2
+            print_origin_cert_guidance
         fi
     else
         echo "No Cloudflare Tunnel pods to show logs for."

--- a/tests/test_cloudflare_tunnel_token_mode.py
+++ b/tests/test_cloudflare_tunnel_token_mode.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import subprocess
 import tempfile
 import textwrap
@@ -31,7 +33,11 @@ def _extract_cf_tunnel_route_recipe_body() -> str:
 @pytest.fixture(scope="module")
 def origin_cert_guidance_text() -> str:
     just_text = JUSTFILE.read_text(encoding="utf-8")
-    match = re.search(r"origin_cert_guidance := \"\"\"(?P<body>.*?)\"\"\"", just_text, re.S)
+    match = re.search(
+        r"cat >&2 <<'ORIGIN_CERT_GUIDANCE'\n(?P<body>.*?)\n\s*ORIGIN_CERT_GUIDANCE",
+        just_text,
+        re.S,
+    )
     assert match, "origin_cert_guidance helper missing from justfile"
 
     return match.group("body")
@@ -168,7 +174,7 @@ def _terminator_has_invalid_whitespace(line: str, terminator: str, allow_tabs: b
 
 
 def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
-    rendered_body = cf_recipe_body.replace("{{ quote(env) }}", "'${env}'")
+    rendered_body = textwrap.dedent(cf_recipe_body).replace("{{ quote(env) }}", "'${env}'")
     script = textwrap.dedent(
         """#!/usr/bin/env bash
         set -euo pipefail
@@ -201,7 +207,9 @@ def test_cf_tunnel_install_shell_syntax_is_valid(cf_recipe_body: str) -> None:
 def _run_cf_tunnel_install_recipe(
     env: str, *, secret_exists: bool = True, token: str | None = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature"
 ) -> subprocess.CompletedProcess[str]:
-    rendered_body = _extract_cf_recipe_body().replace("{{ quote(env) }}", json.dumps(env))
+    rendered_body = textwrap.dedent(_extract_cf_recipe_body()).replace(
+        "{{ quote(env) }}", json.dumps(env)
+    )
     script = textwrap.dedent(
         """#!/usr/bin/env bash
         set -euo pipefail
@@ -240,6 +248,60 @@ def _run_cf_tunnel_install_recipe(
         return subprocess.run(["bash", path], capture_output=True, text=True)
     finally:
         Path(path).unlink(missing_ok=True)
+
+
+def _run_actual_cf_tunnel_install(
+    tmp_path: Path, *, secret_exists: bool
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run Just's fully rendered recipe with inert command stubs."""
+
+    just = shutil.which("just")
+    if just is None:
+        pytest.fail("just is required for the real-rendering regression test")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "calls.log"
+    stub = textwrap.dedent(
+        """#!/usr/bin/env bash
+        set -eu
+        printf '%s:%s\n' "${0##*/}" "$*" >>"${CALL_LOG}"
+        if [ "${0##*/}" = kubectl ] &&
+           [ "$*" = "-n cloudflare get secret tunnel-token -o name" ] &&
+           [ "${SECRET_EXISTS}" = no ]; then
+            exit 1
+        fi
+        if [ "${0##*/}" = helm ] &&
+           [ "$*" = "-n cloudflare list --filter ^cloudflare-tunnel$ --output json" ]; then
+            printf '[]\n'
+        fi
+        """
+    )
+    for command in ("kubectl", "helm"):
+        path = bin_dir / command
+        path.write_text(stub, encoding="utf-8")
+        path.chmod(0o755)
+
+    test_env = os.environ.copy()
+    test_env.pop("CF_TUNNEL_TOKEN", None)
+    test_env.pop("CF_TUNNEL_NAME", None)
+    test_env.pop("CF_TUNNEL_ID", None)
+    test_env.update(
+        {
+            "PATH": f"{bin_dir}:{test_env['PATH']}",
+            "CALL_LOG": str(call_log),
+            "SECRET_EXISTS": "yes" if secret_exists else "no",
+            "HOME": str(tmp_path),
+        }
+    )
+    result = subprocess.run(
+        [just, "--justfile", str(JUSTFILE), "cf-tunnel-install", "env=staging"],
+        cwd=REPO_ROOT,
+        env=test_env,
+        capture_output=True,
+        text=True,
+    )
+    return result, call_log.read_text(encoding="utf-8") if call_log.exists() else ""
 
 
 def test_configmap_creation_removed_in_token_mode(cf_recipe_body: str) -> None:
@@ -417,18 +479,37 @@ def test_cf_tunnel_monitoring_is_applied_only_in_staging() -> None:
         assert result.stdout.count("KUBECTL:-n cloudflare patch deployment") == 1
 
 
-def test_existing_secret_is_preserved_without_token_input() -> None:
-    result = _run_cf_tunnel_install_recipe("staging", secret_exists=True, token=None)
+def test_existing_secret_is_preserved_without_token_input(tmp_path: Path) -> None:
+    result, calls = _run_actual_cf_tunnel_install(tmp_path, secret_exists=True)
     assert result.returncode == 0, result.stderr
     assert "kubectl -n cloudflare get secret tunnel-token -o name" in _extract_cf_recipe_body()
-    assert "create secret generic tunnel-token" not in result.stdout
-    assert "--from-literal" not in result.stdout
+    assert "kubectl:-n cloudflare get secret tunnel-token -o name" in calls
+    assert "create secret" not in calls
+    assert "--from-literal" not in calls
+    assert "get secret tunnel-token" not in calls.replace(
+        "kubectl:-n cloudflare get secret tunnel-token -o name", ""
+    )
+    assert "helm:upgrade --install cloudflare-tunnel" in calls
+    assert calls.count("kubectl:-n cloudflare patch deployment cloudflare-tunnel") == 2
+    assert "CF_TUNNEL_TOKEN" not in result.stdout + result.stderr
 
 
-def test_initial_install_requires_and_creates_secret_from_out_of_band_token() -> None:
-    missing = _run_cf_tunnel_install_recipe("staging", secret_exists=False, token=None)
+def test_guidance_is_deferred_and_nounset_safe(cf_recipe_body: str) -> None:
+    assert "cat >&2 <<'ORIGIN_CERT_GUIDANCE'" in cf_recipe_body
+    assert 'uses "$CF_TUNNEL_TOKEN"' in cf_recipe_body
+    assert 'origin_cert_guidance="' not in cf_recipe_body
+    assert 'origin_cert_guidance="{{ origin_cert_guidance }}"' not in JUSTFILE.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_initial_install_requires_and_creates_secret_from_out_of_band_token(tmp_path: Path) -> None:
+    missing, calls = _run_actual_cf_tunnel_install(tmp_path, secret_exists=False)
     assert missing.returncode != 0
     assert "initial installation" in missing.stderr
+    assert "helm:" not in calls
+    assert "create secret" not in calls
+    assert "--from-literal" not in calls
 
     created = _run_cf_tunnel_install_recipe("staging", secret_exists=False)
     assert created.returncode == 0, created.stderr


### PR DESCRIPTION
### Motivation

- `cf-tunnel-install` defined a double-quoted guidance string that contained the literal example `$CF_TUNNEL_TOKEN`, so Bash expanded it during assignment and `set -u` aborted when that env var was intentionally unset.
- Existing tests parsed an incompletely rendered recipe body and therefore did not exercise the real Just interpolation + nounset failure mode.

### Description

- Replace the eager double-quoted guidance assignment with a deferred `print_origin_cert_guidance()` function that emits a single-quoted heredoc (`<<'ORIGIN_CERT_GUIDANCE'`) so `$CF_TUNNEL_TOKEN` remains literal and cannot be expanded during recipe definition.
- Apply the same nounset-safe deferred guidance to both `cf-tunnel-install` and `cf-tunnel-debug` in `justfile` so diagnostics are printed only when relevant.
- Add a real-rendering regression test that runs the Just-rendered `cf-tunnel-install env=staging` recipe (via `just`) with stubbed `kubectl` and `helm`, explicitly removing `CF_TUNNEL_TOKEN`, `CF_TUNNEL_NAME`, and `CF_TUNNEL_ID` from the environment to reproduce the previous failure mode.
- Assert the existing-Secret path exits successfully and that no Secret creation/`--from-literal`/token lookups occur while Helm and the expected deployment patch calls run; retain tests that initial installs fail closed without an out-of-band token.

### Testing

- `pytest -q tests/test_cloudflare_tunnel_token_mode.py tests/test_cloudflare_tunnel_hardening.py` — 22 passed.
- `just --unstable --fmt --check` — passed.
- `bash -n scripts/verify_cloudflare_tunnel.sh` — syntax check passed.
- `git diff --check` — no whitespace/git-diff errors on committed changes.
- `git diff --cached | ./scripts/scan-secrets.py` — no secrets detected in the staged changes.
- `pyspelling -c .spellcheck.yaml` — passed.
- `linkchecker --no-warnings README.md docs/` — ran with no link errors.

No live Kubernetes cluster, Helm release, Cloudflare API, Secret, or other production resource was accessed or changed; regression coverage uses inert local stubs for `kubectl` and `helm` and explicitly removes tunnel-related environment variables during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77d0048c3c832f998c27c7a38f6b0b)