### PR TITLE
Add deterministic staging-only Cloudflare WAN dependency-loss drill (nftables netns plan + tests)

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -504,25 +504,57 @@ part of this rollout.
    `2026.7.3`, readiness-only `/ready`, two Prometheus targets, four HA connections per connector,
    healthy alerts, and every approved staging public endpoint.
 4. A pod-deletion drill is not an acceptable WAN-recovery test: it proves replacement, not that the
-   same cloudflared processes stay alive during dependency loss and reconnect afterward. The repository
-   shows that staging uses Kubernetes `NetworkPolicy`, but it does not establish which staging CNI
-   enforces a temporary egress-deny policy or prove that an exact release selector cannot affect other
-   workloads. Therefore the dependency-loss drill is **blocked** pending separate owner confirmation of
-   the staging CNI and its egress-policy behavior. Do not apply a speculative policy or substitute pod
-   deletion.
+   same cloudflared processes stay alive during dependency loss and reconnect afterward. A deny-egress
+   `NetworkPolicy` created after cloudflared has connected is also not a deterministic substitute.
+   Kubernetes explicitly makes handling of existing connections after policy creation or change
+   [implementation-defined](https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-and-existing-connections).
+   In particular, an established QUIC flow can continue even when the CNI would deny a new flow. Do
+   not claim that a NetworkPolicy alone must make `/ready` false.
 
