### PR TITLE
Fix Cloudflare Tunnel post-rollout pod verification

### DIFF
--- a/scripts/verify_cloudflare_tunnel.sh
+++ b/scripts/verify_cloudflare_tunnel.sh
@@ -36,7 +36,15 @@ jq -e --arg image "${expected_image}" '
 ' <<<"${deployment}" >/dev/null
 
 pods="$(kubectl -n cloudflare get pods -l app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel -o json)"
-jq -e '[.items[] | select(.status.phase == "Running")] | length == 2 and ([.items[].spec.nodeName] | unique | length == 2)' <<<"${pods}" >/dev/null
+jq -e '
+  [.items[] | select(
+    .metadata.deletionTimestamp == null and
+    .status.phase == "Running" and
+    any(.status.conditions[]?; .type == "Ready" and .status == "True")
+  )] as $ready |
+  ($ready | length == 2) and
+  ($ready | map(.spec.nodeName) | unique | length == 2)
+' <<<"${pods}" >/dev/null
 kubectl -n cloudflare get pdb cloudflare-tunnel -o json | jq -e '.spec.minAvailable == 1' >/dev/null
 service="$(kubectl -n cloudflare get service cloudflare-tunnel-metrics -o json)"
 monitor="$(kubectl -n cloudflare get servicemonitor cloudflare-tunnel -o json)"

--- a/tests/test_cloudflare_tunnel_hardening.py
+++ b/tests/test_cloudflare_tunnel_hardening.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -70,3 +71,129 @@ def test_verifier_is_read_only_and_secret_safe():
         assert mutation not in script
     assert "sugar-staging" in script
     assert "Secret values were not read" in script
