### PR TITLE
Fix Cloudflare Tunnel Pod jq scoping bug and add execution regression test

### DIFF
--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -36,7 +36,15 @@ jq -e --arg image "${expected_image}" '
 ' <<<"${deployment}" >/dev/null
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
-jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+jq -e '
+  [.items[] | select(
+    .metadata.deletionTimestamp == null and
+    .status.phase == "Running" and
+    any(.status.conditions[]?; .type == "Ready" and .status == "True")
+  )] as $current |
+  ($current | length == 2) and
+  ($current | map(.spec.nodeName) | unique | length == 2)
+' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
 monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"

--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -37,12 +37,12 @@ jq -e --arg image "${expected_image}" '
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
 jq -e '
-  [.items[] | select(
-    .metadata.deletionTimestamp == null and
+  [.items[] | select(.metadata.deletionTimestamp == null)] as $current |
+  ($current | length == 2) and
+  ($current | all(
     .status.phase == "Running" and
     any(.status.conditions[]?; .type == "Ready" and .status == "True")
-  )] as $current |
-  ($current | length == 2) and
+  )) and
   ($current | map(.spec.nodeName) | unique | length == 2)
 ' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null

--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -38,12 +38,13 @@ jq -e --arg image "${expected_image}" '
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
 jq -e '
   [.items[] | select(.metadata.deletionTimestamp == null)] as $current |
-  ($current | length == 2) and
-  ($current | all(
+  [$current[] | select(
     .status.phase == "Running" and
     any(.status.conditions[]?; .type == "Ready" and .status == "True")
-  )) and
-  ($current | map(.spec.nodeName) | unique | length == 2)
+  )] as $ready |
+  ($current | length == 2) and
+  ($ready | length == 2) and
+  ($ready | map(.spec.nodeName) | unique | length == 2)
 ' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"

--- a/tests/test_verify_cloudflare_tunnel.py
+++ b/tests/test_verify_cloudflare_tunnel.py
@@ -144,6 +144,16 @@ def test_two_ready_current_pods_on_distinct_nodes_pass(tmp_path: Path) -> None:
     assert 'Cannot index array with string "items"' not in result.stderr
 
 
