### PR TITLE
Fix Cloudflare Tunnel post-rollout pod verifier

### DIFF
--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -36,7 +36,15 @@ jq -e --arg image "${expected_image}" '
 ' <<<"${deployment}" >/dev/null
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
-jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+jq -e '
+  [.items[] | select(
+    .metadata.deletionTimestamp == null and
+    .status.phase == "Running" and
+    any(.status.conditions[]?; .type == "Ready" and .status == "True")
+  )] as $ready |
+  ($ready | length == 2) and
+  ($ready | map(.spec.nodeName) | unique | length == 2)
+' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
 monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"

--- a/tests/test_cloudflare_tunnel_verifier.py
+++ b/tests/test_cloudflare_tunnel_verifier.py
@@ -1,0 +1,124 @@
+# flake8: noqa: E501
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify_cloudflare_tunnel.sh"
+
+
+def pod(name: str, node: str, *, ready: bool = True, terminating: bool = False) -> dict:
+    metadata = {"name": name}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-08-09T00:00:00Z"
+    return {
+        "metadata": metadata,
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def run_verifier(tmp_path: Path, pods: list[dict]) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    pods_file = tmp_path / "pods.json"
+    pods_file.write_text(json.dumps({"apiVersion": "v1", "kind": "PodList", "items": pods}))
+
+    (bin_dir / "helm").write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' \'[{"name":"cloudflare-tunnel","chart":"cloudflare-tunnel-0.3.2"}]\'\n'
+    )
+    (bin_dir / "kubectl").write_text("""#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = " ".join(sys.argv[1:])
+if args == "config current-context":
+    print("sugar-staging")
+elif "get deployment cloudflare-tunnel" in args:
+    print(json.dumps({
+        "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm"}},
+        "spec": {
+            "replicas": 2,
+            "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
+            "template": {"spec": {
+                "affinity": {"podAntiAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": [{
+                    "topologyKey": "kubernetes.io/hostname",
+                    "labelSelector": {"matchLabels": {
+                        "app.kubernetes.io/name": "cloudflare-tunnel",
+                        "app.kubernetes.io/instance": "cloudflare-tunnel",
+                    }},
+                }]}},
+                "containers": [{
+                    "image": "cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf",
+                    "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}},
+                    "env": [{"name": "TUNNEL_TOKEN", "valueFrom": {"secretKeyRef": {"name": "tunnel-token", "key": "token"}}}],
+                }],
+                "volumes": [],
+            }},
+        },
+    }))
+elif "get pods " in args:
+    print(open(os.environ["PODS_FILE"], encoding="utf-8").read())
+elif "get pdb cloudflare-tunnel" in args:
+    print('{"spec":{"minAvailable":1}}')
+elif "get service cloudflare-tunnel-metrics" in args:
+    print('{"spec":{"type":"ClusterIP","selector":{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"},"ports":[{"name":"metrics","port":2000,"protocol":"TCP","targetPort":2000}]}}')
+elif "get servicemonitor cloudflare-tunnel" in args:
+    print('{"metadata":{"labels":{"release":"kube-prometheus-stack"}},"spec":{"selector":{"matchLabels":{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"}},"endpoints":[{"path":"/metrics"}]}}')
+elif "rules?type=alert" in args:
+    rules = ["CloudflareTunnelNoHealthyConnections", "CloudflareTunnelConnectionsDegraded", "CloudflareTunnelMetricsTargetsDown"]
+    print(json.dumps({"data": {"groups": [{"rules": [{"name": name, "health": "ok"} for name in rules]}]}}))
+elif "ALERTS" in args:
+    print('{"data":{"result":[{"value":[0,"0"]}]}}')
+elif "get --raw" in args:
+    print('{"data":{"result":[{"value":[0,"2"]}]}}')
+else:
+    raise SystemExit(f"unexpected kubectl invocation: {args}")
+""")
+    for command in (bin_dir / "helm", bin_dir / "kubectl"):
+        command.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(PATH=f"{bin_dir}:{env['PATH']}", PODS_FILE=str(pods_file))
+    return subprocess.run(
+        ["bash", str(VERIFIER), "env=staging"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_two_ready_pods_on_distinct_nodes_pass(tmp_path: Path) -> None:
+    result = run_verifier(tmp_path, [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-b")])
+
+    assert result.returncode == 0, result.stderr
+    assert 'Cannot index array with string "items"' not in result.stderr
+    assert "staging verification passed" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [pod("tunnel-a", "node-a"), pod("tunnel-b", "node-a")],
+        [pod("tunnel-a", "node-a")],
+        [
+            pod("tunnel-a", "node-a"),
+            pod("tunnel-b", "node-b", ready=False),
+            pod("tunnel-old", "node-c", terminating=True),
+        ],
+    ],
+    ids=["duplicate-node", "incorrect-count", "non-ready-and-terminating"],
+)
+def test_invalid_pod_contract_fails(tmp_path: Path, pods: list[dict]) -> None:
+    result = run_verifier(tmp_path, pods)
+
+    assert result.returncode != 0


### PR DESCRIPTION
### Motivation

- The read-only post-rollout verifier failed with `jq: error: Cannot index array with string "items"` because the pod-list filtering produced an array that the subsequent predicate attempted to index as if it were the original PodList. 
- The staging rollout itself completed successfully (Helm/release and pods were healthy), so the intent is to make the verifier robust without mutating live infrastructure. 

### Description

- Fix the `jq` predicate in `scripts/verify_cloudflare_tunnel.sh` by binding the deliberately filtered, non-terminating Running/Ready pods to a variable (`$ready`) and evaluating both the count and node-uniqueness against that variable. 
- Exclude terminating pods and require an explicit Ready condition when selecting pods by checking `.metadata.deletionTimestamp == null` and `.status.conditions[]` for `Ready == True`. 
- Add an execution-level regression harness `tests/test_cloudflare_tunnel_verifier.py` that runs the actual verifier with stubbed `helm`/`kubectl` and realistic `PodList` payloads to assert passing and failing scenarios. 
- Preserve read-only and Secret-safe behavior; no Helm/kubectl mutations or Secret reads were introduced. 

### Testing

- `git merge-base --is-ancestor d690d50384c931551dfc7c7544d3a84856a7a66b HEAD` succeeded indicating the referenced merge is an ancestor. 
- `bash -n scripts/verify_cloudflare_tunnel.sh` succeeded (syntax check). 
- `python -m pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py` passed (22 tests). 
- `python -m pytest -q tests/test_cloudflare_tunnel_verifier.py` passed (4 tests) and the valid case produced no `Cannot index array with string "items"` error. 

Notes: `pre-commit run --all-files` was unavailable in the environment, and `./scripts/checks.sh` surfaced pre-existing repository-wide flake8 issues unrelated to this change; focused Black/flake8 checks for the new test file passed locally. This PR only fixes the read-only post-rollout verifier and does not touch live infrastructure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77eb201844832fa367258a4fd28f55)