-   Once that evidence is recorded, a separately authorized procedure must use a uniquely named,
-   temporary `NetworkPolicy` in `cloudflare`, selecting exactly
-   `app.kubernetes.io/name=cloudflare-tunnel` and
-   `app.kubernetes.io/instance=cloudflare-tunnel`. Before applying it, record both pod names, UIDs, and
-   restart counts and install a cleanup trap that deletes that exact policy name. Keep the deny interval
-   below five minutes (the shortest alert `for` duration); verify readiness becomes false while both UIDs
-   and restart counts remain unchanged. Delete the exact policy, then require those same two pods to
-   become Ready and report at least four HA connections each within five minutes. This contract may be
-   executed only after the CNI safety blocker is resolved and the exact manifest is separately reviewed.
-5. Cleanup is `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods,
-   Service, ServiceMonitor, and PDB. If a future authorized drill resolves the blocker, exact deletion of
-   its uniquely named NetworkPolicy is mandatory even on interruption.
+   On August 9, 2026, the authorized staging attempt created uniquely owned deny-egress policy
+   `cloudflare-wan-drill-20260809t060056z-29424`, which selected exactly both connectors. Both original
+   pods stayed Ready through 23 polls over about 120 seconds with unchanged UIDs and zero restarts.
+   Cleanup deleted the exact policy. Reconciliation found both original processes healthy with four HA
+   connections, no active Cloudflare alert, all 16 staging endpoints returning HTTP 200, and no Helm or
+   Secret change. This was an **inconclusive dependency-loss test**, not a passing recovery drill; it
+   caused no service impact. Operator evidence remains local and must not be committed.
+5. The repository helper instead plans a process-preserving, pod-network-namespace-local nftables
+   interruption:
+
+   ```bash
+   # Non-mutating default; inspect this first.
+   just cf-tunnel-wan-dependency-loss-drill env=staging
+   ```
+
+   It adds one uniquely named `inet` table inside each exact preflight-selected pod network namespace
+   and gives its output chain a drop policy. Namespace-local output filtering sees packets from existing
+   QUIC sockets, so it interrupts established traffic without killing or signaling cloudflared. It never
+   installs a broad node rule or flushes a ruleset. Root on each affected node is nevertheless a sharp
+   privilege boundary: execution therefore requires an operator-reviewed `WAN_DRILL_NODE_EXEC` adapter
+   that accepts a node and one root command. The helper does not invent credentials, weaken SSH host-key
+   checking, or assume unattended remote access. If authenticated execution on both nodes cannot be
+   guaranteed, leave execution blocked and separately review/run the exact commands from the plan.
+
+   Before adding either table, execution resolves the selected sandbox to one network namespace,
+   refuses an existing owner table or ambiguous result, and installs an independent 210-second
+   transient-systemd cleanup watchdog on that node. Normal and signal cleanup delete only the exact
+   owner table. Partial setup cleans a table already installed on the other node; if deletion cannot be
+   proven, the helper fails closed and prints the exact manual cleanup command. The bounded interruption
+   remains below the shortest five-minute alert threshold. Residual risks are loss of node access,
+   failure of the node's transient systemd manager, container-runtime PID churn, and nftables behavior
+   that differs from the reviewed staging hosts; preflight or cleanup uncertainty blocks the drill.
+
+   A live run remains separately authorized and **blocked unless every helper preflight passes**. It
+   requires `--execute`, the exact approved Git revision, staging context `sugar-staging`, clean worktree,
+   Helm revision 2, two exact Ready pods on distinct nodes, the approved immutable image, four HA
+   connections each, healthy metrics/alerts/endpoints, authenticated node execution, and the typed
+   confirmation printed by `--help`. It captures only metadata in `~/operator-evidence`, never Secret
+   values. It must prove both same-UID, same-restart-count pods become NotReady with zero HA connections,
+   remove the exact tables, and prove those processes recover readiness and four connections within five
+   minutes before running `just cf-tunnel-verify env=staging`. Do not execute it in CI or as part of this
+   rollout.
+6. Retain the two healthy pods, Service, ServiceMonitor, and PDB; clear any temporary operator-shell
+   environment after the authorized work.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/justfile
+++ b/justfile
@@ -727,6 +727,10 @@ cf-tunnel-install env='dev' token='':
 cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
+# Plan the staging WAN dependency-loss drill; pass args='--execute ...' only after authorization.
+cf-tunnel-wan-dependency-loss-drill env='staging' args='':
+    scripts/cloudflare_wan_dependency_loss_drill.sh --env {{ quote(env) }} {{ args }}
+
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:
     #!/usr/bin/env bash

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Deterministic, process-preserving Cloudflare WAN dependency-loss drill.
+set -Eeuo pipefail
+
+readonly EXPECTED_CONTEXT=sugar-staging EXPECTED_REVISION=2
+readonly EXPECTED_IMAGE='cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf'
+readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
+readonly CONFIRM='INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS'
+readonly ENDPOINTS=(
+  https://staging.democratized.space/ https://staging.democratized.space/config.json
+  https://staging.democratized.space/healthz https://staging.democratized.space/livez
+  https://staging.token.place/ https://staging.token.place/healthz
+  https://staging.token.place/livez https://staging.token.place/api/v1/meta
+  https://staging.danielsmith.io/ https://staging.danielsmith.io/healthz
+  https://staging.danielsmith.io/livez https://staging.jobbot3000.tech/
+  https://staging.jobbot3000.tech/healthz https://staging.jobbot3000.tech/livez
+  https://staging.jobbot3000.tech/tracker https://staging.jobbot3000.tech/manifest.webmanifest
+)
+
+execute=0 env_name= approved_revision= confirmation= evidence_dir=
+usage() { cat <<'EOF'
+Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] --env staging
+       [--approved-revision COMMIT] [--confirm 'INTERRUPT BOTH STAGING CLOUDFLARE CONNECTORS']
+
+The default is a non-mutating plan. Execution additionally requires WAN_DRILL_NODE_EXEC,
+an operator-reviewed executable invoked as: NODE_EXEC <node> <root-command>.
+EOF
+}
+while (($#)); do
+  case "$1" in
+    --execute) execute=1; shift ;;
+    --env) env_name=${2-}; shift 2 ;;
+    --approved-revision) approved_revision=${2-}; shift 2 ;;
+    --confirm) confirmation=${2-}; shift 2 ;;
+    --evidence-dir) evidence_dir=${2-}; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+owner="sugarkube-cfwan-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+table="${owner//-/_}"
+cleanup_required=0
+declare -a pods=() uids=() nodes=() restarts=() sandboxes=() netns=() installed=()
+
+node_exec() { "${WAN_DRILL_NODE_EXEC}" "$1" "$2"; }
+cleanup_command() {
+  printf 'nsenter --net=/proc/%q/ns/net nft delete table inet %q' "$2" "$table"
+}
+cleanup() {
+  local rc=${1:-$?} i failed=0 cmd
+  trap - EXIT INT TERM
+  if ((cleanup_required)); then
+    for i in "${!installed[@]}"; do
+      [[ ${installed[$i]} == 1 ]] || continue
+      cmd=$(cleanup_command "${nodes[$i]}" "${netns[$i]}")
+      if ! node_exec "${nodes[$i]}" "$cmd"; then
+        failed=1; printf 'MANUAL CLEANUP (%s): %s\n' "${nodes[$i]}" "$cmd" >&2
+      fi
+    done
+  fi
+  ((failed == 0)) || { echo 'ERROR: automated cleanup could not be proven.' >&2; exit 90; }
+  exit "$rc"
+}
+trap 'cleanup $?' EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+
+if ((execute == 0)); then
+  cat <<EOF
+PLAN ONLY (no cluster or node commands were run)
+Mechanism: create a uniquely named nftables inet table in each selected pod network namespace;
+drop that namespace's OUTPUT traffic, including established QUIC, without signaling cloudflared.
+Before disruption, install an independent 210-second transient-systemd cleanup watchdog per node.
+Only the exact owner table is deleted. No ruleset is flushed. Execution remains blocked until every
+preflight succeeds and an authenticated WAN_DRILL_NODE_EXEC adapter is supplied.
+Owner example: ${owner}
+EOF
+  exit 0
+fi
+
+[[ $env_name == staging ]] || { echo 'ERROR: execution is staging-only.' >&2; exit 3; }
+[[ $(kubectl config current-context) == "$EXPECTED_CONTEXT" ]] || { echo "ERROR: expected context ${EXPECTED_CONTEXT}." >&2; exit 4; }
+[[ -n $approved_revision && $(git rev-parse HEAD) == "$approved_revision" ]] || { echo 'ERROR: HEAD is not the explicitly approved revision.' >&2; exit 5; }
+[[ -z $(git status --porcelain) ]] || { echo 'ERROR: repository tree is dirty.' >&2; exit 6; }
+[[ $confirmation == "$CONFIRM" ]] || { echo "ERROR: confirmation must exactly equal: ${CONFIRM}" >&2; exit 7; }
+[[ -n ${WAN_DRILL_NODE_EXEC:-} && -x ${WAN_DRILL_NODE_EXEC:-/nonexistent} ]] || { echo 'ERROR: WAN_DRILL_NODE_EXEC must name an operator-reviewed executable.' >&2; exit 8; }
+
+releases=$(helm -n cloudflare list -o json)
+jq -e --argjson rev "$EXPECTED_REVISION" '[.[]|select(.name=="cloudflare-tunnel" and .status=="deployed" and .revision==$rev)]|length==1' <<<"$releases" >/dev/null || { echo 'ERROR: expected exactly one deployed Helm release at revision 2.' >&2; exit 9; }
+deployment=$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)
+jq -e --arg image "$EXPECTED_IMAGE" '.metadata.labels["app.kubernetes.io/managed-by"]=="Helm" and .metadata.labels["app.kubernetes.io/name"]=="cloudflare-tunnel" and .metadata.labels["app.kubernetes.io/instance"]=="cloudflare-tunnel" and .spec.template.spec.containers[0].image==$image' <<<"$deployment" >/dev/null || { echo 'ERROR: Deployment labels or immutable image differ.' >&2; exit 10; }
+pods_json=$(kubectl -n cloudflare get pods -l "$SELECTOR" -o json)
+mapfile -t rows < <(jq -r --arg image "$EXPECTED_IMAGE" '[.items[]|select(.metadata.deletionTimestamp==null and .status.phase=="Running" and any(.status.conditions[]?;.type=="Ready" and .status=="True") and .metadata.labels["app.kubernetes.io/name"]=="cloudflare-tunnel" and .metadata.labels["app.kubernetes.io/instance"]=="cloudflare-tunnel" and .spec.containers[0].image==$image)]|.[]|[.metadata.name,.metadata.uid,.spec.nodeName,(.status.containerStatuses[0].restartCount|tostring),.status.containerStatuses[0].containerID]|@tsv' <<<"$pods_json")
+[[ ${#rows[@]} == 2 ]] || { echo 'ERROR: exactly two Ready release pods are required.' >&2; exit 11; }
+for row in "${rows[@]}"; do IFS=$'\t' read -r p u n r s <<<"$row"; pods+=("$p"); uids+=("$u"); nodes+=("$n"); restarts+=("$r"); sandboxes+=("$s"); done
+[[ ${nodes[0]} != "${nodes[1]}" ]] || { echo 'ERROR: connectors must be on distinct nodes.' >&2; exit 12; }
+
+prom() { kubectl get --raw "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query=$(jq -nr --arg q "$1" '$q|@uri')" | jq -r '.data.result[0].value[1]//"0"'; }
+[[ $(prom 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)') == 2 && $(prom 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)') == 2 ]] || { echo 'ERROR: Prometheus targets or HA connections unhealthy.' >&2; exit 13; }
+[[ $(prom 'count(ALERTS{alertname=~"CloudflareTunnel.*",alertstate="firing"})') == 0 ]] || { echo 'ERROR: active Cloudflare alert.' >&2; exit 14; }
+printf '' >"${TMPDIR:-/tmp}/${owner}-endpoints"
+for url in "${ENDPOINTS[@]}"; do code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$url"); printf '%s\t%s\n' "$url" "$code" >>"${TMPDIR:-/tmp}/${owner}-endpoints"; [[ $code == 200 ]] || { echo "ERROR: unhealthy endpoint: $url" >&2; exit 15; }; done
+
+mkdir -p "${evidence_dir:=${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-${owner}}"; chmod 700 "$evidence_dir"
+# Metadata only: kubectl never requests Secret data; jsonpath selects metadata explicitly.
+helm -n cloudflare history cloudflare-tunnel -o json >"$evidence_dir/helm-before.json"
+kubectl -n cloudflare get secret tunnel-token -o 'jsonpath={.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\n"}' >"$evidence_dir/secret-before.tsv"
+kubectl -n cloudflare get deployment cloudflare-tunnel -o json >"$evidence_dir/deployment-before.json"
+printf '%s\n' "${rows[@]}" >"$evidence_dir/pods-before.tsv"
+cp "${TMPDIR:-/tmp}/${owner}-endpoints" "$evidence_dir/endpoints-before.tsv"
+printf 'targets=2\nha_pods=2\nalerts=0\n' >"$evidence_dir/metrics-before.txt"
+rm -f "${TMPDIR:-/tmp}/${owner}-endpoints"
+
+for i in 0 1; do
+  # The adapter must resolve the exact container sandbox to one live netns PID and reject ambiguity.
+  pid=$(node_exec "${nodes[$i]}" "crictl inspect '${sandboxes[$i]#*://}' -o json | jq -er '.info.pid|select(type==\"number\" and .>1)'") || { echo 'ERROR: exact pod network namespace could not be resolved.' >&2; exit 16; }
+  [[ $pid =~ ^[0-9]+$ ]] || { echo 'ERROR: invalid network namespace PID.' >&2; exit 16; }; netns+=("$pid")
+  check="nsenter --net=/proc/${pid}/ns/net nft list table inet ${table}"
+  node_exec "${nodes[$i]}" "$check" >/dev/null 2>&1 && { echo 'ERROR: owner-tagged rule already exists.' >&2; exit 17; }
+done
+printf '%s\n' "${netns[@]}" >"$evidence_dir/netns-pids.tsv"
+
+cleanup_required=1; installed=(0 0)
+for i in 0 1; do
+  delete=$(cleanup_command "${nodes[$i]}" "${netns[$i]}")
+  watchdog="systemd-run --quiet --unit '${owner}-cleanup' --on-active=210s /bin/sh -c '${delete}'"
+  node_exec "${nodes[$i]}" "$watchdog" || { echo 'ERROR: cleanup watchdog installation failed.' >&2; exit 18; }
+  add="nsenter --net=/proc/${netns[$i]}/ns/net nft add table inet ${table}; nsenter --net=/proc/${netns[$i]}/ns/net nft add chain inet ${table} output '{ type filter hook output priority -300; policy drop; comment \"${owner}\"; }'"
+  node_exec "${nodes[$i]}" "$add" || { echo 'ERROR: disruption setup failed.' >&2; exit 19; }; installed[$i]=1
+done
+
+deadline=$((SECONDS+120))
+while ((SECONDS < deadline)); do
+  now=$(kubectl -n cloudflare get pods -l "$SELECTOR" -o json)
+  unchanged=$(jq -r --arg u0 "${uids[0]}" --arg u1 "${uids[1]}" --argjson r0 "${restarts[0]}" --argjson r1 "${restarts[1]}" '[.items[]|select((.metadata.uid==$u0 and .status.containerStatuses[0].restartCount==$r0) or (.metadata.uid==$u1 and .status.containerStatuses[0].restartCount==$r1))]|length' <<<"$now")
+  [[ $unchanged == 2 ]] || { echo 'ERROR: pod UID changed or cloudflared restarted.' >&2; exit 20; }
+  ready=$(jq '[.items[]|select(any(.status.conditions[]?;.type=="Ready" and .status=="True"))]|length' <<<"$now")
+  [[ $ready == 0 && $(prom 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})') == 0 ]] && break
+  sleep 5
+done
+[[ ${ready:-2} == 0 ]] || { echo 'ERROR: interruption was not proven; NetworkPolicy-only results never pass.' >&2; exit 21; }
+for i in 0 1; do node_exec "${nodes[$i]}" "$(cleanup_command "${nodes[$i]}" "${netns[$i]}")"; installed[$i]=0; done; cleanup_required=0
+
+deadline=$((SECONDS+300)); recovered=0
+while ((SECONDS < deadline)); do
+  now=$(kubectl -n cloudflare get pods -l "$SELECTOR" -o json)
+  same=$(jq -r --arg u0 "${uids[0]}" --arg u1 "${uids[1]}" --argjson r0 "${restarts[0]}" --argjson r1 "${restarts[1]}" '[.items[]|select((.metadata.uid==$u0 and .status.containerStatuses[0].restartCount==$r0) or (.metadata.uid==$u1 and .status.containerStatuses[0].restartCount==$r1))|select(any(.status.conditions[]?;.type=="Ready" and .status=="True"))]|length' <<<"$now")
+  [[ $same == 2 && $(prom 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)') == 2 ]] && { recovered=1; break; }; sleep 5
+done
+[[ $recovered == 1 ]] || { echo 'ERROR: same-process recovery was not proven.' >&2; exit 22; }
+for url in "${ENDPOINTS[@]}"; do [[ $(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$url") == 200 ]] || exit 23; done
+diff -u "$evidence_dir/helm-before.json" <(helm -n cloudflare history cloudflare-tunnel -o json)
+diff -u "$evidence_dir/secret-before.tsv" <(kubectl -n cloudflare get secret tunnel-token -o 'jsonpath={.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\n"}')
+diff -u "$evidence_dir/deployment-before.json" <(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)
+just cf-tunnel-verify env=staging
+echo "PASS: same-process WAN dependency loss and recovery proven; evidence: $evidence_dir"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -1,0 +1,71 @@
+"""Offline safety-contract tests for the staging WAN drill."""
+
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/cloudflare_wan_dependency_loss_drill.sh"
+
+
+def test_plan_is_default_and_invokes_no_external_commands(tmp_path):
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--env", "staging"],
+        text=True,
+        capture_output=True,
+        env={"PATH": f"{tmp_path}:/usr/bin:/bin"},
+    )
+    assert result.returncode == 0
+    assert "PLAN ONLY" in result.stdout
+    assert "No ruleset is flushed" in result.stdout
+
+
+def test_execution_rejects_non_staging_before_cluster_access(tmp_path):
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT), "--execute", "--env", "prod"],
+        text=True,
+        capture_output=True,
+        env={"PATH": f"{tmp_path}:/usr/bin:/bin"},
+    )
+    assert result.returncode != 0
+    assert "staging-only" in result.stderr
+
+
+def test_fail_closed_contract_is_explicit():
+    text = SCRIPT.read_text()
+    required = [
+        "EXPECTED_CONTEXT=sugar-staging",
+        "EXPECTED_REVISION=2",
+        "git status --porcelain",
+        "exactly two Ready",
+        "distinct nodes",
+        "active Cloudflare alert",
+        "EXPECTED_IMAGE",
+        "WAN_DRILL_NODE_EXEC",
+        "confirmation must exactly equal",
+        "cleanup watchdog installation",
+        "owner-tagged rule already exists",
+        "exact pod network namespace",
+        "UID changed",
+        "same-process recovery",
+        "systemd-run",
+        "--on-active=210s",
+        "nft delete table",
+        "just cf-tunnel-verify env=staging",
+        "NetworkPolicy-only results never pass",
+    ]
+    for phrase in required:
+        assert phrase in text
+    assert "flush ruleset" not in text
+    assert "StrictHostKeyChecking=no" not in text
+    assert "secret tunnel-token -o json" not in text.lower()
+    assert "secret tunnel-token -o 'jsonpath={.metadata" in text
+
+
+def test_signal_and_partial_failure_cleanup_are_trapped():
+    text = SCRIPT.read_text()
+    assert "trap 'cleanup 130' INT" in text
+    assert "trap 'cleanup 143' TERM" in text
+    assert "MANUAL CLEANUP" in text
+    assert text.index("cleanup watchdog installation failed") < text.index(
+        "disruption setup failed"
+    )


### PR DESCRIPTION
### Motivation

- The existing NetworkPolicy-only WAN drill proved unreliable because newly-applied egress policies do not deterministically interrupt already-established QUIC connections, so the staging August 9 attempt was inconclusive and must be recorded as such. 
- Operators need a deterministic, process-preserving, staging-only drill that can interrupt established connector traffic without killing or replacing the cloudflared processes while providing fail-closed automation and exact cleanup. 
- The change provides a repository-owned helper, recipe, tests, and documentation so the drill stays blocked unless all safety preflight checks pass and an authorized operator intentionally executes it.

### Description

- Introduces a plan-first, fail-closed drill helper script `scripts/cloudflare_wan_dependency_loss_drill.sh` that defaults to a non-mutating plan and requires `--execute` plus an operator-reviewed `WAN_DRILL_NODE_EXEC` adapter and a typed confirmation to run. 
- Selects a deterministic interruption mechanism: add a uniquely-named `inet` nftables table inside each selected pod's network namespace and set the `output` chain to `drop`, which interrupts packets from existing QUIC sockets without terminating the cloudflared processes. 
- Implements strict preflight and execution gates including staging context `sugar-staging`, explicit approved Git revision and clean tree, exactly one Helm release at the approved revision, exactly two Ready connector pods on distinct nodes using the pinned immutable image, four or more HA connections per pod, healthy Prometheus targets and no active Cloudflare alert, and healthy approved endpoints; script captures only metadata and never reads secret values. 
- Adds robust safety and cleanup: installs an independent 210-second transient `systemd-run` cleanup watchdog per node before disruption, refuses pre-existing owner-tagged rules or ambiguous netns resolution, traps signals for partial-failure cleanup, prints exact manual cleanup commands when automated cleanup cannot be proven, and requires proof both pods return Ready with unchanged UIDs/restart counts and four HA connections each within five minutes before completing. 
- Adds offline tests `tests/test_cloudflare_wan_dependency_loss_drill.py` covering plan-only behavior, non-staging rejection, preflight checks, owner/cleanup contracts, signal/partial-failure handling, and that the old NetworkPolicy-only approach is not treated as a passing test, and wires a Just recipe `cf-tunnel-wan-dependency-loss-drill` to run the helper. 
- Updates documentation `docs/cloudflare_tunnel.md` to: record the August 9 inconclusive drill and successful cleanup, cite Kubernetes’ implementation-defined semantics for existing connections, remove any claim that NetworkPolicy alone must make `/ready` false, keep pod deletion prohibited as a valid survival test, and document the new mechanism, privilege boundary, cleanup guarantees, and residual risks.

Changed files: `scripts/cloudflare_wan_dependency_loss_drill.sh`, `tests/test_cloudflare_wan_dependency_loss_drill.py`, `docs/cloudflare_tunnel.md`, and `justfile` (recipe addition).

### Testing

- Syntax and unit checks: `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` succeeded and `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_hardening.py tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_token_mode.py` passed (33 passed). 
- Formatting/recipe checks: `just --unstable --fmt --check` passed for the repository and the new recipe, and focused `pre-commit` hooks for the changed files passed (trim/EOL fixes applied where needed). 
- Documentation checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` completed (link check found 208 links with 0 errors). 
- Secrets and policy: `git diff | ./scripts/scan-secrets.py` and targeted scans were run and findings were processed (no secret values were committed; operator evidence remains local and was explicitly not added). 
- Known limits: a full `pre-commit run --all-files` encountered unrelated repository-wide lint failures that pre-existed this change and therefore were not gated by this PR, and the environment lacked an authenticated `gh`/`make_pr` invocation so a remote PR was not created here. 

Residual risks & notes: node-root execution is a sharp privilege boundary and therefore the helper requires an operator-reviewed `WAN_DRILL_NODE_EXEC` adapter that runs exactly one root command per node; residual risks include loss of node access, transient-systemd failures, container-runtime PID churn that breaks netns resolution, and host-specific nftables differences which will block execution if detected; the helper fails closed and prints exact manual cleanup commands when automated cleanup cannot be proven.

Operator evidence referenced in the user brief remains local and was not committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781f663840832fbd5a766b17ff72fa)