+def test_two_ready_pods_and_additional_terminating_pod_pass(tmp_path: Path) -> None:
+    pods = [
+        _pod("tunnel-a", "node-a"),
+        _pod("tunnel-b", "node-b"),
+        _pod("tunnel-old", "node-c", terminating=True),
+    ]
+    result = _run_verifier(tmp_path, pods)
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.parametrize(
     "pods",
     [

--- a/tests/test_verify_cloudflare_tunnel.py
+++ b/tests/test_verify_cloudflare_tunnel.py
@@ -1,0 +1,159 @@
+"""Execution regressions for the read-only Cloudflare Tunnel verifier."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify_cloudflare_tunnel.sh"
+
+
+def _pod(name: str, node: str, *, ready: bool = True, terminating: bool = False) -> dict:
+    metadata = {"name": name}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-08-09T00:00:00Z"
+    return {
+        "metadata": metadata,
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def _run_verifier(tmp_path: Path, pods: list[dict]) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "helm").write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' "
+        '\'[{"name":"cloudflare-tunnel","chart":"cloudflare-tunnel-0.3.2"}]\'\n'
+    )
+    deployment = {
+        "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm"}},
+        "spec": {
+            "replicas": 2,
+            "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
+            "template": {
+                "spec": {
+                    "affinity": {
+                        "podAntiAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": [
+                                {
+                                    "topologyKey": "kubernetes.io/hostname",
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/name": "cloudflare-tunnel",
+                                            "app.kubernetes.io/instance": "cloudflare-tunnel",
+                                        }
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                    "containers": [
+                        {
+                            "image": (
+                                "cloudflare/cloudflared:2026.7.3@sha256:"
+                                "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+                            ),
+                            "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}},
+                            "env": [
+                                {
+                                    "name": "TUNNEL_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {"name": "tunnel-token", "key": "token"}
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [],
+                }
+            },
+        },
+    }
+    payloads = {
+        "deployment": deployment,
+        "pods": {"apiVersion": "v1", "kind": "PodList", "items": pods},
+        "pdb": {"spec": {"minAvailable": 1}},
+        "service": {
+            "spec": {
+                "type": "ClusterIP",
+                "selector": {
+                    "app.kubernetes.io/instance": "cloudflare-tunnel",
+                    "app.kubernetes.io/name": "cloudflare-tunnel",
+                },
+                "ports": [{"name": "metrics", "port": 2000, "protocol": "TCP", "targetPort": 2000}],
+            }
+        },
+        "servicemonitor": {
+            "metadata": {"labels": {"release": "kube-prometheus-stack"}},
+            "spec": {
+                "selector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/instance": "cloudflare-tunnel",
+                        "app.kubernetes.io/name": "cloudflare-tunnel",
+                    }
+                },
+                "endpoints": [{"path": "/metrics"}],
+            },
+        },
+    }
+    (tmp_path / "payloads.json").write_text(json.dumps(payloads))
+    (bin_dir / "kubectl").write_text("""#!/usr/bin/env python3
+import json, os, sys
+payloads = json.load(open(os.environ["TEST_PAYLOADS"]))
+args = " ".join(sys.argv[1:])
+if args == "config current-context": print("sugar-staging")
+elif " get deployment " in f" {args} ": print(json.dumps(payloads["deployment"]))
+elif " get pods " in f" {args} ": print(json.dumps(payloads["pods"]))
+elif " get pdb " in f" {args} ": print(json.dumps(payloads["pdb"]))
+elif " get service " in f" {args} ": print(json.dumps(payloads["service"]))
+elif " get servicemonitor " in f" {args} ": print(json.dumps(payloads["servicemonitor"]))
+elif "rules?type=alert" in args:
+    print(json.dumps({"data":{"groups":[{"rules":[
+        {"name":"CloudflareTunnelNoHealthyConnections","health":"ok"},
+        {"name":"CloudflareTunnelConnectionsDegraded","health":"ok"},
+        {"name":"CloudflareTunnelMetricsTargetsDown","health":"ok"}] }]}}))
+elif "query?query=" in args:
+    value = "0" if "ALERTS" in args else "2"
+    print(json.dumps({"data":{"result":[{"value":[0,value]}]}}))
+else: raise SystemExit(f"unexpected kubectl call: {args}")
+""")
+    for command in (bin_dir / "helm", bin_dir / "kubectl"):
+        command.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "TEST_PAYLOADS": str(tmp_path / "payloads.json"),
+    }
+    return subprocess.run(
+        ["bash", str(VERIFIER), "staging"], capture_output=True, text=True, env=env
+    )
+
+
+def test_two_ready_current_pods_on_distinct_nodes_pass(tmp_path: Path) -> None:
+    result = _run_verifier(tmp_path, [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b")])
+    assert result.returncode == 0, result.stderr
+    assert 'Cannot index array with string "items"' not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "pods",
+    [
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-a")],
+        [_pod("tunnel-a", "node-a")],
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", ready=False)],
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", terminating=True)],
+    ],
+    ids=["duplicate-node", "incorrect-count", "not-ready", "terminating"],
+)
+def test_invalid_pod_contract_fails(tmp_path: Path, pods: list[dict]) -> None:
+    result = _run_verifier(tmp_path, pods)
+    assert result.returncode != 0

--- a/tests/test_verify_cloudflare_tunnel.py
+++ b/tests/test_verify_cloudflare_tunnel.py
@@ -150,9 +150,14 @@ def test_two_ready_current_pods_on_distinct_nodes_pass(tmp_path: Path) -> None:
         [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-a")],
         [_pod("tunnel-a", "node-a")],
         [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", ready=False)],
+        [
+            _pod("tunnel-a", "node-a"),
+            _pod("tunnel-b", "node-b"),
+            _pod("tunnel-surge", "node-c", ready=False),
+        ],
         [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", terminating=True)],
     ],
-    ids=["duplicate-node", "incorrect-count", "not-ready", "terminating"],
+    ids=["duplicate-node", "incorrect-count", "not-ready", "unready-surge", "terminating"],
 )
 def test_invalid_pod_contract_fails(tmp_path: Path, pods: list[dict]) -> None:
     result = _run_verifier(tmp_path, pods)


### PR DESCRIPTION
### Motivation

- The post-#2541 read-only verifier failed with `jq: error: Cannot index array with string "items"` because one jq predicate transformed the Kubernetes PodList into an array before a later predicate attempted to access `.items`.
- The guarded staging rollout itself completed successfully. This PR fixes only the subsequent read-only verifier and does not access or mutate live infrastructure.

### Description

- Fix `scripts/verify_cloudflare_tunnel.sh` by binding all non-terminating selected pods to `$current`, deriving the `Running` and `Ready=True` subset as `$ready`, and evaluating each predicate against the correct input.
- Enforce the fail-closed pod contract:
  - exactly two non-terminating current pods;
  - exactly two Running and Ready pods;
  - the two Ready pods are scheduled on distinct nodes.
- Deliberately ignore terminating pods while rejecting an additional active Pending or NotReady surge pod.
- Add `tests/test_verify_cloudflare_tunnel.py`, an execution-level harness that invokes the real verifier with isolated `helm` and `kubectl` shims and realistic Kubernetes payloads.
- Preserve the verifier’s read-only and Secret-safe behavior. No Cloudflare image coordinates, Helm configuration, observability rules, or operational documentation are changed.

### Regression coverage

The execution harness proves:

- two Ready pods on distinct nodes pass without producing `Cannot index array with string "items"`;
- two Ready pods plus an additional terminating pod pass;
- duplicate-node placement fails;
- an incorrect pod count fails;
- a non-ready pod does not satisfy the contract;
- two Ready pods plus an additional active non-ready surge pod fail;
- a terminating pod cannot substitute for a required current Ready pod.

### Testing

- `git merge-base --is-ancestor d690d50384c931551dfc7c7544d3a84856a7a66b HEAD` — passed.
- `bash -n scripts/verify_cloudflare_tunnel.sh` — passed.
- `python -m pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py` — 29 passed.
- `flake8 tests/test_verify_cloudflare_tunnel.py --max-line-length=100` — passed.
- `isort --check-only tests/test_verify_cloudflare_tunnel.py` — passed.
- `black --check tests/test_verify_cloudflare_tunnel.py --line-length=100` — passed.
- `git diff --check` — passed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed.
- Repository-wide `pre-commit run --all-files` still encounters pre-existing unrelated YAML and lint findings; no out-of-scope hook changes were retained.

The staging rollout had already completed successfully, and no live deployment, rollback, Secret read, or other infrastructure mutation was performed by this change or its tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77eb2866d4832f94c4eab7c0fa0d34)