### PR TITLE
fix(observability): consolidate production dashboard tables

### DIFF
--- a/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
+++ b/clusters/prod/observability/dashboards/sugarkube-prod-observability.json
@@ -85,7 +85,27 @@
           "instant": true,
           "legendFormat": "{{job}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "job": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "job": "Job",
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -176,7 +196,27 @@
           "instant": true,
           "legendFormat": "{{node}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "node": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "node": "Node",
+              "Value": "Status"
+            }
+          }
         }
       ]
     },
@@ -227,7 +267,29 @@
           "instant": true,
           "legendFormat": "{{namespace}} / {{deployment}}",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "namespace": 0,
+              "deployment": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "namespace": "Namespace",
+              "deployment": "Deployment",
+              "Value": "Deficit"
+            }
+          }
         }
       ]
     },
@@ -599,47 +661,36 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "max by (pod, version, revision) (prometheus_build_info)",
+          "expr": "label_replace(max by (pod, version, revision) (prometheus_build_info), \"component\", \"prometheus\", \"\", \"\") or label_replace(max by (pod, version, revision) (alertmanager_build_info), \"component\", \"alertmanager\", \"\", \"\") or label_replace(max by (pod, version, revision) (grafana_build_info), \"component\", \"grafana\", \"\", \"\") or label_replace(max by (pod, version, revision) (node_exporter_build_info), \"component\", \"node-exporter\", \"\", \"\")",
+          "format": "table",
           "instant": true,
-          "legendFormat": "Prometheus: {{pod}} / {{version}} / {{revision}}",
+          "legendFormat": "",
           "range": false,
           "refId": "A"
-        },
+        }
+      ],
+      "transformations": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (alertmanager_build_info)",
-          "instant": true,
-          "legendFormat": "Alertmanager: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (grafana_build_info)",
-          "instant": true,
-          "legendFormat": "Grafana: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "max by (pod, version, revision) (node_exporter_build_info)",
-          "instant": true,
-          "legendFormat": "node-exporter: {{pod}} / {{version}} / {{revision}}",
-          "range": false,
-          "refId": "D"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "component": 0,
+              "pod": 1,
+              "version": 2,
+              "revision": 3
+            },
+            "renameByName": {
+              "component": "Component",
+              "pod": "Pod",
+              "version": "Version",
+              "revision": "Revision"
+            }
+          }
         }
       ]
     }

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -181,7 +181,10 @@ def configure_profile(dashboard: dict) -> bool:
     global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
     identity = (dashboard.get("uid"), dashboard.get("title"))
     production = identity == (PROD_UID, PROD_TITLE)
-    if not production and identity != ("sugarkube-staging-observability", "Sugarkube Staging Observability"):
+    if not production and identity != (
+        "sugarkube-staging-observability",
+        "Sugarkube Staging Observability",
+    ):
         raise SystemExit("ERROR: dashboard title and UID do not match a supported profile.")
     UID, TITLE = identity
     DASHBOARD_FILE = f"{UID}.json"
@@ -209,8 +212,12 @@ def validate_production_dashboard(dashboard: dict) -> None:
         "Observability build identity": None,
     }
     actual_titles = [panel.get("title") for panel in panels(dashboard)]
-    if len(actual_titles) != len(required) + 1 or any(actual_titles.count(title) != 1 for title in required):
-        raise SystemExit("ERROR: production dashboard must contain every required row and panel exactly once.")
+    if len(actual_titles) != len(required) + 1 or any(
+        actual_titles.count(title) != 1 for title in required
+    ):
+        raise SystemExit(
+            "ERROR: production dashboard must contain every required row and panel exactly once."
+        )
     for title, expression in required.items():
         panel = panel_named(dashboard, title)
         if expression is None:
@@ -218,51 +225,124 @@ def validate_production_dashboard(dashboard: dict) -> None:
                 raise SystemExit("ERROR: production dashboard row contract is invalid.")
         elif panel_expression(dashboard, title) != expression:
             raise SystemExit(f"ERROR: production PromQL contract changed for {title}.")
