### PR TITLE
Fix Cloudflare Tunnel verifier jq scoping and add execution-level tests

### DIFF
--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -36,7 +36,14 @@ jq -e --arg image "${expected_image}" '
 ' <<<"${deployment}" >/dev/null
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
-jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+jq -e '
+  [.items[] | select(
+    .metadata.deletionTimestamp == null and
+    .status.phase == "Running" and
+    any(.status.conditions[]?; .type == "Ready" and .status == "True")
+  )] as $ready |
+  ($ready | length) == 2 and ([$ready[].spec.nodeName] | unique | length) == 2
+' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
 monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"

--- a/tests/test_verify_cloudflare_tunnel.py
+++ b/tests/test_verify_cloudflare_tunnel.py
@@ -1,0 +1,105 @@
+# flake8: noqa: E501
+"""Execution-level regression tests for the Cloudflare Tunnel verifier."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify_cloudflare_tunnel.sh"
+IMAGE = "cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+
+
+def pod(name: str, node: str, *, ready: bool = True, terminating: bool = False) -> dict:
+    metadata = {"name": name}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-08-09T12:00:00Z"
+    return {
+        "metadata": metadata,
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+@pytest.fixture
+def fake_commands(tmp_path: Path) -> Path:
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "helm").write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'[{"name":"cloudflare-tunnel","chart":"cloudflare-tunnel-0.3.2"}]\'\n'
+    )
+    (bindir / "helm").chmod(0o755)
+    (bindir / "kubectl").write_text(f"""#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+if args == ["config", "current-context"]:
+    print("sugar-staging")
+elif "deployment" in args:
+    print(json.dumps({{
+        "metadata": {{"labels": {{"app.kubernetes.io/managed-by": "Helm"}}}},
+        "spec": {{"replicas": 2, "strategy": {{"rollingUpdate": {{"maxUnavailable": 0, "maxSurge": 1}}}},
+          "template": {{"spec": {{"affinity": {{"podAntiAffinity": {{"requiredDuringSchedulingIgnoredDuringExecution": [{{
+            "topologyKey": "kubernetes.io/hostname", "labelSelector": {{"matchLabels": {{
+              "app.kubernetes.io/name": "cloudflare-tunnel", "app.kubernetes.io/instance": "cloudflare-tunnel"}}}}}}]}}}},
+            "containers": [{{"image": "{IMAGE}", "readinessProbe": {{"httpGet": {{"path": "/ready", "port": 2000}}}},
+              "env": [{{"name": "TUNNEL_TOKEN", "valueFrom": {{"secretKeyRef": {{"name": "tunnel-token", "key": "token"}}}}}}]}}],
+            "volumes": []}}}}}}}}))
+elif "pods" in args:
+    print(os.environ["POD_LIST"])
+elif "pdb" in args:
+    print('{{"spec":{{"minAvailable":1}}}}')
+elif "service" in args and "servicemonitor" not in args:
+    print('{{"spec":{{"type":"ClusterIP","selector":{{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"}},"ports":[{{"name":"metrics","port":2000,"protocol":"TCP","targetPort":2000}}]}}}}')
+elif "servicemonitor" in args:
+    print('{{"metadata":{{"labels":{{"release":"kube-prometheus-stack"}}}},"spec":{{"selector":{{"matchLabels":{{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"}}}},"endpoints":[{{"path":"/metrics"}}]}}}}')
+elif any("rules?type=alert" in arg for arg in args):
+    names = ["CloudflareTunnelNoHealthyConnections", "CloudflareTunnelConnectionsDegraded", "CloudflareTunnelMetricsTargetsDown"]
+    print(json.dumps({{"data": {{"groups": [{{"rules": [{{"name": name, "health": "ok"}} for name in names]}}]}}}}))
+elif "--raw" in args:
+    value = "0" if "ALERTS" in "".join(args) else "2"
+    print(json.dumps({{"data": {{"result": [{{"value": [0, value]}}]}}}}))
+else:
+    raise SystemExit(f"unexpected kubectl invocation: {{args}}")
+""")
+    (bindir / "kubectl").chmod(0o755)
+    return bindir
+
+
+def run_verifier(fake_commands: Path, pods: list[dict]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_commands}:{env['PATH']}"
+    env["POD_LIST"] = json.dumps({"apiVersion": "v1", "kind": "PodList", "items": pods})
+    return subprocess.run(
+        ["bash", str(VERIFIER), "staging"], env=env, text=True, capture_output=True, check=False
+    )
+
+
+def test_two_ready_current_pods_on_distinct_nodes_pass(fake_commands: Path) -> None:
+    result = run_verifier(
+        fake_commands, [pod("connector-1", "node-a"), pod("connector-2", "node-b")]
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert 'Cannot index array with string "items"' not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [pod("connector-1", "node-a"), pod("connector-2", "node-a")],
+        [pod("connector-1", "node-a")],
+        [pod("connector-1", "node-a"), pod("connector-2", "node-b", ready=False)],
+        [pod("connector-1", "node-a"), pod("connector-2", "node-b", terminating=True)],
+    ],
+    ids=["duplicate-node", "incorrect-count", "non-ready", "terminating"],
+)
+def test_invalid_pod_sets_fail(fake_commands: Path, pods: list[dict]) -> None:
+    result = run_verifier(fake_commands, pods)
+
+    assert result.returncode != 0


### PR DESCRIPTION
### Motivation

- The post-#2541 read-only verifier could fail with `jq: error: Cannot index array with string "items"` due to improper jq input scoping when composing two predicates from a PodList.
- The verifier must only count non-terminating, Running pods that are Ready=True and verify they are scheduled on two distinct nodes without reading Secrets or mutating infrastructure.

### Description

- Fix the PodList assertion in `scripts/verify_cloudflare_tunnel.sh` by binding the filtered pod array to `$ready` and applying both predicates to that array, preventing accidental `.items` indexing of an array. The new predicate also explicitly ignores terminating pods and requires a `Ready=True` condition. (Small targeted change to one jq expression.)
- Preserve read-only/Secret-safe behavior and the intended pod contract: exactly two non-terminating, Running, Ready pods on two distinct nodes are required.
- Add `tests/test_verify_cloudflare_tunnel.py`, an execution-level regression test that invokes the real verifier script while mocking `kubectl`/`helm`/Prometheus responses to exercise the complete validation path.

### Testing

- Confirmed the merge commit `d690d50384c931551dfc7c7544d3a84856a7a66b` is an ancestor of `HEAD` with `git merge-base --is-ancestor d690d50384c931551dfc7c7544d3a84856a7a66b HEAD` (returned success).
- Syntax check: `bash -n scripts/verify_cloudflare_tunnel.sh` — passed.
- Regression tests: `python -m pytest -q tests/test_verify_cloudflare_tunnel.py` — passed (5 tests for the verifier); extended test run `python -m pytest -q tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py` — all tests passed (27 passed total).
- Targeted formatting/lint checks for the touched files: `pre-commit run trailing-whitespace --files scripts/verify_cloudflare_tunnel.sh tests/test_verify_cloudflare_tunnel.py` and `pre-commit run end-of-file-fixer --files scripts/verify_cloudflare_tunnel.sh tests/test_verify_cloudflare_tunnel.py` — passed; `black/isort/ruff` checks on the new test file passed as run in the workflow.
- Note: `pre-commit run --all-files` was not completed repository-wide due to unrelated legacy checks in other files, and `pyspelling` was not run because the environment lacks `aspell`; these are unrelated to this small, targeted verifier fix.

This rollout itself had completed successfully (Cloudflare Tunnel Helm revision 2 deployed, two `cloudflared` connectors Running/Ready, Service/ServiceMonitor/PDB present, observability Helm revision 9 deployed, public staging endpoints returned HTTP 200), and this PR only fixes the read-only post-rollout verifier logic and adds regression coverage. No live infrastructure was accessed or mutated by the change or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77eb2b1d9c832fa418a848fb1f9e66)