### PR TITLE
fix(observability): consolidate production dashboard tables

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -85,7 +85,26 @@
           "instant": true,
           "legendFormat": "{{job}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "job": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -176,7 +195,26 @@
           "instant": true,
           "legendFormat": "{{node}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "node": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -227,7 +265,27 @@
           "instant": true,
           "legendFormat": "{{namespace}} / {{deployment}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "namespace": 0,
+              "deployment": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "Value": "Replica deficit"
+            }
+          }
         }
       ]
     },
@@ -599,47 +657,31 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "expr": "label_replace(max by (pod, version, revision) (prometheus_build_info), \"component\", \"prometheus\", \"pod\", \".*\") or label_replace(max by (pod, version, revision) (alertmanager_build_info), \"component\", \"alertmanager\", \"pod\", \".*\") or label_replace(max by (pod, version, revision) (grafana_build_info), \"component\", \"grafana\", \"pod\", \".*\") or label_replace(max by (pod, version, revision) (node_exporter_build_info), \"component\", \"node-exporter\", \"pod\", \".*\")",
           "instant": true,
-          "legendFormat": "Prometheus: {{pod}} / {{version}} / {{revision}}",
+          "legendFormat": "",
           "range": false,
-          "refId": "A"
-        },
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
-          "instant": true,
-          "legendFormat": "Alertmanager: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (grafana_build_info)",
-          "instant": true,
-          "legendFormat": "Grafana: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
-          "instant": true,
-          "legendFormat": "node-exporter: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "D"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "component": 0,
+              "pod": 1,
+              "version": 2,
+              "revision": 3
+            },
+            "renameByName": {}
+          }
         }
       ]
     }

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -181,7 +181,10 @@ def configure_profile(dashboard: dict) -> bool:
     global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
     identity = (dashboard.get("uid"), dashboard.get("title"))
     production = identity == (PROD_UID, PROD_TITLE)
-    if not production and identity != ("sugarkube-staging-observability", "Sugarkube Staging Observability"):
+    if not production and identity != (
+        "sugarkube-staging-observability",
+        "Sugarkube Staging Observability",
+    ):
         raise SystemExit("ERROR: dashboard title and UID do not match a supported profile.")
     UID, TITLE = identity
     DASHBOARD_FILE = f"{UID}.json"
@@ -209,8 +212,12 @@ def validate_production_dashboard(dashboard: dict) -> None:
         "Observability build identity": None,
     }
     actual_titles = [panel.get("title") for panel in panels(dashboard)]
-    if len(actual_titles) != len(required) + 1 or any(actual_titles.count(title) != 1 for title in required):
-        raise SystemExit("ERROR: production dashboard must contain every required row and panel exactly once.")
+    if len(actual_titles) != len(required) + 1 or any(
+        actual_titles.count(title) != 1 for title in required
+    ):
+        raise SystemExit(
+            "ERROR: production dashboard must contain every required row and panel exactly once."
+        )
     for title, expression in required.items():
         panel = panel_named(dashboard, title)
         if expression is None:
@@ -218,51 +225,126 @@ def validate_production_dashboard(dashboard: dict) -> None:
                 raise SystemExit("ERROR: production dashboard row contract is invalid.")
         elif panel_expression(dashboard, title) != expression:
             raise SystemExit(f"ERROR: production PromQL contract changed for {title}.")
