### PR TITLE
ci: fix Claude workflow auth and sandbox bootstrap

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Install Bubblewrap sandbox runtime
         run: |
           set -euo pipefail
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends bubblewrap
           if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -138,6 +138,9 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get install -y --no-install-recommends bubblewrap
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Prove validation sandbox denies outbound network
         working-directory: pr-workspace
@@ -359,7 +362,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.claude-app-token.outputs.token }}
           allowed_non_write_users: ${{ needs.authorize.outputs.authorized_actor }}
           include_comments_by_actor: ${{ needs.authorize.outputs.trusted_actors }}


### PR DESCRIPTION
### Motivation

The first real @claude test after #2545 merged showed two failures (run https://github.com/futuroptimist/sugarkube/actions/runs/31297331667):

1. **`claude` job**: `is_error:true`, `num_turns:1`, `total_cost_usd:0` after ~2s — the documented signature for an invalid credential in `anthropics/claude-code-action`. The configured `CLAUDE_CODE_OAUTH_TOKEN` secret actually holds an Anthropic Console API key (`sk-ant-api03-...`), not a `claude setup-token`-generated OAuth token (`sk-ant-oat01-...`) — different credential types, different action inputs.
2. **`claude-validation` job**: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` — the bubblewrap install step in this job was missing the `kernel.apparmor_restrict_unprivileged_userns=0` workaround that the `claude` job already had, so its network-sandbox probe couldn't set up bubblewrap's isolated network namespace.

### Description

- Switch the `claude` job to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` (matches the credential type already available) instead of `claude_code_oauth_token`.
- Add the same `apparmor_restrict_unprivileged_userns` sysctl workaround to `claude-validation`'s "Install Bubblewrap sandbox runtime" step.

### Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml'))"` — YAML parses.
- Requires the `ANTHROPIC_API_KEY` repository secret to be added (Settings → Secrets and variables → Actions) before this actually fixes the auth failure — done alongside this PR.