+
+
+def _pod(name, node, *, ready=True, terminating=False):
+    metadata = {"name": name}
+    if terminating:
+        metadata["deletionTimestamp"] = "2026-08-09T00:00:00Z"
+    return {
+        "metadata": metadata,
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
+def _run_verifier(tmp_path, pods):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    payloads = tmp_path / "payloads"
+    payloads.mkdir()
+    (payloads / "pods.json").write_text(
+        json.dumps({"apiVersion": "v1", "kind": "PodList", "items": pods})
+    )
+
+    deployment = {
+        "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm"}},
+        "spec": {
+            "replicas": 2,
+            "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
+            "template": {
+                "spec": {
+                    "affinity": {
+                        "podAntiAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": [
+                                {
+                                    "topologyKey": "kubernetes.io/hostname",
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/name": "cloudflare-tunnel",
+                                            "app.kubernetes.io/instance": "cloudflare-tunnel",
+                                        }
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                    "containers": [
+                        {
+                            "image": "cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf",
+                            "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}},
+                            "env": [
+                                {
+                                    "name": "TUNNEL_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {"name": "tunnel-token", "key": "token"}
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                    "volumes": [],
+                }
+            },
+        },
+    }
+    (payloads / "deployment.json").write_text(json.dumps(deployment))
+
+    helm = bin_dir / "helm"
+    helm.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'[{"name":"cloudflare-tunnel","chart":"cloudflare-tunnel-0.3.2"}]\'\n'
+    )
+    helm.chmod(0o755)
+    kubectl = bin_dir / "kubectl"
+    kubectl.write_text("""#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+if args == ["config", "current-context"]:
+    print("sugar-staging")
+elif "deployment" in args:
+    print(open(os.environ["PAYLOADS"] + "/deployment.json").read())
+elif "pods" in args:
+    print(open(os.environ["PAYLOADS"] + "/pods.json").read())
+elif "pdb" in args:
+    print('{"spec":{"minAvailable":1}}')
+elif "service" in args and "cloudflare-tunnel-metrics" in args:
+    print('{"spec":{"type":"ClusterIP","selector":{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"},"ports":[{"name":"metrics","port":2000,"protocol":"TCP","targetPort":2000}]}}')
+elif "servicemonitor" in args:
+    print('{"metadata":{"labels":{"release":"kube-prometheus-stack"}},"spec":{"selector":{"matchLabels":{"app.kubernetes.io/instance":"cloudflare-tunnel","app.kubernetes.io/name":"cloudflare-tunnel"}},"endpoints":[{"path":"/metrics"}]}}')
+elif any("rules?type=alert" in arg for arg in args):
+    print(json.dumps({"data":{"groups":[{"rules":[{"name": name, "health":"ok"} for name in ["CloudflareTunnelNoHealthyConnections","CloudflareTunnelConnectionsDegraded","CloudflareTunnelMetricsTargetsDown"]]}]}}))
+elif any("query?query=" in arg for arg in args):
+    query = " ".join(args)
+    value = "0" if "ALERTS" in query else "2"
+    print(json.dumps({"data":{"result":[{"value":[0, value]}]}}))
+else:
+    raise SystemExit("unexpected kubectl arguments: " + repr(args))
+""")
+    kubectl.chmod(0o755)
+    env = os.environ | {"PATH": f"{bin_dir}:{os.environ['PATH']}", "PAYLOADS": str(payloads)}
+    return subprocess.run(
+        ["bash", str(ROOT / "scripts/verify_cloudflare_tunnel.sh"), "staging"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_executable_verifier_accepts_two_ready_pods_on_distinct_nodes(tmp_path):
+    result = _run_verifier(tmp_path, [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b")])
+    assert result.returncode == 0, result.stderr
+    assert 'Cannot index array with string "items"' not in result.stderr
+
+
+def test_executable_verifier_rejects_invalid_pod_contracts(tmp_path):
+    cases = [
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-a")],
+        [_pod("tunnel-a", "node-a")],
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", ready=False)],
+        [_pod("tunnel-a", "node-a"), _pod("tunnel-b", "node-b", terminating=True)],
+    ]
+    for index, pods in enumerate(cases):
+        case_path = tmp_path / str(index)
+        case_path.mkdir()
+        result = _run_verifier(case_path, pods)
+        assert result.returncode != 0, f"case {index} unexpectedly passed"


### PR DESCRIPTION
### Motivation

- The read-only post-rollout verifier for the Cloudflare Tunnel release could fail with `jq: error: Cannot index array with string "items"` because a pipeline converted the input PodList into an array and a later subexpression attempted to re-index `.items` on that array. This change targets only the verifier logic and test harness.  
- The guarded staging rollout itself completed successfully (Cloudflare Tunnel Helm revision 2 deployed, two cloudflared connectors Running/Ready on separate nodes, metrics Service/ServiceMonitor/PDB present, observability revision 9, public staging endpoints returned HTTP 200). This PR fixes the subsequent read-only verifier only.

### Description

- Fix `scripts/verify_cloudflare_tunnel.sh` by scoping the jq input correctly: bind the filtered set of non-terminating, Running, Ready pods to a variable (`as $ready`) and then assert `($ready | length == 2)` and `($ready | map(.spec.nodeName) | unique | length == 2)` so both predicates operate on the original PodList context.  
- The jq change deliberately filters out terminating pods and requires an explicit Ready condition to avoid counting non-ready or terminating pods.  
- Add an execution-level regression harness in `tests/test_cloudflare_tunnel_hardening.py` that runs the exact verifier script against realistic mocked `kubectl`/`helm` responses (no live infra access and no Secret reads), covering: valid placement, duplicate-node placement, wrong pod count, non-ready pod, and terminating pod.  
- Preserve read-only and Secret-safe behavior and make no changes to images, Helm charts, observability rules, or operational docs.

### Testing

- Confirmed the referenced merge commit is an ancestor with `git merge-base --is-ancestor d690d50384c931551dfc7c7544d3a84856a7a66b HEAD` (succeeds).  
- Syntax check of the verifier: `bash -n scripts/verify_cloudflare_tunnel.sh` (passed).  
- Executable regression tests: `python -m pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py` (24 passed).  
- Formatting and safety checks: `python -m black --check tests/test_cloudflare_tunnel_hardening.py` (passed) and `git diff --cached | ./scripts/scan-secrets.py` (no secrets found); `pre-commit run --all-files` was attempted but repository-wide pre-existing YAML/lint issues unrelated to this change prevented a clean run (hooks did auto-fix unrelated trailing whitespace which was reverted before commit).  

Residual risk: unrelated repository-wide lint/YAML problems remain outside the scope of this minimal fix; the change here is narrowly scoped to the verifier and covered by focused tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77eb2d29f8832f8b92d556ef3cfd94)