### PR TITLE
fix(observability): consolidate production tables

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -85,7 +85,27 @@
           "instant": true,
           "legendFormat": "{{job}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "job": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "job": "Job",
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -176,7 +196,27 @@
           "instant": true,
           "legendFormat": "{{node}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "node": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "node": "Node",
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -227,7 +267,29 @@
           "instant": true,
           "legendFormat": "{{namespace}} / {{deployment}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "namespace": 0,
+              "deployment": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "namespace": "Namespace",
+              "deployment": "Deployment",
+              "Value": "Replica deficit"
+            }
+          }
         }
       ]
     },
@@ -599,47 +661,35 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "expr": "max by (component, pod, version, revision) (label_replace(prometheus_build_info, \"component\", \"prometheus\", \"\", \"\") or label_replace(alertmanager_build_info, \"component\", \"alertmanager\", \"\", \"\") or label_replace(grafana_build_info, \"component\", \"grafana\", \"\", \"\") or label_replace(node_exporter_build_info, \"component\", \"node-exporter\", \"\", \"\"))",
+          "format": "table",
           "instant": true,
-          "legendFormat": "Prometheus: {{pod}} / {{version}} / {{revision}}",
           "range": false,
           "refId": "A"
-        },
+        }
+      ],
+      "transformations": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
-          "instant": true,
-          "legendFormat": "Alertmanager: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (grafana_build_info)",
-          "instant": true,
-          "legendFormat": "Grafana: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
-          "instant": true,
-          "legendFormat": "node-exporter: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "D"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "Value": true
+            },
+            "indexByName": {
+              "component": 0,
+              "pod": 1,
+              "version": 2,
+              "revision": 3
+            },
+            "renameByName": {
+              "component": "Component",
+              "pod": "Pod",
+              "version": "Version",
+              "revision": "Revision"
+            }
+          }
         }
       ]
     }

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -224,23 +224,71 @@ def validate_production_dashboard(dashboard: dict) -> None:
         "Deployment replica deficit",
         "Observability component build identity",
     )
-    if any(
-        target.get("instant") is not True or target.get("range") is not False
-        for title in snapshot_tables
-        for target in panel_named(dashboard, title).get("targets", [])
-    ):
-        raise SystemExit("ERROR: production snapshot tables must use instant-only queries.")
-    build = panel_named(dashboard, "Observability component build identity")
-    expected_builds = {
-        "prometheus_build_info": "Prometheus:", "alertmanager_build_info": "Alertmanager:",
-        "grafana_build_info": "Grafana:", "node_exporter_build_info": "node-exporter:",
+    table_columns = {
+        "Scrape availability by job": (["job", "Value"], {"Time", "__name__"}),
+        "Node readiness": (["node", "Value"], {"Time", "__name__"}),
+        "Deployment replica deficit": (
+            ["namespace", "deployment", "Value"],
+            {"Time", "__name__"},
+        ),
+        "Observability component build identity": (
+            ["component", "pod", "version", "revision"],
+            {"Time", "__name__", "Value"},
+        ),
     }
-    if build.get("type") != "table" or len(build.get("targets", [])) != 4:
-        raise SystemExit("ERROR: production build identity must have four table queries.")
-    for metric, prefix in expected_builds.items():
-        matches = [target for target in build["targets"] if metric in target.get("expr", "")]
-        if len(matches) != 1 or matches[0]["expr"] != f"max by (pod, version, revision) ({metric})" or not matches[0].get("legendFormat", "").startswith(prefix):
-            raise SystemExit("ERROR: production build identity must retain pod/version/revision and component legends.")
+    for title in snapshot_tables:
+        panel = panel_named(dashboard, title)
+        targets = panel.get("targets", [])
+        if (
+            panel.get("type") != "table"
+            or len(targets) != 1
+            or targets[0].get("format") != "table"
+            or targets[0].get("instant") is not True
+            or targets[0].get("range") is not False
+        ):
+            raise SystemExit(
+                "ERROR: production tables must use one table-formatted instant-only query."
+            )
+        transformations = panel.get("transformations", [])
+        if len(transformations) != 1 or transformations[0].get("id") != "organize":
+            raise SystemExit(
+                "ERROR: production tables require deterministic single-frame consolidation."
+            )
+        options = transformations[0].get("options", {})
+        columns, excluded = table_columns[title]
+        if (
+            list(options.get("indexByName", {})) != columns
+            or {field for field, hidden in options.get("excludeByName", {}).items() if hidden}
+            != excluded
+            or set(options.get("renameByName", {})) != set(columns)
+        ):
+            raise SystemExit(
+                f"ERROR: production table {title} is missing required label/value columns."
+            )
+    build = panel_named(dashboard, "Observability component build identity")
+    build_expression = re.sub(r"\s+", " ", build["targets"][0]["expr"])
+    expected_builds = {
+        "prometheus_build_info": "prometheus",
+        "alertmanager_build_info": "alertmanager",
+        "grafana_build_info": "grafana",
+        "node_exporter_build_info": "node-exporter",
+    }
+    if not build_expression.startswith("max by (component, pod, version, revision) ("):
+        raise SystemExit("ERROR: production build identity must retain bounded identity labels.")
+    for metric, component in expected_builds.items():
+        expected = f'label_replace({metric}, "component", "{component}", "", "")'
+        if build_expression.count(expected) != 1:
+            raise SystemExit(
+                "ERROR: production build identity must union every fixed bounded component."
+            )
+    build_labels = re.search(r"max by \(([^)]*)\)", build_expression)
+    if not build_labels or {label.strip() for label in build_labels.group(1).split(",")} != {
+        "component",
+        "pod",
+        "version",
+        "revision",
+    }:
+        raise SystemExit("ERROR: production build identity introduced raw or unbounded labels.")
     serialized = json.dumps(dashboard)
     expressions = "\n".join(target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", []))
     if dashboard.get("refresh") != "30s" or dashboard.get("time") != {"from": "now-6h", "to": "now"} or dashboard.get("templating", {}).get("list") != []:

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -122,10 +122,39 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
         "Observability component build identity",
     }
     assert all(
-        target.get("instant") is True and target.get("range") is False
+        len(panels[title]["targets"]) == 1
+        and panels[title]["targets"][0].get("format") == "table"
+        and panels[title]["targets"][0].get("instant") is True
+        and panels[title]["targets"][0].get("range") is False
         for title in snapshot_tables
-        for target in panels[title]["targets"]
     )
+    assert {
+        title: list(panels[title]["transformations"][0]["options"]["indexByName"])
+        for title in snapshot_tables
+    } == {
+        "Scrape availability by job": ["job", "Value"],
+        "Node readiness": ["node", "Value"],
+        "Deployment replica deficit": ["namespace", "deployment", "Value"],
+        "Observability component build identity": [
+            "component",
+            "pod",
+            "version",
+            "revision",
+        ],
+    }
+    build = panels["Observability component build identity"]["targets"][0]["expr"]
+    assert build.startswith("max by (component, pod, version, revision)")
+    assert {
+        (metric, component)
+        for metric, component in re.findall(
+            r'label_replace\((\w+), "component", "([\w-]+)", "", ""\)', build
+        )
+    } == {
+        ("prometheus_build_info", "prometheus"),
+        ("alertmanager_build_info", "alertmanager"),
+        ("grafana_build_info", "grafana"),
+        ("node_exporter_build_info", "node-exporter"),
+    }
     unready = panels["Unready pods by namespace"]["targets"][0]["expr"]
     assert 'kube_pod_status_phase{phase=~"Pending|Running|Unknown"} == 1' in unready
     assert "group_left" in unready
@@ -155,17 +184,28 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
             "PromQL contract",
         ),
         (lambda d: d["panels"][1]["targets"][0].update(instant=False, range=True), "instant-only"),