-    snapshot_tables = (
-        "Scrape availability by job",
-        "Node readiness",
-        "Deployment replica deficit",
-        "Observability component build identity",
-    )
-    if any(
-        target.get("instant") is not True or target.get("range") is not False
-        for title in snapshot_tables
-        for target in panel_named(dashboard, title).get("targets", [])
-    ):
-        raise SystemExit("ERROR: production snapshot tables must use instant-only queries.")
-    build = panel_named(dashboard, "Observability component build identity")
-    expected_builds = {
-        "prometheus_build_info": "Prometheus:", "alertmanager_build_info": "Alertmanager:",
-        "grafana_build_info": "Grafana:", "node_exporter_build_info": "node-exporter:",
+    table_contracts = {
+        "Scrape availability by job": ({"job", "Value"}, {"Time", "__name__"}),
+        "Node readiness": ({"node", "Value"}, {"Time", "__name__"}),
+        "Deployment replica deficit": (
+            {"namespace", "deployment", "Value"},
+            {"Time", "__name__"},
+        ),
+        "Observability component build identity": (
+            {"component", "pod", "version", "revision"},
+            {"Time", "Value", "__name__"},
+        ),
     }
-    if build.get("type") != "table" or len(build.get("targets", [])) != 4:
-        raise SystemExit("ERROR: production build identity must have four table queries.")
-    for metric, prefix in expected_builds.items():
-        matches = [target for target in build["targets"] if metric in target.get("expr", "")]
-        if len(matches) != 1 or matches[0]["expr"] != f"max by (pod, version, revision) ({metric})" or not matches[0].get("legendFormat", "").startswith(prefix):
-            raise SystemExit("ERROR: production build identity must retain pod/version/revision and component legends.")
+    for title, (visible_fields, hidden_fields) in table_contracts.items():
+        panel = panel_named(dashboard, title)
+        targets = panel.get("targets", [])
+        transformations = panel.get("transformations", [])
+        organize = [item for item in transformations if item.get("id") == "organize"]
+        if (
+            panel.get("type") != "table"
+            or len(targets) != 1
+            or targets[0].get("format") != "table"
+            or targets[0].get("instant") is not True
+            or targets[0].get("range") is not False
+        ):
+            raise SystemExit(
+                "ERROR: production tables must have one table-formatted instant-only query."
+            )
+        if len(organize) != 1 or len(transformations) != 1:
+            raise SystemExit(
+                "ERROR: production tables require deterministic single-frame organization."
+            )
+        options = organize[0].get("options", {})
+        indexed = options.get("indexByName", {})
+        excluded = {name for name, hidden in options.get("excludeByName", {}).items() if hidden}
+        renamed = options.get("renameByName", {})
+        if set(indexed) != visible_fields or set(indexed.values()) != set(range(len(indexed))):
+            raise SystemExit("ERROR: production table required label/value columns are missing.")
+        if not hidden_fields <= excluded or not visible_fields <= set(renamed):
+            raise SystemExit("ERROR: production table fields must be clearly named and bounded.")
+
+    build = panel_named(dashboard, "Observability component build identity")
+    build_expression = build["targets"][0]["expr"]
+    expected_builds = {
+        "prometheus_build_info": "prometheus",
+        "alertmanager_build_info": "alertmanager",
+        "grafana_build_info": "grafana",
+        "node_exporter_build_info": "node-exporter",
+    }
+    for metric, component in expected_builds.items():
+        expected = (
+            f"label_replace(max by (pod, version, revision) ({metric}), "
+            f'"component", "{component}", "", "")'
+        )
+        if build_expression.count(expected) != 1:
+            raise SystemExit(
+                "ERROR: production build identity must union bounded component/pod/version/revision rows."
+            )
+    if any(
+        label in build_expression
+        for label in ("instance", "address", "endpoint", "device", "url", "system_uuid")
+    ):
+        raise SystemExit("ERROR: production build identity exposes a raw or unbounded label.")
     serialized = json.dumps(dashboard)
-    expressions = "\n".join(target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", []))
-    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {"from": "now-6h", "to": "now"} or dashboard.get("templating", {}).get("list") != []:
+    expressions = "\n".join(
+        target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", [])
+    )
+    if (
+        dashboard.get("refresh") != "30s"
+        or dashboard.get("time") != {"from": "now-6h", "to": "now"}
+        or dashboard.get("templating", {}).get("list") != []
+    ):
         raise SystemExit("ERROR: production dashboard defaults or variables are invalid.")
-    if "or vector(0)" in expressions or "or on() vector(0)" in expressions or re.search(r'cluster\s*(?:=|=~)', expressions):
-        raise SystemExit("ERROR: production queries must preserve missing data and omit external-label selectors.")
-    forbidden = ("kube_state_metrics_build_info", "probe_", "dspace", "tokenplace", "blackbox", "synthetic")
+    if (
+        "or vector(0)" in expressions
+        or "or on() vector(0)" in expressions
+        or re.search(r"cluster\s*(?:=|=~)", expressions)
+    ):
+        raise SystemExit(
+            "ERROR: production queries must preserve missing data and omit external-label selectors."
+        )
+    forbidden = (
+        "kube_state_metrics_build_info",
+        "probe_",
+        "dspace",
+        "tokenplace",
+        "blackbox",
+        "synthetic",
+    )
     if any(item in expressions.lower() for item in forbidden):
         raise SystemExit("ERROR: production dashboard contains an unverified signal.")
-    if re.search(r"{{\s*(instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}", serialized, re.I):
+    if re.search(
+        r"{{\s*(instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}",
+        serialized,
+        re.I,
+    ):
         raise SystemExit("ERROR: production legends expose a forbidden raw identity label.")
     for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization"):
         if panel_named(dashboard, title)["targets"][0].get("legendFormat") != "{{nodename}}":
             raise SystemExit("ERROR: node panels must expose only nodename in their legends.")
-    for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization", "Prometheus PVC utilization"):
+    for title in (
+        "Node CPU utilization",
+        "Node memory utilization",
+        "Root filesystem utilization",
+        "Prometheus PVC utilization",
+    ):
         defaults = panel_named(dashboard, title).get("fieldConfig", {}).get("defaults", {})
         if (defaults.get("unit"), defaults.get("min"), defaults.get("max")) != ("percent", 0, 100):
             raise SystemExit("ERROR: production percentage panels require a 0-100 percent scale.")
-    if any(panel.get("type") != "row" and panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA" for panel in panels(dashboard)):
+    if any(
+        panel.get("type") != "row"
+        and panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA"
+        for panel in panels(dashboard)
+    ):
         raise SystemExit("ERROR: production panels must explicitly preserve NO DATA.")
     datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
-    if DATASOURCE_UID not in datasource_refs or any(uid not in {DATASOURCE_UID, PROD_UID} for uid in datasource_refs):
+    if DATASOURCE_UID not in datasource_refs or any(
+        uid not in {DATASOURCE_UID, PROD_UID} for uid in datasource_refs
+    ):
         raise SystemExit("ERROR: production datasource references must use Prometheus UID.")
 
 

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -122,10 +122,47 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
         "Observability component build identity",
     }
     assert all(
-        target.get("instant") is True and target.get("range") is False
+        target.get("format") == "table"
+        and target.get("instant") is True
+        and target.get("range") is False
         for title in snapshot_tables
         for target in panels[title]["targets"]
     )
+    expected_columns = {
+        "Scrape availability by job": {"job", "Value"},
+        "Node readiness": {"node", "Value"},
+        "Deployment replica deficit": {"namespace", "deployment", "Value"},
+        "Observability component build identity": {
+            "component",
+            "pod",
+            "version",
+            "revision",
+        },
+    }
+    for title, columns in expected_columns.items():
+        panel = panels[title]
+        assert len(panel["targets"]) == 1
+        assert [item["id"] for item in panel["transformations"]] == ["organize"]
+        organize = panel["transformations"][0]["options"]
+        assert set(organize["indexByName"]) == columns
+        assert set(organize["indexByName"].values()) == set(range(len(columns)))
+        assert columns <= set(organize["renameByName"])
+        assert organize["excludeByName"]["Time"] is True
+        assert organize["excludeByName"]["__name__"] is True
+
+    build = panels["Observability component build identity"]
+    expression = build["targets"][0]["expr"]
+    for metric, component in {
+        "prometheus_build_info": "prometheus",
+        "alertmanager_build_info": "alertmanager",
+        "grafana_build_info": "grafana",
+        "node_exporter_build_info": "node-exporter",
+    }.items():
+        assert (
+            f"label_replace(max by (pod, version, revision) ({metric}), "
+            f'"component", "{component}", "", "")'
+        ) in expression
+    assert build["transformations"][0]["options"]["excludeByName"]["Value"] is True
     unready = panels["Unready pods by namespace"]["targets"][0]["expr"]
     assert 'kube_pod_status_phase{phase=~"Pending|Running|Unknown"} == 1' in unready
     assert "group_left" in unready
@@ -154,18 +191,27 @@ def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
             lambda d: d["panels"][14]["targets"][0].update(expr="sum(prometheus_tsdb_head_series)"),
             "PromQL contract",
         ),
-        (lambda d: d["panels"][1]["targets"][0].update(instant=False, range=True), "instant-only"),
+        (
+            lambda d: d["panels"][1]["targets"][0].update(format="time_series"),
+            "table-formatted instant-only",
+        ),
         (
             lambda d: production_panel(d, "Observability component build identity").update(
-                type="stat"
+                transformations=[]
             ),
-            "four table queries",
+            "deterministic single-frame organization",
+        ),
+        (
+            lambda d: production_panel(d, "Node readiness")["transformations"][0]["options"][
+                "indexByName"
+            ].pop("node"),
+            "required label/value columns",
         ),
         (
             lambda d: production_panel(d, "Observability component build identity")["targets"][
                 0
-            ].update(legendFormat="Prometheus"),
-            "pod/version/revision",
+            ].update(expr="max by (instance, version) (prometheus_build_info)"),
+            "bounded component/pod/version/revision",
         ),
         (lambda d: d.update(refresh="1m"), "defaults or variables"),
         (lambda d: add_row_expression(d, "or vector(0)"), "preserve missing data"),


