### PR TITLE
Add deterministic staging Cloudflare WAN dependency-loss drill (nftables namespace drop + tests/docs)

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -504,25 +504,44 @@ part of this rollout.
    `2026.7.3`, readiness-only `/ready`, two Prometheus targets, four HA connections per connector,
    healthy alerts, and every approved staging public endpoint.
 4. A pod-deletion drill is not an acceptable WAN-recovery test: it proves replacement, not that the
-   same cloudflared processes stay alive during dependency loss and reconnect afterward. The repository
-   shows that staging uses Kubernetes `NetworkPolicy`, but it does not establish which staging CNI
-   enforces a temporary egress-deny policy or prove that an exact release selector cannot affect other
-   workloads. Therefore the dependency-loss drill is **blocked** pending separate owner confirmation of
-   the staging CNI and its egress-policy behavior. Do not apply a speculative policy or substitute pod
-   deletion.
+   same cloudflared processes stay alive during dependency loss and reconnect afterward.
 
-   Once that evidence is recorded, a separately authorized procedure must use a uniquely named,
-   temporary `NetworkPolicy` in `cloudflare`, selecting exactly
-   `app.kubernetes.io/name=cloudflare-tunnel` and
-   `app.kubernetes.io/instance=cloudflare-tunnel`. Before applying it, record both pod names, UIDs, and
-   restart counts and install a cleanup trap that deletes that exact policy name. Keep the deny interval
-   below five minutes (the shortest alert `for` duration); verify readiness becomes false while both UIDs
-   and restart counts remain unchanged. Delete the exact policy, then require those same two pods to
-   become Ready and report at least four HA connections each within five minutes. This contract may be
-   executed only after the CNI safety blocker is resolved and the exact manifest is separately reviewed.
-5. Cleanup is `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods,
-   Service, ServiceMonitor, and PDB. If a future authorized drill resolves the blocker, exact deletion of
-   its uniquely named NetworkPolicy is mandatory even on interruption.
+   A deny-egress `NetworkPolicy` created after cloudflared has connected is not an acceptable substitute.
+   Kubernetes explicitly makes the effect of a newly applied policy on existing connections
+   [implementation-defined](https://kubernetes.io/docs/concepts/services-networking/network-policies/#network-traffic-filtering),
+   so a conforming implementation can leave established QUIC sessions intact. On 2026-08-09 the uniquely
+   owned staging policy `cloudflare-wan-drill-20260809t060056z-29424` selected both connectors, but both
+   remained Ready through 23 polls over about 120 seconds. That result is an **inconclusive dependency-loss
+   test**, not a pass: cleanup removed the exact policy, the original UIDs and restart counts were
+   unchanged, all four HA connections per pod returned healthy, no alert fired, and all 16 public probes
+   remained HTTP 200. Operator evidence remains local and must not be committed.
+
+5. Use `just cf-tunnel-wan-dependency-loss-drill env=staging` to print the repository-owned,
+   non-mutating plan. The deterministic mechanism is an nftables output-hook table inside each exact pod
+   network namespace which drops TCP and UDP edge traffic on ports 443 and 7844. Unlike a post-connection
+   NetworkPolicy, a netfilter output hook sees packets from established QUIC flows; it leaves the
+   cloudflared processes and local readiness/metrics traffic running. It never adds a host-wide rule or
+   flushes a ruleset. Execution remains **blocked** unless every preflight succeeds, an approved revision
+   and authenticated node executor are explicitly supplied, and the operator types the exact confirmation.
+
+   Before either drop table is installed, the helper resolves the exact CRI pod sandbox PID and installs
+   an independently surviving, four-minute transient systemd cleanup timer on both nodes. Each table name
+   contains the bounded unique owner ID and sandbox PID. Cleanup deletes only those exact tables and prints
+   exact per-node manual cleanup commands if deletion cannot be proved. The runner must provide already
+   authorized, host-key-verified access; the helper never creates keys, handles interactive credentials,
+   weakens SSH host checking, or assumes unattended access. If such execution is unavailable, it refuses
+   the live drill.
+
+   An authorized run must pass `--execute`, set `CF_WAN_APPROVED_REVISION` to the reviewed commit and
+   `CF_WAN_NODE_EXEC` to the approved runner, and pass
+   `--confirm 'INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS'`. It captures only sanitized Kubernetes,
+   Helm, metrics and endpoint evidence under `~/operator-evidence`; it never requests Secret values. It
+   proves both original pods become NotReady with zero HA connections and no restart, removes the exact
+   tables, then proves those same UIDs recover Ready with at least four HA connections within five minutes.
+   It also requires endpoint, Helm history, Secret metadata, Deployment, and the full read-only verifier
+   to remain healthy. Do not execute this procedure in CI or without separate owner authorization.
+6. Cleanup is `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods,
+   Service, ServiceMonitor, and PDB.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/justfile
+++ b/justfile
@@ -727,6 +727,15 @@ cf-tunnel-install env='dev' token='':
 cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