+        (lambda d: d["panels"][1]["targets"][0].update(format="time_series"), "table-formatted"),
+        (
+            lambda d: d["panels"][3]["targets"].append(d["panels"][3]["targets"][0].copy()),
+            "exactly one PromQL target",
+        ),
+        (
+            lambda d: d["panels"][5]["transformations"][0]["options"]["indexByName"].pop(
+                "deployment"
+            ),
+            "required label/value columns",
+        ),
         (
             lambda d: production_panel(d, "Observability component build identity").update(
                 type="stat"
             ),
-            "four table queries",
+            "table-formatted instant-only",
         ),
         (
             lambda d: production_panel(d, "Observability component build identity")["targets"][
                 0
-            ].update(legendFormat="Prometheus"),
-            "pod/version/revision",
+            ].update(expr="max by (instance, pod, version, revision) (prometheus_build_info)"),
+            "bounded identity labels",
         ),
         (lambda d: d.update(refresh="1m"), "defaults or variables"),
         (lambda d: add_row_expression(d, "or vector(0)"), "preserve missing data"),


### PR DESCRIPTION
### Motivation

- Live inspection showed Grafana table panels rendering Prometheus results as multiple selectable frames instead of a single table of rows, causing labels to be truncated and requiring a dataset selector to view all entities.
- The change must present all returned jobs/nodes/deployments/components simultaneously as rows while preserving existing PromQL semantics, NO DATA behavior, numeric zeros, and panel layout/IDs.

### Description

- Updated the four production table panels in `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` (IDs 2, 4, 6, 17) so Prometheus targets use `format: "table"`, `instant: true`, and `range: false` and cannot produce multiple selectable frames.
- Added deterministic Grafana `organize` transformations to each table panel to set column ordering, rename columns to readable names, and hide irrelevant fields (`Time`, `__name__`, and `Value` where appropriate) so each panel renders as one coherent table (Scrape by `job`, Node by `node`, Deployment by `namespace`/`deployment`, Build identity by `component`/`pod`/`version`/`revision`).
- Consolidated the four independent build-info queries into a single instant table query that unions the four metrics with `label_replace(..., "component", "<fixed>", "", "")` to assign bounded `component` values (`prometheus`, `alertmanager`, `grafana`, `node-exporter`) while preserving `pod`, `version`, and `revision` and hiding raw instance/address labels.
- Extended `scripts/validate_observability_dashboard.py` to enforce that production snapshot tables are single target, table-formatted, instant-only, and use a single deterministic `organize` transformation with the required columns; also validate the consolidated bounded build-identity query and reject raw/unbounded labels or missing label/value columns.
- Updated `tests/test_observability_dashboard.py` with focused regression tests that assert table formatting, instant/range flags, deterministic column organization, the build-identity union, and validator failure cases for the covered alterations.

### Testing

- Ran validator: `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — passed.
- Verified table target flags with `jq`: `jq -e '[.panels[] | select(.type == "table") | .targets[] | select(.format != "table" or .instant != true or .range != false)] | length == 0' clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — returned `true`.
- Ran unit tests: `pytest -q tests/test_observability_dashboard.py` — 137 passed.
- Ran dashboard + helm tests: `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — 370 passed (full affected suites green).
- Ran link check: `linkchecker --no-warnings README.md docs/` — 208 URLs checked, no errors.

Notes and environment limits: `just observability-render env=prod` / `env=staging` could not be executed here because `helm` (and the `just` recipe dependencies) are not available in the execution environment; `pre-commit` and `aspell` (used by `pyspelling`) were also not installed, so those repository-wide checks were not run locally in this environment. No live cluster was contacted or modified during this work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77fae825f8832f8843fd634453c5b3)