-    snapshot_tables = (
-        "Scrape availability by job",
-        "Node readiness",
-        "Deployment replica deficit",
-        "Observability component build identity",
-    )
-    if any(
-        target.get("instant") is not True or target.get("range") is not False
-        for title in snapshot_tables
-        for target in panel_named(dashboard, title).get("targets", [])
-    ):
-        raise SystemExit("ERROR: production snapshot tables must use instant-only queries.")
-    build = panel_named(dashboard, "Observability component build identity")
-    expected_builds = {
-        "prometheus_build_info": "Prometheus:", "alertmanager_build_info": "Alertmanager:",
-        "grafana_build_info": "Grafana:", "node_exporter_build_info": "node-exporter:",
+    table_contracts = {
+        "Scrape availability by job": ({"job": 0, "Value": 1}, {"Value": "Status"}, False),
+        "Node readiness": ({"node": 0, "Value": 1}, {"Value": "Status"}, False),
+        "Deployment replica deficit": (
+            {"namespace": 0, "deployment": 1, "Value": 2},
+            {"Value": "Replica deficit"},
+            False,
+        ),
+        "Observability component build identity": (
+            {"component": 0, "pod": 1, "version": 2, "revision": 3},
+            {},
+            True,
+        ),
     }
-    if build.get("type") != "table" or len(build.get("targets", [])) != 4:
-        raise SystemExit("ERROR: production build identity must have four table queries.")
-    for metric, prefix in expected_builds.items():
-        matches = [target for target in build["targets"] if metric in target.get("expr", "")]
-        if len(matches) != 1 or matches[0]["expr"] != f"max by (pod, version, revision) ({metric})" or not matches[0].get("legendFormat", "").startswith(prefix):
-            raise SystemExit("ERROR: production build identity must retain pod/version/revision and component legends.")
+    for title, (columns, renames, hide_value) in table_contracts.items():
+        panel = panel_named(dashboard, title)
+        targets = panel.get("targets", [])
+        if panel.get("type") != "table" or len(targets) != 1:
+            raise SystemExit(
+                f"ERROR: production table {title} must deterministically consolidate into one frame."
+            )
+        target = targets[0]
+        if (
+            target.get("format") != "table"
+            or target.get("instant") is not True
+            or target.get("range") is not False
+        ):
+            raise SystemExit(
+                "ERROR: production table targets must be table-formatted and instant-only."
+            )
+        transformations = panel.get("transformations", [])
+        if len(transformations) != 1 or transformations[0].get("id") != "organize":
+            raise SystemExit(
+                f"ERROR: production table {title} requires deterministic field organization."
+            )
+        options = transformations[0].get("options", {})
+        excluded = options.get("excludeByName")
+        expected_excluded = {"Time": True, "__name__": True}
+        if hide_value:
+            expected_excluded["Value"] = True
+        if (
+            options.get("indexByName") != columns
+            or options.get("renameByName") != renames
+            or excluded != expected_excluded
+        ):
+            raise SystemExit(
+                f"ERROR: production table {title} has missing, raw, or unordered fields."
+            )
+
+    build = panel_named(dashboard, "Observability component build identity")
+    expected_build = " or ".join(
+        f"label_replace(max by (pod, version, revision) ({metric}), "
+        f'"component", "{component}", "pod", ".*")'
+        for metric, component in (
+            ("prometheus_build_info", "prometheus"),
+            ("alertmanager_build_info", "alertmanager"),
+            ("grafana_build_info", "grafana"),
+            ("node_exporter_build_info", "node-exporter"),
+        )
+    )
+    if build["targets"][0].get("expr") != expected_build:
+        raise SystemExit(
+            "ERROR: production build identity must safely union bounded component/pod/version/revision rows."
+        )
     serialized = json.dumps(dashboard)
-    expressions = "\n".join(target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", []))
-    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {"from": "now-6h", "to": "now"} or dashboard.get("templating", {}).get("list") != []:
+    expressions = "\n".join(
+        target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", [])
+    )
+    if (
+        dashboard.get("refresh") != "30s"
+        or dashboard.get("time") != {"from": "now-6h", "to": "now"}
+        or dashboard.get("templating", {}).get("list") != []
+    ):
         raise SystemExit("ERROR: production dashboard defaults or variables are invalid.")
-    if "or vector(0)" in expressions or "or on() vector(0)" in expressions or re.search(r'cluster\s*(?:=|=~)', expressions):
-        raise SystemExit("ERROR: production queries must preserve missing data and omit external-label selectors.")
-    forbidden = ("kube_state_metrics_build_info", "probe_", "dspace", "tokenplace", "blackbox", "synthetic")
+    if (
+        "or vector(0)" in expressions
+        or "or on() vector(0)" in expressions
+        or re.search(r"cluster\s*(?:=|=~)", expressions)
+    ):
+        raise SystemExit(
+            "ERROR: production queries must preserve missing data and omit external-label selectors."
+        )
+    forbidden = (
+        "kube_state_metrics_build_info",
+        "probe_",
+        "dspace",
+        "tokenplace",
+        "blackbox",
+        "synthetic",
+    )
     if any(item in expressions.lower() for item in forbidden):
         raise SystemExit("ERROR: production dashboard contains an unverified signal.")
-    if re.search(r"{{\s*(instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}", serialized, re.I):
+    if re.search(
+        r"{{\s*(instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}",
+        serialized,
+        re.I,
+    ):
         raise SystemExit("ERROR: production legends expose a forbidden raw identity label.")
     for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization"):
         if panel_named(dashboard, title)["targets"][0].get("legendFormat") != "{{nodename}}":
             raise SystemExit("ERROR: node panels must expose only nodename in their legends.")
-    for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization", "Prometheus PVC utilization"):
+    for title in (
+        "Node CPU utilization",
+        "Node memory utilization",
+        "Root filesystem utilization",
+        "Prometheus PVC utilization",
+    ):
         defaults = panel_named(dashboard, title).get("fieldConfig", {}).get("defaults", {})
         if (defaults.get("unit"), defaults.get("min"), defaults.get("max")) != ("percent", 0, 100):
             raise SystemExit("ERROR: production percentage panels require a 0-100 percent scale.")
-    if any(panel.get("type") != "row" and panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA" for panel in panels(dashboard)):
+    if any(
+        panel.get("type") != "row"
+        and panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA"
+        for panel in panels(dashboard)
+    ):
         raise SystemExit("ERROR: production panels must explicitly preserve NO DATA.")
     datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
-    if DATASOURCE_UID not in datasource_refs or any(uid not in {DATASOURCE_UID, PROD_UID} for uid in datasource_refs):
+    if DATASOURCE_UID not in datasource_refs or any(
+        uid not in {DATASOURCE_UID, PROD_UID} for uid in datasource_refs
+    ):
         raise SystemExit("ERROR: production datasource references must use Prometheus UID.")
 
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -122,9 +122,16 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
         "Observability component build identity",
     }
     assert all(
-        target.get("instant") is True and target.get("range") is False
+        len(panels[title]["targets"]) == 1
+        and panels[title]["targets"][0].get("format") == "table"
+        and panels[title]["targets"][0].get("instant") is True
+        and panels[title]["targets"][0].get("range") is False
         for title in snapshot_tables
-        for target in panels[title]["targets"]
+    )
+    assert all(
+        [transformation["id"] for transformation in panels[title]["transformations"]]
+        == ["organize"]
+        for title in snapshot_tables
     )
     unready = panels["Unready pods by namespace"]["targets"][0]["expr"]
     assert 'kube_pod_status_phase{phase=~"Pending|Running|Unknown"} == 1' in unready
@@ -155,17 +162,26 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
             "PromQL contract",
         ),
         (lambda d: d["panels"][1]["targets"][0].update(instant=False, range=True), "instant-only"),
+        (lambda d: d["panels"][1]["targets"][0].update(format="time_series"), "table-formatted"),
         (
-            lambda d: production_panel(d, "Observability component build identity").update(
-                type="stat"
+            lambda d: production_panel(d, "Observability component build identity")[
+                "targets"
+            ].append(
+                dict(production_panel(d, "Observability component build identity")["targets"][0])
             ),
-            "four table queries",
+            "consolidate into one frame",
+        ),
+        (
+            lambda d: production_panel(d, "Node readiness")["transformations"][0]["options"][
+                "indexByName"
+            ].pop("node"),
+            "missing, raw, or unordered fields",
         ),
         (
             lambda d: production_panel(d, "Observability component build identity")["targets"][
                 0
-            ].update(legendFormat="Prometheus"),
-            "pod/version/revision",
+            ].update(expr="max by (instance, pod, version, revision) (prometheus_build_info)"),
+            "safely union bounded",
         ),
         (lambda d: d.update(refresh="1m"), "defaults or variables"),
         (lambda d: add_row_expression(d, "or vector(0)"), "preserve missing data"),
@@ -872,7 +888,7 @@ def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
 
 
 def rendered_dashboard_yaml(dashboard, mount_path=None, sub_path=None):
-    filename = "sugarkube-staging-observability.json"
+    filename = f"{dashboard['uid']}.json"
     mount_path = mount_path or f"/var/lib/grafana/dashboards/sugarkube/{filename}"
     sub_path = sub_path or filename
     payload = json.dumps(dashboard, indent=2)
@@ -914,6 +930,13 @@ def test_validator_accepts_chart_native_render(tmp_path, dashboard):
     rendered = tmp_path / "direct-rendered.yaml"
     rendered.write_text(rendered_dashboard_yaml(dashboard), encoding="utf-8")
     dashboard_json = validator.validate_dashboard(DASHBOARD)
+    validator.validate_render(rendered, dashboard_json)
+
+
+def test_production_rendered_dashboard_equals_source(tmp_path, prod_dashboard):
+    rendered = tmp_path / "prod-rendered.yaml"
+    rendered.write_text(rendered_dashboard_yaml(prod_dashboard), encoding="utf-8")
+    dashboard_json = validator.validate_dashboard(PROD_DASHBOARD)
     validator.validate_render(rendered, dashboard_json)
 
 


### PR DESCRIPTION
### Motivation

- Live inspection exposed that several production table panels rendered Prometheus series as separate selectable frames so only one series was visible at a time instead of showing all entities as rows.
- The intent is to present simultaneous rows for jobs, nodes, deployments and to show a consolidated build-identity table while preserving NO DATA, zero values, and existing PromQL semantics.

### Description

- Updated `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` to make the four production snapshot table panels (IDs 2, 4, 6, 17) use Prometheus instant table queries (`format: "table"`, `instant: true`, `range: false`), and added deterministic `organize` transformations to produce single table frames with named columns and hidden internals.
- Consolidated the four build-info queries into one safe unioned instant table using `label_replace(... ) or ...` so the build-identity panel returns bounded `component`, `pod`, `version`, and `revision` rows (no raw `instance`/IP/URL exposure), and reordered/renamed fields for readable columns.
- Extended `scripts/validate_observability_dashboard.py` to fail-closed on production table contracts by requiring each production table to have exactly one table-formatted instant target, a single `organize` transformation with expected `indexByName`/`renameByName`/`excludeByName`, and the exact bounded build-identity expression.
- Added and updated tests in `tests/test_observability_dashboard.py` to assert single-frame table formatting, the presence of deterministic `organize` transformations, the consolidated build identity, and a rendered-dashboard equality check; no staging files or non-approved paths were modified.

### Testing

- Ran dashboard validation: `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — succeeded.
- Verified all production table targets are table-formatted instant-only with `jq -e '[.panels[] | select(.type == "table") | .targets[] | select(.format != "table" or .instant != true or .range != false)] | length == 0' clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — returned true.
- Ran unit tests: `pytest -q tests/test_observability_dashboard.py` — passed (137 tests); `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — passed (370 tests).
- Render verification: `just observability-render env=prod` and `just observability-render env=staging` (offline Helm render) — succeeded for both environments in this offline render context.
- Formatting and lint checks: `python3 -m black scripts/validate_observability_dashboard.py tests/test_observability_dashboard.py` and subsequent `pytest` runs completed successfully for changed tests; `pre-commit run --all-files` reported existing repository-wide YAML/lint issues unrelated to the scoped changes (these are pre-existing and outside the scope of this PR).
- Docs/link/spell checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were executed (note: `aspell` was installed in the test environment to run spelling); link checks found no errors.

All automated validations added or extended by this change passed in CI-like local runs; unrelated repository-wide pre-commit failures were observed but are not caused by the scope-locked edits in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77faeb0330832f92311968d24a8a68)