### PR TITLE
Fix Cloudflare Tunnel verifier jq scoping and add execution-level regression tests

### DIFF
--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -36,7 +36,14 @@ jq -e --arg image "${expected_image}" '
 ' <<<"${deployment}" >/dev/null
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
-jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+jq -e '
+  [.items[] | select(
+    .metadata.deletionTimestamp == null and
+    .status.phase == "Running" and
+    any(.status.conditions[]?; .type == "Ready" and .status == "True")
+  )] as $ready |
+  ($ready | length == 2) and ([$ready[].spec.nodeName] | unique | length == 2)
+' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
 monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"

--- a/tests/test_cloudflare_tunnel_verifier.py
+++ b/tests/test_cloudflare_tunnel_verifier.py
@@ -1,0 +1,162 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts/verify_cloudflare_tunnel.sh"
+
+
+def pod(name, node, *, ready=True, terminating=False):
+    metadata = {"name": name}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-08-09T00:00:00Z"
+    return {
+        "metadata": metadata,
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def run_verifier(tmp_path, pods):
+    deployment = {
+        "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm"}},
+        "spec": {
+            "replicas": 2,
+            "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
+            "template": {
+                "spec": {
+                    "affinity": {
+                        "podAntiAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": [
+                                {
+                                    "topologyKey": "kubernetes.io/hostname",
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/name": "cloudflare-tunnel",
+                                            "app.kubernetes.io/instance": "cloudflare-tunnel",
+                                        }
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                    "containers": [
+                        {
+                            "image": "cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf",
+                            "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}},
+                            "env": [
+                                {
+                                    "name": "TUNNEL_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {"name": "tunnel-token", "key": "token"}
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [],
+                }
+            },
+        },
+    }
+    responses = {
+        "deployment": deployment,
+        "pods": {"apiVersion": "v1", "kind": "PodList", "items": pods},
+        "pdb": {"spec": {"minAvailable": 1}},
+        "service": {
+            "spec": {
+                "type": "ClusterIP",
+                "selector": {
+                    "app.kubernetes.io/instance": "cloudflare-tunnel",
+                    "app.kubernetes.io/name": "cloudflare-tunnel",
+                },
+                "ports": [{"name": "metrics", "port": 2000, "protocol": "TCP", "targetPort": 2000}],
+            }
+        },
+        "servicemonitor": {
+            "metadata": {"labels": {"release": "kube-prometheus-stack"}},
+            "spec": {
+                "selector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/instance": "cloudflare-tunnel",
+                        "app.kubernetes.io/name": "cloudflare-tunnel",
+                    }
+                },
+                "endpoints": [{"path": "/metrics"}],
+            },
+        },
+    }
+    fixture = tmp_path / "responses.json"
+    fixture.write_text(json.dumps(responses))
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "helm").write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'[{"name":"cloudflare-tunnel","chart":"cloudflare-tunnel-0.3.2"}]\'\n'
+    )
+    (bin_dir / "kubectl").write_text("""#!/usr/bin/env python3
+import json, os, sys
+data = json.load(open(os.environ["VERIFIER_RESPONSES"]))
+args = sys.argv[1:]
+if args == ["config", "current-context"]:
+    print("sugar-staging")
+elif "--raw" in args:
+    path = args[-1]
+    if "rules?type=alert" in path:
+        print(json.dumps({"data": {"groups": [{"rules": [
+            {"name": name, "health": "ok"} for name in (
+                "CloudflareTunnelNoHealthyConnections",
+                "CloudflareTunnelConnectionsDegraded",
+                "CloudflareTunnelMetricsTargetsDown",
+            )
+        ]}]}}))
+    else:
+        value = "0" if "ALERTS" in path else "2"
+        print(json.dumps({"data": {"result": [{"value": [0, value]}]}}))
+elif "deployment" in args:
+    print(json.dumps(data["deployment"]))
+elif "pods" in args:
+    print(json.dumps(data["pods"]))
+elif "pdb" in args:
+    print(json.dumps(data["pdb"]))
+elif "service" in args:
+    print(json.dumps(data["service"]))
+elif "servicemonitor" in args:
+    print(json.dumps(data["servicemonitor"]))
+else:
+    raise SystemExit(f"unexpected kubectl arguments: {args}")
+""")
+    for command in (bin_dir / "helm", bin_dir / "kubectl"):
+        command.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "VERIFIER_RESPONSES": str(fixture),
+    }
+    return subprocess.run(
+        ["bash", str(VERIFIER), "env=staging"], text=True, capture_output=True, env=env
+    )
+
+
+def test_two_ready_pods_on_distinct_nodes_pass(tmp_path):
+    result = run_verifier(tmp_path, [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-b")])
+    assert result.returncode == 0, result.stderr
+    assert 'Cannot index array with string "items"' not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-a")],
+        [pod("tunnel-a", "node-a")],
+        [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-b", ready=False)],
+        [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-b", terminating=True)],
+    ],
+    ids=["duplicate-node", "incorrect-count", "not-ready", "terminating"],
+)
+def test_invalid_pod_sets_fail(tmp_path, pods):
+    assert run_verifier(tmp_path, pods).returncode != 0


### PR DESCRIPTION
### Motivation

- The post-#2541 read-only Cloudflare Tunnel verifier failed with `jq: error: Cannot index array with string "items"` because a pipeline bound an array and then attempted to index `.items` from that array. 
- The verifier must remain read-only and Secret-safe while correctly enforcing the pod contract: exactly two Running, Ready, non-terminating Cloudflare Tunnel pods on distinct nodes.

### Description

- Fix `scripts/verify_cloudflare_tunnel.sh` by scoping the filtered PodList into a variable (`as $ready`) and evaluating both predicates against the original/filtered data, ensuring the right-hand side of `and` does not try to access `.items` from an array. 
- Tighten the pod qualification to explicitly require `metadata.deletionTimestamp == null`, `.status.phase == "Running"`, and a `Ready=True` condition before counting and checking unique node placement. 
- Add an execution-level regression test `tests/test_cloudflare_tunnel_verifier.py` which mocks `kubectl`/`helm` responses and runs the real verifier to prove valid and invalid pod sets behave as intended. 
- The change is minimal and only affects the read-only verifier logic and its tests; no Helm charts, image coordinates, observability rules, or operational docs were modified.

### Testing

- Confirmed merge base: `git merge-base --is-ancestor d690d50384c931551dfc7c7544d3a84856a7a66b HEAD` succeeded. 
- Syntax check: `bash -n scripts/verify_cloudflare_tunnel.sh` succeeded. 
- Unit/regression tests: `python -m pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_cloudflare_tunnel_verifier.py` all passed (total tests shown by run: 27 passed across relevant suites). 
- Formatting/lint checks on the new test file passed: `python -m black --check tests/test_cloudflare_tunnel_verifier.py` and `python -m isort --check-only tests/test_cloudflare_tunnel_verifier.py` passed after formatting; `pre-commit run --all-files` could not be completed repository-wide in this environment due to unrelated pre-existing hooks making automatic edits, but the committed changes were verified and `./scripts/scan-secrets.py` returned no secrets.

Notes: the rollout itself was successful (Helm and pods in staging are Running/Ready and endpoints returned HTTP 200) and this PR only fixes the read-only post-rollout verifier; no live infrastructure was accessed or mutated during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77e6f459ac832f9fce33fc715bd7bc)