+# Plan (default) or execute the deterministic, process-preserving staging WAN drill.
+cf-tunnel-wan-dependency-loss-drill env='staging' execute='false' confirm='' evidence_dir='':
+    #!/usr/bin/env bash
+    args=(--env {{ quote(env) }})
+    [[ {{ quote(execute) }} == true ]] && args+=(--execute)
+    [[ -z {{ quote(confirm) }} ]] || args+=(--confirm {{ quote(confirm) }})
+    [[ -z {{ quote(evidence_dir) }} ]] || args+=(--evidence-dir {{ quote(evidence_dir) }})
+    scripts/cloudflare_wan_dependency_loss_drill.sh "${args[@]}"
+
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:
     #!/usr/bin/env bash

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Staging-only, process-preserving Cloudflare WAN dependency-loss drill.
+set -Eeuo pipefail
+
+readonly EXPECTED_CONTEXT=sugar-staging
+readonly EXPECTED_IMAGE='cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf'
+readonly EXPECTED_CONFIRMATION='INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS'
+readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
+readonly MAX_DISRUPTION_SECONDS=240
+execute=0
+env_name=staging
+confirmation=''
+evidence_dir=''
+
+usage() {
+  cat <<'EOF'
+Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
+       [--confirm 'INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS'] [--evidence-dir DIR]
+
+The default is a non-mutating plan. Execution also requires CF_WAN_APPROVED_REVISION
+and CF_WAN_NODE_EXEC, an executable invoked as: NODE_EXEC <node> <shell-command>.
+EOF
+}
+while (($#)); do
+  case "$1" in
+    --execute) execute=1 ;;
+    --env) env_name="${2:?missing --env value}"; shift ;;
+    --confirm) confirmation="${2:?missing --confirm value}"; shift ;;
+    --evidence-dir) evidence_dir="${2:?missing --evidence-dir value}"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null || die "required command not found: $1"; }
+for command in git kubectl helm jq curl; do need "${command}"; done
+[[ "${env_name}" == staging ]] || die 'WAN dependency-loss drill is staging-only.'
+[[ "$(kubectl config current-context)" == "${EXPECTED_CONTEXT}" ]] || die "expected context ${EXPECTED_CONTEXT}."
+
+repo_root="$(git rev-parse --show-toplevel)"
+head="$(git -C "${repo_root}" rev-parse HEAD)"
+[[ -z "$(git -C "${repo_root}" status --porcelain --untracked-files=normal)" ]] || die 'repository tree is dirty.'
+if ((execute)); then
+  [[ -n "${CF_WAN_APPROVED_REVISION:-}" && "${head}" == "${CF_WAN_APPROVED_REVISION}" ]] || die 'HEAD is not the explicitly approved revision.'
+fi
+
+releases="$(helm -n cloudflare list -o json)"
+jq -e '[.[] | select(.name=="cloudflare-tunnel" and .status=="deployed")] | length == 1' <<<"${releases}" >/dev/null || die 'expected exactly one deployed cloudflare-tunnel release.'
+revision="$(jq -r '.[] | select(.name=="cloudflare-tunnel") | .revision' <<<"${releases}")"
+[[ "${revision}" == 2 ]] || die "cloudflare-tunnel must be Helm revision 2; got ${revision}."
+
+deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
+jq -e --arg image "${EXPECTED_IMAGE}" '
+ .metadata.labels["app.kubernetes.io/managed-by"] == "Helm" and
+ .metadata.labels["app.kubernetes.io/name"] == "cloudflare-tunnel" and
+ .metadata.labels["app.kubernetes.io/instance"] == "cloudflare-tunnel" and
+ .spec.template.spec.containers[0].image == $image' <<<"${deployment}" >/dev/null || die 'Deployment ownership, labels, or immutable image differ.'
+
+pods="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
+jq -e --arg image "${EXPECTED_IMAGE}" '
+ [.items[] | select(.metadata.deletionTimestamp == null)] as $p |
+ ($p|length)==2 and all($p[];
+   .metadata.labels["app.kubernetes.io/name"]=="cloudflare-tunnel" and
+   .metadata.labels["app.kubernetes.io/instance"]=="cloudflare-tunnel" and
+   .status.phase=="Running" and any(.status.conditions[]?; .type=="Ready" and .status=="True") and
+   .spec.containers[0].image==$image) and ($p|map(.spec.nodeName)|unique|length)==2
+' <<<"${pods}" >/dev/null || die 'expected exactly two Ready, correctly labelled connectors on distinct nodes with the approved image.'
+
+prom_query() {
+  local encoded
+  encoded="$(jq -nr --arg v "$1" '$v|@uri')"
+  kubectl get --raw "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query=${encoded}"
+}
+[[ "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1] // "0"')" == 2 ]] || die 'Prometheus connector targets are unhealthy.'
+[[ "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1] // "0"')" == 2 ]] || die 'each connector must have at least four HA connections.'
+[[ "$(prom_query 'count(ALERTS{alertname=~"CloudflareTunnel(NoHealthyConnections|ConnectionsDegraded|MetricsTargetsDown)",alertstate="firing"})' | jq -r '.data.result[0].value[1] // "0"')" == 0 ]] || die 'a Cloudflare alert is active.'
+
+need yq
+mapfile -t endpoints < <(yq -r '.spec.targets.staticConfig.static[]? // empty' "${repo_root}/clusters/staging/observability/probes/public-apps.yaml")
+((${#endpoints[@]} == 16)) || die 'approved staging endpoint inventory must contain exactly 16 entries.'
+check_endpoints() {
+  local endpoint code
+  for endpoint in "${endpoints[@]}"; do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "${endpoint}")" || return 1
+    [[ "${code}" == 200 ]] || return 1
+  done
+}
+check_endpoints || die 'one or more approved public staging endpoints are unhealthy.'
+
+cat <<EOF
+PLAN (no mutation unless --execute was supplied)
+  mechanism: pod-network-namespace-local nftables edge-port output drop table
+  pods: $(jq -r '[.items[].metadata.name]|join(", ")' <<<"${pods}")
+  nodes: $(jq -r '[.items[].spec.nodeName]|join(", ")' <<<"${pods}")
+  maximum disruption: ${MAX_DISRUPTION_SECONDS}s
+  cleanup: per-node transient systemd watchdog plus exact table deletion
+EOF
+((execute)) || exit 0
+[[ "${confirmation}" == "${EXPECTED_CONFIRMATION}" ]] || die "confirmation must exactly equal: ${EXPECTED_CONFIRMATION}"
+[[ -n "${CF_WAN_NODE_EXEC:-}" && -x "${CF_WAN_NODE_EXEC}" ]] || die 'safe node execution is unavailable; set CF_WAN_NODE_EXEC to an executable authenticated node runner.'
+
+owner="cfwan_$(date -u +%Y%m%dT%H%M%SZ)_$$_${RANDOM}"
+owner="${owner//-/_}"
+[[ "${owner}" =~ ^[a-zA-Z0-9_]+$ ]] || die 'invalid generated owner.'
+evidence_dir="${evidence_dir:-${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-$(date -u +%Y%m%dT%H%M%SZ)}"
+mkdir -m 700 -p "${evidence_dir}"
+printf '%s\n' "owner=${owner}" "revision=${head}" >"${evidence_dir}/summary.txt"
+jq '[.items[] | {name:.metadata.name,uid:.metadata.uid,node:.spec.nodeName,image:.spec.containers[0].image,restarts:([.status.containerStatuses[].restartCount]|add),sandboxID:(.status.containerStatuses[0].containerID // "")} ]' <<<"${pods}" >"${evidence_dir}/pods-before.json"
+helm -n cloudflare history cloudflare-tunnel -o json >"${evidence_dir}/helm-before.json"
+kubectl -n cloudflare get secret tunnel-token -o json | jq '{apiVersion,kind,metadata:{name:.metadata.name,namespace:.metadata.namespace,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,creationTimestamp:.metadata.creationTimestamp}}' >"${evidence_dir}/secret-metadata-before.json"
+printf '%s\n' "${deployment}" >"${evidence_dir}/deployment-before.json"
+prom_query 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}' >"${evidence_dir}/metrics-before.json"
+for endpoint in "${endpoints[@]}"; do
+  printf '%s\t%s\n' "${endpoint}" "$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "${endpoint}")"
+done >"${evidence_dir}/endpoints-before.tsv"
+
+node_exec() { "${CF_WAN_NODE_EXEC}" "$1" "$2"; }
+declare -a installed_nodes=() cleanup_commands=()
+cleanup_ok=1
+cleanup() {
+  trap - EXIT INT TERM
+  local i
+  for ((i=${#installed_nodes[@]}-1; i>=0; i--)); do
+    if ! node_exec "${installed_nodes[i]}" "${cleanup_commands[i]}"; then cleanup_ok=0; fi
+  done
+  if ((cleanup_ok==0)); then
+    echo 'ERROR: automated cleanup could not be proven. Run these exact commands through the approved node runner:' >&2
+    for ((i=0; i<${#installed_nodes[@]}; i++)); do printf '  node=%q command=%q\n' "${installed_nodes[i]}" "${cleanup_commands[i]}" >&2; done
+    exit 1
+  fi
+}
+trap cleanup EXIT INT TERM
+
+mapfile -t pod_rows < <(jq -r '.items[] | [.metadata.name,.metadata.uid,.spec.nodeName,([.status.containerStatuses[].restartCount]|add)] | @tsv' <<<"${pods}")
+for row in "${pod_rows[@]}"; do
+  IFS=$'\t' read -r pod uid node restarts <<<"${row}"
+  resolve="sid=\$(sudo crictl pods --namespace cloudflare --name '^${pod}$' -q); test \"\$(printf '%s\\n' \$sid | sed '/^$/d' | wc -l)\" -eq 1; sudo crictl inspectp \$sid | jq -er '.info.pid'"
+  pid="$(node_exec "${node}" "${resolve}")" || die "cannot resolve exact sandbox network namespace for ${pod}."
+  [[ "${pid}" =~ ^[0-9]+$ ]] || die "ambiguous sandbox PID for ${pod}."
+  printf '%s\t%s\t%s\t%s\n' "${pod}" "${uid}" "${node}" "${pid}" >>"${evidence_dir}/network-namespaces.tsv"
+  table="${owner}_${pid}"
+  cleanup_cmd="sudo nsenter -t ${pid} -n nft delete table inet ${table}"
+  node_exec "${node}" "! sudo nsenter -t ${pid} -n nft list table inet ${table} >/dev/null 2>&1" || die "owner-tagged rule already exists for ${pod}."
+  # The watchdog is installed and verified before any packet is dropped.
+  watchdog="sudo systemd-run --unit=${table}_cleanup --collect --on-active=${MAX_DISRUPTION_SECONDS}s /usr/sbin/nsenter -t ${pid} -n /usr/sbin/nft delete table inet ${table}"
+  node_exec "${node}" "${watchdog} && sudo systemctl is-active --quiet ${table}_cleanup.timer"
+  installed_nodes+=("${node}"); cleanup_commands+=("${cleanup_cmd}")
+done
+
+# Only after every watchdog exists do we disrupt the two exact namespaces.
+for row in "${pod_rows[@]}"; do
+  IFS=$'\t' read -r pod uid node restarts <<<"${row}"
+  pid="$(node_exec "${node}" "sid=\$(sudo crictl pods --namespace cloudflare --name '^${pod}$' -q); sudo crictl inspectp \$sid | jq -er '.info.pid'")"
+  table="${owner}_${pid}"
+  node_exec "${node}" "sudo nsenter -t ${pid} -n nft add table inet ${table}; sudo nsenter -t ${pid} -n nft 'add chain inet ${table} output { type filter hook output priority -200; policy accept; }'; sudo nsenter -t ${pid} -n nft 'add rule inet ${table} output meta l4proto { tcp, udp } th dport { 443, 7844 } counter drop'; sudo nsenter -t ${pid} -n nft list table inet ${table}"
+done
+
+deadline=$((SECONDS+120)); interrupted=0
+while ((SECONDS<deadline)); do
+  now="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
+  same="$(jq --argjson before "${pods}" '[.items[]|{uid:.metadata.uid,restarts:([.status.containerStatuses[].restartCount]|add)}] == [$before.items[]|{uid:.metadata.uid,restarts:([.status.containerStatuses[].restartCount]|add)}]' <<<"${now}")"
+  [[ "${same}" == true ]] || die 'a connector UID or restart count changed during interruption.'
+  ready="$(jq '[.items[]|select(any(.status.conditions[]?;.type=="Ready" and .status=="True"))]|length' <<<"${now}")"
+  ha="$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 0)' | jq -r '.data.result[0].value[1] // "0"')"
+  if [[ "${ready}" == 0 && "${ha}" == 2 ]]; then interrupted=1; break; fi
+  sleep 5
+done
+((interrupted)) || die 'did not prove both original processes NotReady with zero HA connections.'
+cleanup
+
+deadline=$((SECONDS+300)); recovered=0
+while ((SECONDS<deadline)); do
+  now="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
+  same="$(jq --argjson before "${pods}" '[.items[]|{uid:.metadata.uid,restarts:([.status.containerStatuses[].restartCount]|add)}] == [$before.items[]|{uid:.metadata.uid,restarts:([.status.containerStatuses[].restartCount]|add)}]' <<<"${now}")"
+  [[ "${same}" == true ]] || die 'a connector was replaced or restarted during recovery.'
+  ready="$(jq '[.items[]|select(any(.status.conditions[]?;.type=="Ready" and .status=="True"))]|length' <<<"${now}")"
+  ha="$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1] // "0"')"
+  if [[ "${ready}" == 2 && "${ha}" == 2 ]]; then recovered=1; break; fi
+  sleep 5
+done
+((recovered)) || die 'same-pod recovery with four HA connections each was not proven within five minutes.'
+check_endpoints || die 'approved endpoints did not recover to HTTP 200.'
+cmp -s <(helm -n cloudflare history cloudflare-tunnel -o json) "${evidence_dir}/helm-before.json" || die 'Helm history changed.'
+cmp -s <(kubectl -n cloudflare get secret tunnel-token -o json | jq '{apiVersion,kind,metadata:{name:.metadata.name,namespace:.metadata.namespace,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,creationTimestamp:.metadata.creationTimestamp}}') "${evidence_dir}/secret-metadata-before.json" || die 'Secret metadata changed.'
+cmp -s <(kubectl -n cloudflare get deployment cloudflare-tunnel -o json) "${evidence_dir}/deployment-before.json" || die 'Deployment changed.'
+just cf-tunnel-verify env=staging
+printf 'Drill passed; sanitized evidence: %s\n' "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -1,0 +1,105 @@
+"""Offline contract tests for the staging Cloudflare WAN drill."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts/cloudflare_wan_dependency_loss_drill.sh"
+SCRIPT = SCRIPT_PATH.read_text()
+
+
+def test_default_is_a_non_mutating_plan():
+    assert "execute=0" in SCRIPT
+    assert "((execute)) || exit 0" in SCRIPT
+    assert SCRIPT.index("((execute)) || exit 0") < SCRIPT.index("nft add table")
+
+
+def test_environment_and_context_are_fail_closed():
+    assert '[[ "${env_name}" == staging ]]' in SCRIPT
+    assert "EXPECTED_CONTEXT=sugar-staging" in SCRIPT
+    assert "kubectl config current-context" in SCRIPT
+
+
+def test_repository_revision_and_clean_tree_are_required():
+    assert "CF_WAN_APPROVED_REVISION" in SCRIPT
+    assert "status --porcelain --untracked-files=normal" in SCRIPT
+
+
+def test_release_image_and_pod_selection_are_exact():
+    assert "cloudflare-tunnel must be Helm revision 2" in SCRIPT
+    assert "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf" in SCRIPT
+    assert "($p|length)==2" in SCRIPT
+    assert "map(.spec.nodeName)|unique|length)==2" in SCRIPT
+
+
+def test_metrics_alerts_and_endpoints_are_preflights():
+    assert "cloudflared_tunnel_ha_connections" in SCRIPT
+    assert "CloudflareTunnel(NoHealthyConnections|ConnectionsDegraded|MetricsTargetsDown)" in SCRIPT
+    assert "approved staging endpoint inventory must contain exactly 16" in SCRIPT
+
+
+def test_exact_sandbox_resolution_is_required():
+    assert "crictl pods --namespace cloudflare --name '^${pod}$'" in SCRIPT
+    assert "cannot resolve exact sandbox network namespace" in SCRIPT
+    assert "inspectp" in SCRIPT and "'.info.pid'" in SCRIPT
+
+
+def test_existing_owner_table_is_refused():
+    assert "nft list table inet ${table}" in SCRIPT
+    assert "owner-tagged rule already exists" in SCRIPT
+
+
+def test_watchdogs_precede_all_disruption():
+    watchdog = SCRIPT.index("systemd-run --unit=${table}_cleanup")
+    disruption = SCRIPT.index("# Only after every watchdog exists")
+    assert watchdog < disruption
+    assert "--on-active=${MAX_DISRUPTION_SECONDS}s" in SCRIPT
+
+
+def test_partial_setup_and_signals_run_cleanup():
+    assert "trap cleanup EXIT INT TERM" in SCRIPT
+    assert "installed_nodes+=(\"${node}\")" in SCRIPT
+    assert "for ((i=${#installed_nodes[@]}-1; i>=0; i--))" in SCRIPT
+
+
+def test_interruption_rejects_restarts_and_requires_zero_connections():
+    assert "a connector UID or restart count changed during interruption" in SCRIPT
+    assert 'if [[ "${ready}" == 0 && "${ha}" == 2 ]]' in SCRIPT
+
+
+def test_cleanup_is_exact_and_never_flushes_rules():
+    assert "nft delete table inet ${table}" in SCRIPT
+    assert "Run these exact commands through the approved node runner" in SCRIPT
+    assert "nft flush" not in SCRIPT
+    assert "iptables" not in SCRIPT
+
+
+def test_recovery_requires_same_processes_and_four_connections():
+    assert "a connector was replaced or restarted during recovery" in SCRIPT
+    assert 'if [[ "${ready}" == 2 && "${ha}" == 2 ]]' in SCRIPT
+    assert "SECONDS+300" in SCRIPT
+
+
+def test_secret_values_are_never_requested_or_printed():
+    secret_commands = [line for line in SCRIPT.splitlines() if "get secret" in line]
+    assert secret_commands
+    assert all("-o json" in line and "jq '{apiVersion,kind,metadata:" in line for line in secret_commands)
+    assert all(".data" not in line for line in secret_commands)
+    assert "tunnel-token -o jsonpath" not in SCRIPT
+
+
+def test_exact_operator_confirmation_is_enforced():
+    assert "INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS" in SCRIPT
+    assert '[[ "${confirmation}" == "${EXPECTED_CONFIRMATION}" ]]' in SCRIPT
+
+
+def test_evidence_is_sanitized_and_networkpolicy_is_not_used():
+    assert "secret-metadata-before.json" in SCRIPT
+    assert "pods-before.json" in SCRIPT
+    assert "NetworkPolicy" not in SCRIPT
+
+
+def test_just_recipe_is_clearly_named():
+    justfile = (ROOT / "justfile").read_text()
+    assert "cf-tunnel-wan-dependency-loss-drill env='staging' execute='false'" in justfile
+    assert "scripts/cloudflare_wan_dependency_loss_drill.sh" in justfile


### PR DESCRIPTION
### Motivation

- The existing NetworkPolicy-only dependency-loss contract is unreliable because Kubernetes leaves the effect on existing connections implementation-defined, and the 2026-08-09 staging attempt was therefore inconclusive despite exact cleanup and no service impact.  
- We need a deterministic, process-preserving, staging-only drill that can interrupt established connector traffic without killing or replacing the cloudflared processes and that fails closed unless strong preflight checks pass.  

### Description

- Add a staging-only helper script `scripts/cloudflare_wan_dependency_loss_drill.sh` that defaults to a non-mutating plan and requires `--execute`, `CF_WAN_APPROVED_REVISION`, `CF_WAN_NODE_EXEC` (an authenticated node runner), `--confirm 'INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS'`, and `context=sugar-staging` to run mutating actions.  
- Use a deterministic, per-pod pod-network-namespace-local nftables output-hook table that drops TCP and UDP edge traffic on ports 443 and 7844 inside the exact CRI sandbox namespace so established QUIC/TCP packets are affected while leaving the cloudflared process, readiness probe, and local metrics traffic running; no host-wide rules, flushes, or node persistent configuration changes are made.  
- Install independently surviving, time-bounded `systemd-run` cleanup watchdog timers on each affected node before any packet drop is applied; table names include a unique owner ID and sandbox PID and automated cleanup removes only those exact tables, with exact manual node commands printed if automated cleanup cannot be proven.  
- Implement exhaustive fail-closed preflight checks (kube context, repo clean-tree and approved revision, Helm release/revision, exact labels and pinned immutable image, exactly two Ready connectors on distinct nodes, Prometheus targets and HA connection counts, zero relevant Cloudflare alerts, all 16 approved staging endpoints healthy, exact CRI sandbox PID resolution), capture sanitized evidence (pods, UIDs, PIDs, helm history, secret metadata only, metrics and endpoints) and explicitly never request or print Secret values.  
- Add a Just recipe `cf-tunnel-wan-dependency-loss-drill` to print a plan or invoke the helper with explicit args; update `docs/cloudflare_tunnel.md` to record Kubernetes existing-connection semantics, classify the August 9 attempt as inconclusive, document the new mechanism, privilege boundary, and cleanup guarantees; and add offline contract tests `tests/test_cloudflare_wan_dependency_loss_drill.py` that assert fail-closed behavior and correct ordering.  
- Files changed/added: `scripts/cloudflare_wan_dependency_loss_drill.sh`, `tests/test_cloudflare_wan_dependency_loss_drill.py`, `justfile` (new recipe), `docs/cloudflare_tunnel.md` (contract/docs edits).  

### Testing

- Ran shell syntax check: `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — PASS.  
- Ran unit and contract tests: `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_hardening.py tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_token_mode.py` — PASS (45 passed).  
- Ran Just formatting/check: `just --unstable --fmt --check` — PASS.  
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — PASS (scan-secrets observed nothing sensitive in staged diff).  
- Tools not available in this environment and therefore not run here: `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/`, and `shellcheck` (these commands were attempted but the binaries are not installed in the runner).  
- PR creation was attempted but `gh` was not authenticated in this environment; changes were committed locally as commit `2ce812c8` with message "Add deterministic Cloudflare WAN drill".  

Residual risks and follow-ups

- The drill requires an already-authorized, host-key-verified node runner that can safely run `crictl`, `nsenter`, `nft`, and `systemd-run` with narrowly scoped sudo; this PR does not introduce or change authentication and will refuse to run mutating steps without it.  
- CRI sandbox PIDs can disappear; the helper treats inability to resolve an exact namespace or inability to prove cleanup as a failure and prints exact manual cleanup commands so operators can complete remediation.  
- Live execution must still be separately authorized and run in a maintenance window; this PR only adds the deterministic tool, tests, and documentation and does not execute any cluster disruption.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781f630a3c832f8410345e7a7911b8)