### PR DESCRIPTION
### Motivation
- Grafana table panels in production were rendering Prometheus series as separate selectable frames, causing rows such as jobs, nodes, and deployments to appear one-at-a-time instead of as a single table and truncating labels. 
- The goal is to present all returned entities as deterministic table rows without changing live cluster signals or PromQL semantics beyond safe, bounded label consolidation for build identity.

### Description
- Updated `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` to set the four production snapshot panels (ID 2, 4, 6, 17) to `format: "table"`, `instant: true`, `range: false`, and added a deterministic `organize` transformation with `excludeByName`/`indexByName`/`renameByName` so each panel renders a single coherent table (Scrape availability by job, Node readiness, Deployment replica deficit, Observability component build identity). 
- Consolidated the four build-info queries into a single table-formatted instant query that unions the four build-info families and injects a fixed bounded `component` label via `label_replace` for `prometheus`, `alertmanager`, `grafana`, and `node-exporter`, preserving per-pod/version/revision identity and hiding raw identity labels. 
- Extended `scripts/validate_observability_dashboard.py` to enforce that production snapshot tables are table-formatted instant-only queries, require exactly one deterministic `organize` transformation, verify required visible columns and renamed headers, ensure the build-identity expression unions the bounded component rows, and forbid raw/unbounded labels or unsafe zero-masking. 
- Added focused regression assertions in `tests/test_observability_dashboard.py` to cover `format/instant/range`, presence and shape of `organize` options, the consolidated build-expression pattern, and preservation of `NO DATA`/zero semantics.

### Testing
- `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — passed.
- `jq -e '[.panels[] | select(.type == "table") | .targets[] | select(.format != "table" or .instant != true or .range != false)] | length == 0' clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — returned `true` (check passed).
- `pytest -q tests/test_observability_dashboard.py` — passed (existing and new assertions; run completed successfully).
- `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — full suite run completed successfully (both suites passed in the environment used).
- Formatting and linting: `python3 -m black` reformatted the touched files as needed and was run; `bash scripts/checks.sh` was executed as the repository substitute and completed, and `linkchecker --no-warnings README.md docs/` completed with no errors. 
- Environment limitations: `just observability-render env=prod` / `staging` could not be executed because `helm` is not available in this environment, and `pyspelling` failed due to missing `aspell`; these are environment tool limitations and do not affect the validator/tests that guard the dashboard contract.

All changes are limited to the requested files and preserve dashboard UID/title/datasource, panel IDs and layout, PromQL correctness, and the expected runtime signals (NO DATA, legitimate zero values, and transient unready-pod spikes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77fadb1728832fb8c6aeee9af5278c)