### PR TITLE
Generate canonical observability dashboard; unify staging & prod panels

### DIFF
--- a/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
+++ b/clusters/staging/observability/dashboards/sugarkube-staging-observability.json
@@ -4,8 +4,8 @@
   "title": "Sugarkube Staging Observability",
   "tags": [
     "sugarkube",
-    "staging",
-    "provisioned"
+    "observability",
+    "staging"
   ],
   "timezone": "browser",
   "schemaVersion": 41,
@@ -20,29 +20,30 @@
     "list": [
       {
         "name": "environment",
-        "label": "Environment",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "query": {
-          "query": "label_values(probe_success, environment)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "includeAll": false,
-        "multi": false,
-        "allValue": null,
+        "type": "constant",
+        "query": "staging",
         "current": {
           "text": "staging",
           "value": "staging"
-        }
+        },
+        "hide": 2,
+        "skipUrlSync": true
+      },
+      {
+        "name": "cluster",
+        "type": "constant",
+        "query": "sugarkube-int",
+        "current": {
+          "text": "sugarkube-int",
+          "value": "sugarkube-int"
+        },
+        "hide": 2,
+        "skipUrlSync": true
       },
       {
         "name": "app",
-        "label": "Probe application",
         "type": "query",
+        "label": "Application",
         "datasource": {
           "type": "prometheus",
           "uid": "prometheus"
@@ -51,19 +52,19 @@
           "query": "label_values(probe_success{environment=~\"$environment\"}, app)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
-        "includeAll": true,
-        "multi": true,
-        "allValue": ".*",
         "current": {
           "text": "All",
           "value": "$__all"
-        }
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 1
       },
       {
         "name": "route",
-        "label": "Probe route",
         "type": "query",
+        "label": "Route",
         "datasource": {
           "type": "prometheus",
           "uid": "prometheus"
@@ -72,14 +73,14 @@
           "query": "label_values(probe_success{environment=~\"$environment\",app=~\"$app\"}, route)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
-        "includeAll": true,
-        "multi": true,
-        "allValue": ".*",
         "current": {
           "text": "All",
           "value": "$__all"
-        }
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 1
       }
     ]
   },
@@ -89,18 +90,203 @@
   "panels": [
     {
       "id": 1,
+      "title": "Cluster and service health",
       "type": "row",
-      "title": "Overall status",
       "collapsed": false,
       "gridPos": {
-        "h": 1,
-        "w": 24,
         "x": 0,
-        "y": 0
-      }
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
     },
     {
       "id": 2,
+      "title": "Scrape availability by job",
+      "type": "table",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "UNHEALTHY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "min by (job) (up)",
+          "instant": true,
+          "legendFormat": "{{job}}",
+          "range": false,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "job": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "job": "Job",
+              "Value": "Status"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Ready nodes",
+      "type": "stat",
+      "description": "Three Ready nodes were observed live; this is a visual expectation, not an alert threshold.",
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"}))",
+          "instant": false,
+          "legendFormat": "Ready nodes",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Node readiness",
+      "type": "table",
+      "description": "",
+      "gridPos": {
+        "x": 16,
+        "y": 1,
+        "w": 8,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "NOT READY",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "READY",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
+          "instant": true,
+          "legendFormat": "{{node}}",
+          "range": false,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "node": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "node": "Node",
+              "Value": "Status"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 5,
       "type": "stat",
       "title": "DSPACE scrape availability",
       "description": "Prometheus scrape availability for DSPACE.",
@@ -109,10 +295,10 @@
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 0,
-        "y": 1
+        "y": 7,
+        "w": 8,
+        "h": 6
       },
       "targets": [
         {
@@ -136,7 +322,8 @@
                 "value": 1
               }
             ]
-          }
+          },
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -151,19 +338,19 @@
       }
     },
     {
-      "id": 3,
+      "id": 6,
       "type": "stat",
-      "title": "Instrumentation health",
+      "title": "DSPACE instrumentation health",
       "description": "Application instrumentation self-check.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 8,
-        "y": 1
+        "y": 7,
+        "w": 8,
+        "h": 6
       },
       "targets": [
         {
@@ -187,7 +374,8 @@
                 "value": 1
               }
             ]
-          }
+          },
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -202,7 +390,7 @@
       }
     },
     {
-      "id": 4,
+      "id": 7,
       "type": "stat",
       "title": "Public availability summary",
       "description": "Current healthy, failed, and retention-backed missing probe-data counts for the selected filters; complete absence of expected target data is shown as no data.",
@@ -211,29 +399,29 @@
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 16,
-        "y": 1
+        "y": 7,
+        "w": 8,
+        "h": 6
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1)",
+          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 1)",
           "legendFormat": "Healthy endpoints",
           "instant": true,
           "range": false
         },
         {
           "refId": "B",
-          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 0)",
+          "expr": "sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) == bool 0)",
           "legendFormat": "Failed endpoints",
           "instant": true,
           "range": false
         },
         {
           "refId": "C",
-          "expr": "sum(max by (environment, app, route) (max_over_time(up{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[7d])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) >= bool 0) or vector(0))",
+          "expr": "sum(max by (environment, app, route) (max_over_time(up{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}[7d])) >= bool 0) - (sum(min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) >= bool 0) or vector(0))",
           "legendFormat": "Missing probe data",
           "instant": true,
           "range": false
@@ -322,7 +510,480 @@
       }
     },
     {
-      "id": 5,
+      "id": 8,
+      "title": "Workload health",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Deployment replica deficit",
+      "type": "table",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
+          "instant": true,
+          "legendFormat": "{{namespace}} / {{deployment}}",
+          "range": false,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "namespace": 0,
+              "deployment": 1,
+              "Value": 2
+            },
+            "renameByName": {
+              "namespace": "Namespace",
+              "deployment": "Deployment",
+              "Value": "Replica deficit"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Unready pods by namespace",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition=\"false\"}) * on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{phase=~\"Pending|Running|Unknown\"} == 1))",
+          "instant": false,
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Problem pods by namespace",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"}))",
+          "instant": false,
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Container restart rate",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 12,
+        "y": 21,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "{{namespace}} / {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Node and Prometheus capacity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 14,
+      "title": "Node CPU utilization",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 29,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)",
+          "instant": false,
+          "legendFormat": "{{nodename}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "title": "Node memory utilization",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 8,
+        "y": 29,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
+          "instant": false,
+          "legendFormat": "{{nodename}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Root filesystem utilization",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 16,
+        "y": 29,
+        "w": 8,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"}) * on (instance) group_left (nodename) node_uname_info)",
+          "instant": false,
+          "legendFormat": "{{nodename}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "title": "Prometheus PVC utilization",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "noValue": "NO DATA",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=\"monitoring\",persistentvolumeclaim=~\"prometheus-kube-prometheus-stack-prometheus-db-.*\"}))",
+          "instant": false,
+          "legendFormat": "{{namespace}} / {{persistentvolumeclaim}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "title": "Prometheus active series",
+      "type": "timeseries",
+      "description": "",
+      "gridPos": {
+        "x": 12,
+        "y": 36,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (pod) (prometheus_tsdb_head_series)",
+          "instant": false,
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "title": "Observability build identity",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 43,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "title": "Observability component build identity",
+      "type": "table",
+      "description": "",
+      "gridPos": {
+        "x": 0,
+        "y": 44,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "NO DATA"
+        },
+        "overrides": []
+      },
+      "options": {},
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (component, pod, version, revision) (label_replace(prometheus_build_info, \"component\", \"prometheus\", \"\", \"\") or label_replace(alertmanager_build_info, \"component\", \"alertmanager\", \"\", \"\") or label_replace(grafana_build_info, \"component\", \"grafana\", \"\", \"\") or label_replace(node_exporter_build_info, \"component\", \"node-exporter\", \"\", \"\"))",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "component": 0,
+              "pod": 1,
+              "version": 2,
+              "revision": 3
+            },
+            "renameByName": {
+              "component": "Component",
+              "pod": "Pod",
+              "version": "Version",
+              "revision": "Revision"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 21,
       "type": "row",
       "title": "DSPACE HTTP",
       "collapsed": false,
@@ -330,11 +991,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 52
       }
     },
     {
-      "id": 6,
+      "id": 22,
       "type": "timeseries",
       "title": "User request rate by route and status class",
       "description": "Application request rate by bounded route templates and status classes; operational health and metrics routes are excluded.",
@@ -346,7 +1007,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 7
+        "y": 53
       },
       "targets": [
         {
@@ -357,7 +1018,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps"
+          "unit": "reqps",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -372,7 +1034,7 @@
       }
     },
     {
-      "id": 7,
+      "id": 23,
       "type": "piechart",
       "title": "Status-class distribution",
       "description": "Selected-window request totals grouped by bounded status class.",
@@ -384,7 +1046,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 7
+        "y": 53
       },
       "targets": [
         {
@@ -397,7 +1059,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "NO DATA"
         },
         "overrides": [
           {
@@ -476,7 +1139,7 @@
       }
     },
     {
-      "id": 21,
+      "id": 24,
       "type": "timeseries",
       "title": "Operational request rate",
       "description": "Health, liveness, and metrics request rate kept separate from user traffic.",
@@ -488,7 +1151,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 7
+        "y": 53
       },
       "targets": [
         {
@@ -499,7 +1162,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps"
+          "unit": "reqps",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -514,7 +1178,7 @@
       }
     },
     {
-      "id": 8,
+      "id": 25,
       "type": "timeseries",
       "title": "5xx error ratio",
       "description": "Fraction of observed DSPACE HTTP requests returning 5xx.",
@@ -526,7 +1190,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 61
       },
       "targets": [
         {
@@ -554,7 +1218,8 @@
                 "value": 0.05
               }
             ]
-          }
+          },
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -569,7 +1234,7 @@
       }
     },
     {
-      "id": 9,
+      "id": 26,
       "type": "timeseries",
       "title": "HTTP latency percentiles",
       "description": "DSPACE HTTP latency by bounded route template.",
@@ -581,7 +1246,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 15
+        "y": 61
       },
       "targets": [
         {
@@ -602,7 +1267,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s"
+          "unit": "s",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -617,7 +1283,7 @@
       }
     },
     {
-      "id": 10,
+      "id": 27,
       "type": "row",
       "title": "DSPACE runtime and release",
       "collapsed": false,
@@ -625,11 +1291,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 69
       }
     },
     {
-      "id": 11,
+      "id": 28,
       "type": "timeseries",
       "title": "Resident memory by pod",
       "description": "Resident process memory for each DSPACE pod.",
@@ -641,7 +1307,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 70
       },
       "targets": [
         {
@@ -652,7 +1318,8 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes"
+          "unit": "bytes",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -667,9 +1334,9 @@
       }
     },
     {
-      "id": 12,
+      "id": 29,
       "type": "table",
-      "title": "Build identity",
+      "title": "DSPACE build identity",
       "description": "Safe release identity fields: pod, version, and revision.",
       "datasource": {
         "type": "prometheus",
@@ -679,7 +1346,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 70
       },
       "targets": [
         {
@@ -687,12 +1354,14 @@
           "expr": "max by (pod, version, revision) (dspace_build_info{environment=~\"$environment\"})",
           "legendFormat": "{{pod}} {{version}} {{revision}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -707,27 +1376,29 @@
       },
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true,
+              "__name__": true,
               "Value": true
             },
             "indexByName": {
               "pod": 0,
               "version": 1,
               "revision": 2
+            },
+            "renameByName": {
+              "pod": "Pod",
+              "version": "Version",
+              "revision": "Revision"
             }
           }
         }
       ]
     },
     {
-      "id": 13,
+      "id": 30,
       "type": "row",
       "title": "DSPACE feature traffic",
       "collapsed": false,
@@ -735,11 +1406,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 78
       }
     },
     {
-      "id": 14,
+      "id": 31,
       "type": "timeseries",
       "title": "dChat request activity",
       "description": "Zero means no dChat requests were observed; it is not an instrumentation failure.",
@@ -751,12 +1422,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 79
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(dspace_dchat_requests_total{environment=~\"$environment\"}[$__rate_interval])) or on() vector(0)",
+          "expr": "sum(rate(dspace_dchat_requests_total{environment=~\"$environment\"}[$__rate_interval])) or on() (0 * max(dspace_instrumentation_up{environment=~\"$environment\"}))",
           "legendFormat": "dChat requests"
         }
       ],
@@ -772,7 +1443,8 @@
                 }
               }
             }
-          ]
+          ],
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -787,7 +1459,7 @@
       }
     },
     {
-      "id": 15,
+      "id": 32,
       "type": "timeseries",
       "title": "token.place dependency request activity",
       "description": "Zero means no token.place dependency requests were observed; it is not an instrumentation failure.",
@@ -799,12 +1471,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 79
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(dspace_dependency_requests_total{environment=~\"$environment\",dependency=\"tokenplace\"}[$__rate_interval])) or on() vector(0)",
+          "expr": "sum(rate(dspace_dependency_requests_total{environment=~\"$environment\",dependency=\"tokenplace\"}[$__rate_interval])) or on() (0 * max(dspace_instrumentation_up{environment=~\"$environment\"}))",
           "legendFormat": "token.place requests"
         }
       ],
@@ -820,7 +1492,8 @@
                 }
               }
             }
-          ]
+          ],
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -835,7 +1508,7 @@
       }
     },
     {
-      "id": 16,
+      "id": 33,
       "type": "row",
       "title": "Blackbox monitoring",
       "collapsed": false,
@@ -843,11 +1516,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 87
       }
     },
     {
-      "id": 17,
+      "id": 34,
       "type": "table",
       "title": "Endpoint matrix",
       "description": "Latest endpoint result without exposing raw target URLs.",
@@ -859,15 +1532,16 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 88
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (environment, app, route) (probe_success{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
+          "expr": "min by (environment, app, route) (probe_success{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
         }
       ],
       "fieldConfig": {
@@ -900,7 +1574,8 @@
                 }
               }
             }
-          ]
+          ],
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -912,10 +1587,33 @@
         "tooltip": {
           "mode": "multi"
         }
-      }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "environment": 0,
+              "app": 1,
+              "route": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "environment": "Environment",
+              "app": "Application",
+              "route": "Route",
+              "Value": "Success"
+            }
+          }
+        }
+      ]
     },
     {
-      "id": 18,
+      "id": 35,
       "type": "timeseries",
       "title": "Probe duration",
       "description": "End-to-end blackbox probe duration.",
@@ -927,18 +1625,19 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 88
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (environment, app, route) (probe_duration_seconds{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
+          "expr": "max by (environment, app, route) (probe_duration_seconds{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s"
+          "unit": "s",
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -953,7 +1652,7 @@
       }
     },
     {
-      "id": 19,
+      "id": 36,
       "type": "table",
       "title": "HTTP response status",
       "description": "HTTP response status by bounded labels.",
@@ -965,15 +1664,16 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 97
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (environment, app, route) (probe_http_status_code{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
+          "expr": "max by (environment, app, route) (probe_http_status_code{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"})",
           "legendFormat": "{{environment}} / {{app}} / {{route}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
         }
       ],
       "fieldConfig": {
@@ -999,7 +1699,8 @@
                 "value": 500
               }
             ]
-          }
+          },
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -1011,10 +1712,33 @@
         "tooltip": {
           "mode": "multi"
         }
-      }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "environment": 0,
+              "app": 1,
+              "route": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "environment": "Environment",
+              "app": "Application",
+              "route": "Route",
+              "Value": "HTTP status"
+            }
+          }
+        }
+      ]
     },
     {
-      "id": 20,
+      "id": 37,
       "type": "timeseries",
       "title": "TLS certificate lifetime",
       "description": "Days until the earliest certificate expiry.",
@@ -1026,12 +1750,12 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 97
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "(min by (environment, app, route) (probe_ssl_earliest_cert_expiry{environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) - time()) / 86400",
+          "expr": "(min by (environment, app, route) (probe_ssl_earliest_cert_expiry{job=~\"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-$environment-.*\",environment=~\"$environment\",app=~\"$app\",route=~\"$route\"}) - time()) / 86400",
           "legendFormat": "{{environment}} / {{app}} / {{route}}"
         }
       ],
@@ -1058,7 +1782,8 @@
                 "value": 30
               }
             ]
-          }
+          },
+          "noValue": "NO DATA"
         },
         "overrides": []
       },
@@ -1073,7 +1798,7 @@
       }
     },
     {
-      "id": 22,
+      "id": 38,
       "type": "row",
       "title": "DSPACE release integrity",
       "collapsed": false,
@@ -1081,7 +1806,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 106
       }
     },
     {
@@ -1090,11 +1815,13 @@
         "uid": "prometheus"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "NO DATA"
+        },
         "overrides": []
       },
       "options": {},
-      "id": 23,
+      "id": 39,
       "type": "table",
       "title": "Approved revision",
       "description": "Approved immutable coordinate from finalized release evidence.",
@@ -1102,7 +1829,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 61
+        "y": 107
       },
       "targets": [
         {
@@ -1110,7 +1837,34 @@
           "expr": "dspace_release_approved_info{environment=~\"$environment\"}",
           "legendFormat": "{{revision}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "Value": true
+            },
+            "indexByName": {
+              "environment": 0,
+              "revision": 1,
+              "image": 2,
+              "image_digest": 3,
+              "evidence": 4
+            },
+            "renameByName": {
+              "environment": "Environment",
+              "revision": "Revision",
+              "image": "Image tag",
+              "image_digest": "Image digest",
+              "evidence": "Evidence"
+            }
+          }
         }
       ]
     },
@@ -1120,11 +1874,13 @@
         "uid": "prometheus"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "NO DATA"
+        },
         "overrides": []
       },
       "options": {},
-      "id": 24,
+      "id": 40,
       "type": "table",
       "title": "Active build revisions by pod",
       "description": "Build identities reported by ready, Running, non-terminating DSPACE pods.",
@@ -1132,7 +1888,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 61
+        "y": 107
       },
       "targets": [
         {
@@ -1140,7 +1896,28 @@
           "expr": "max by (pod, revision) (dspace_build_info{environment=~\"$environment\"} and on (namespace, pod) (kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"}))",
           "legendFormat": "{{pod}} {{revision}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "Value": true
+            },
+            "indexByName": {
+              "pod": 0,
+              "revision": 1
+            },
+            "renameByName": {
+              "pod": "Pod",
+              "revision": "Revision"
+            }
+          }
         }
       ]
     },
@@ -1150,11 +1927,13 @@
         "uid": "prometheus"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "NO DATA"
+        },
         "overrides": []
       },
       "options": {},
-      "id": 25,
+      "id": 41,
       "type": "stat",
       "title": "Image-pin agreement",
       "description": "Zero means no active DSPACE container differs from the approved digest.",
@@ -1162,12 +1941,12 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 61
+        "y": 107
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "count(max by (pod, image_id, image_spec) ((kube_pod_container_info{namespace=\"dspace\",container=\"dspace\"} unless on (namespace, pod, container) kube_pod_container_info{namespace=\"dspace\",container=\"dspace\",image_id=~\"^(docker-pullable://)?ghcr.io/democratizedspace/dspace@sha256:2b95b7fdccdd011553c8d8617e3090ee27323996c532148fdb147cb9fd6e1b6c$\",image_spec=\"ghcr.io/democratizedspace/dspace:main-018687f\"}) and on (namespace, pod, container) (kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"})) or label_replace(label_replace((kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"}) unless on (namespace, pod, container) kube_pod_container_info{namespace=\"dspace\",container=\"dspace\"}, \"image_id\", \"unknown\", \"\", \"\"), \"image_spec\", \"unknown\", \"\", \"\")) or on() vector(0)",
+          "expr": "(count((kube_pod_container_info{namespace=\"dspace\",container=\"dspace\"} and on (namespace, pod, container) (kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"})) unless on (image_spec, image_id) label_replace(label_replace(dspace_release_approved_info{environment=~\"$environment\"}, \"image_spec\", \"ghcr.io/democratizedspace/dspace:$1\", \"image\", \"(.*)\"), \"image_id\", \"docker-pullable://ghcr.io/democratizedspace/dspace@$1\", \"image_digest\", \"(.*)\")) or on() (0 * count(dspace_release_approved_info{environment=~\"$environment\"}))) and on() (count(dspace_release_approved_info{environment=~\"$environment\"}) > 0)",
           "legendFormat": "mismatched pods",
           "instant": true,
           "range": false
@@ -1180,11 +1959,13 @@
         "uid": "prometheus"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "NO DATA"
+        },
         "overrides": []
       },
       "options": {},
-      "id": 26,
+      "id": 42,
       "type": "stat",
       "title": "DSPACE metrics-target health",
       "description": "Count of ready, Running, non-terminating DSPACE pods whose target is down or undiscovered. Zero is healthy; missing targets fail closed.",
@@ -1192,12 +1973,12 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 67
+        "y": 113
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "count((up{namespace=\"dspace\",service=~\"dspace.*\"} == 0) or ((kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"}) unless on (namespace, pod) up{namespace=\"dspace\",service=~\"dspace.*\"})) or on() vector(0)",
+          "expr": "(count((up{namespace=\"dspace\",service=~\"dspace.*\"} == 0) or ((kube_pod_container_status_ready{namespace=\"dspace\",container=\"dspace\"} == 1 and on (namespace, pod) kube_pod_status_phase{namespace=\"dspace\",phase=\"Running\"} == 1 unless on (namespace, pod) kube_pod_deletion_timestamp{namespace=\"dspace\"}) unless on (namespace, pod) up{namespace=\"dspace\",service=~\"dspace.*\"})) or on() (0 * count(dspace_release_approved_info{environment=~\"$environment\"}))) and on() (count(dspace_release_approved_info{environment=~\"$environment\"}) > 0)",
           "legendFormat": "down or missing serving targets",
           "instant": true,
           "range": false
@@ -1210,11 +1991,13 @@
         "uid": "prometheus"
       },
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "noValue": "NO DATA"
+        },
         "overrides": []
       },
       "options": {},
-      "id": 27,
+      "id": 43,
       "type": "stat",
       "title": "/chat synthetic result and freshness",
       "description": "Success and age; missing or older than 15 minutes fails closed.",
@@ -1222,12 +2005,12 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 67
+        "y": 113
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "dspace_chat_synthetic_success{environment=~\"$environment\"} or on() vector(0)",
+          "expr": "(dspace_chat_synthetic_success{environment=~\"$environment\"} or on() (0 * count(dspace_release_approved_info{environment=~\"$environment\"}))) and on() (count(dspace_release_approved_info{environment=~\"$environment\"}) > 0)",
           "legendFormat": "success",
           "instant": true,
           "range": false
@@ -1242,7 +2025,7 @@
       ]
     },
     {
-      "id": 28,
+      "id": 44,
       "type": "text",
       "title": "Release integrity references",
       "description": "Operator-owned stable references.",
@@ -1250,15 +2033,15 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 67
+        "y": 113
       },
       "options": {
         "mode": "markdown",
-        "content": "[DSPACE integrity runbook](https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md) · [Finalized staging evidence](https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json)"
+        "content": "[DSPACE integrity runbook](https://github.com/futuroptimist/sugarkube/blob/main/docs/observability-dspace-release-integrity.md) \u00b7 [Finalized staging evidence](https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json)"
       }
     },
     {
-      "id": 29,
+      "id": 45,
       "type": "row",
       "title": "token.place relay and compute capacity",
       "collapsed": false,
@@ -1266,11 +2049,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 119
       }
     },
     {
-      "id": 30,
+      "id": 46,
       "type": "stat",
       "title": "token.place scrape availability",
       "description": "Prometheus scrape health per relay pod. Missing targets remain NO DATA.",
@@ -1282,12 +2065,12 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 74
+        "y": 120
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (pod) (up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "min by (pod) (up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{pod}} scrape",
           "instant": true,
           "range": false
@@ -1339,7 +2122,7 @@
       }
     },
     {
-      "id": 31,
+      "id": 47,
       "type": "stat",
       "title": "token.place instrumentation health",
       "description": "Application instrumentation self-check per relay pod; zero is unhealthy and an absent series remains NO DATA.",
@@ -1351,12 +2134,12 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 74
+        "y": 120
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "min by (pod) (tokenplace_instrumentation_up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "min by (pod) (tokenplace_instrumentation_up{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{pod}} instrumentation",
           "instant": true,
           "range": false
@@ -1408,7 +2191,7 @@
       }
     },
     {
-      "id": 32,
+      "id": 48,
       "type": "timeseries",
       "title": "token.place compute-node counts",
       "description": "Registered and healthy logical compute-node gauges. max deduplicates identical values emitted by future relay replicas without multiplying capacity.",
@@ -1420,17 +2203,17 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 79
+        "y": 125
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max(tokenplace_compute_nodes_registered{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max(tokenplace_compute_nodes_registered{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "registered"
         },
         {
           "refId": "B",
-          "expr": "max(tokenplace_compute_nodes_healthy{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max(tokenplace_compute_nodes_healthy{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "healthy"
         }
       ],
@@ -1453,7 +2236,7 @@
       }
     },
     {
-      "id": 33,
+      "id": 49,
       "type": "timeseries",
       "title": "token.place oldest compute-node lease age",
       "description": "Oldest lease age reported by the relay fleet. max preserves the worst observed logical age across replicas.",
@@ -1465,12 +2248,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 79
+        "y": 125
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max(tokenplace_compute_node_lease_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max(tokenplace_compute_node_lease_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "oldest lease"
         }
       ],
@@ -1493,7 +2276,7 @@
       }
     },
     {
-      "id": 34,
+      "id": 50,
       "type": "timeseries",
       "title": "token.place compute-node eviction rate",
       "description": "Summed process-local eviction counter rate grouped only by bounded reason.",
@@ -1505,12 +2288,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 133
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (reason) (rate(tokenplace_compute_node_evictions_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(tokenplace_compute_node_evictions_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}"
         }
       ],
@@ -1533,7 +2316,7 @@
       }
     },
     {
-      "id": 35,
+      "id": 51,
       "type": "timeseries",
       "title": "token.place relay queue depth",
       "description": "Logical queue depth by bounded provider mode. max avoids multiplying a shared queue gauge across future relay replicas.",
@@ -1545,12 +2328,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 87
+        "y": 133
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (provider_mode) (tokenplace_relay_queue_depth{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max by (provider_mode) (tokenplace_relay_queue_depth{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{provider_mode}}"
         }
       ],
@@ -1573,7 +2356,7 @@
       }
     },
     {
-      "id": 36,
+      "id": 52,
       "type": "timeseries",
       "title": "token.place oldest queued-request age",
       "description": "Oldest queued-request age by bounded provider mode. max shows the worst age without multiplying replicated logical gauges.",
@@ -1585,12 +2368,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 95
+        "y": 141
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (provider_mode) (tokenplace_relay_oldest_queued_request_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max by (provider_mode) (tokenplace_relay_oldest_queued_request_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{provider_mode}}"
         }
       ],
@@ -1613,7 +2396,7 @@
       }
     },
     {
-      "id": 37,
+      "id": 53,
       "type": "timeseries",
       "title": "token.place in-flight requests by pod",
       "description": "In-flight ownership is relay-process local, so values remain per pod rather than being combined across replicas.",
@@ -1625,12 +2408,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 95
+        "y": 141
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (pod) (tokenplace_relay_in_flight_requests{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max by (pod) (tokenplace_relay_in_flight_requests{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{pod}}"
         }
       ],
@@ -1653,7 +2436,7 @@
       }
     },
     {
-      "id": 38,
+      "id": 54,
       "type": "timeseries",
       "title": "token.place oldest in-flight age by pod",
       "description": "Oldest in-flight age remains per relay pod because cross-replica ownership is not assumed.",
@@ -1665,12 +2448,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 149
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (pod) (tokenplace_relay_oldest_in_flight_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max by (pod) (tokenplace_relay_oldest_in_flight_age_seconds{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{pod}}"
         }
       ],
@@ -1693,7 +2476,7 @@
       }
     },
     {
-      "id": 39,
+      "id": 55,
       "type": "timeseries",
       "title": "token.place terminal outcome rate",
       "description": "Summed process-local terminal outcome counter rate grouped only by bounded outcome.",
@@ -1705,12 +2488,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 149
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (outcome) (rate(tokenplace_relay_request_outcomes_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "expr": "sum by (outcome) (rate(tokenplace_relay_request_outcomes_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval]))",
           "legendFormat": "{{outcome}}"
         }
       ],
@@ -1733,7 +2516,7 @@
       }
     },
     {
-      "id": 40,
+      "id": 56,
       "type": "row",
       "title": "token.place HTTP and release",
       "collapsed": false,
@@ -1741,11 +2524,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 157
       }
     },
     {
-      "id": 41,
+      "id": 57,
       "type": "timeseries",
       "title": "token.place HTTP request rate",
       "description": "Summed request rate grouped by normalized route and bounded status class.",
@@ -1757,12 +2540,12 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 158
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (route, status_class) (rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval]))",
+          "expr": "sum by (route, status_class) (rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval]))",
           "legendFormat": "{{route}} {{status_class}}"
         }
       ],
@@ -1785,7 +2568,7 @@
       }
     },
     {
-      "id": 42,
+      "id": 58,
       "type": "timeseries",
       "title": "token.place HTTP 5xx ratio",
       "description": "Fraction of observed token.place HTTP requests returning a bounded 5xx status class; absent counters remain NO DATA.",
@@ -1797,12 +2580,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 158
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\",status_class=\"5xx\"}[$__rate_interval])) / clamp_min(sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])), 1e-9)",
+          "expr": "sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\",status_class=\"5xx\"}[$__rate_interval])) / clamp_min(sum(rate(tokenplace_http_requests_total{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval])), 1e-9)",
           "legendFormat": "5xx ratio"
         }
       ],
@@ -1843,7 +2626,7 @@
       }
     },
     {
-      "id": 43,
+      "id": 59,
       "type": "timeseries",
       "title": "token.place HTTP latency percentiles",
       "description": "Request latency percentiles from histogram buckets, grouped only by normalized route.",
@@ -1855,22 +2638,22 @@
         "h": 8,
         "w": 16,
         "x": 0,
-        "y": 120
+        "y": 166
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(.50, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(.50, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval])))",
           "legendFormat": "p50 {{route}}"
         },
         {
           "refId": "B",
-          "expr": "histogram_quantile(.95, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(.95, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval])))",
           "legendFormat": "p95 {{route}}"
         },
         {
           "refId": "C",
-          "expr": "histogram_quantile(.99, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(.99, sum by (le, route) (rate(tokenplace_http_request_duration_seconds_bucket{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"}[$__rate_interval])))",
           "legendFormat": "p99 {{route}}"
         }
       ],
@@ -1893,7 +2676,7 @@
       }
     },
     {
-      "id": 44,
+      "id": 60,
       "type": "table",
       "title": "token.place build identity",
       "description": "Safe release identity per relay pod: version and revision.",
@@ -1905,15 +2688,16 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 120
+        "y": 166
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "max by (pod, version, revision) (tokenplace_build_info{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=\"sugarkube-int\",namespace=\"tokenplace\"})",
+          "expr": "max by (pod, version, revision) (tokenplace_build_info{app=\"tokenplace\",environment=~\"$environment\",release=\"tokenplace\",cluster=~\"$cluster\",namespace=\"tokenplace\"})",
           "legendFormat": "{{pod}} {{version}} {{revision}}",
           "instant": true,
-          "range": false
+          "range": false,
+          "format": "table"
         }
       ],
       "fieldConfig": {
@@ -1934,20 +2718,22 @@
       },
       "transformations": [
         {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true,
+              "__name__": true,
               "Value": true
             },
             "indexByName": {
               "pod": 0,
               "version": 1,
               "revision": 2
+            },
+            "renameByName": {
+              "pod": "Pod",
+              "version": "Version",
+              "revision": "Revision"
             }
           }
         }

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -1,9 +1,10 @@
 # Observability operations runbook
 
-This runbook covers the live staging stack and repository support for the production
-core-stack lifecycle. It is intentionally non-Flux: operators use guarded Helm commands
-from this repository, with the chart version and full values chain committed in Git.
-Merging production support is not evidence that the stack or a production dashboard is live.
+This runbook covers the staging and production observability core-stack lifecycles. It is
+intentionally non-Flux: operators use guarded Helm commands from this repository, with the chart
+version and full values chain committed in Git. Repository changes and generated dashboard
+artifacts are not deployment evidence; each environment requires its own guarded upgrade and
+acceptance evidence.
 
 ## Canonical sources
 
@@ -12,8 +13,13 @@ Merging production support is not evidence that the stack or a production dashbo
 - Staging overrides: `clusters/staging/observability/kube-prometheus-stack.values.yaml`.
 - Production overrides: `clusters/prod/observability/kube-prometheus-stack.values.yaml`.
 - Canonical DSPACE rules: `platform/observability/rules/dspace-release-integrity.yaml`.
-- Staging dashboard: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
-- Production dashboard: `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`.
+- Authoritative dashboard layout:
+  `platform/observability/dashboards/observability-dashboard.template.json`.
+- Dashboard generator: `scripts/generate_observability_dashboards.py`.
+- Generated staging artifact:
+  `clusters/staging/observability/dashboards/sugarkube-staging-observability.json`.
+- Generated production artifact:
+  `clusters/prod/observability/dashboards/sugarkube-prod-observability.json`.
 - Helper: `scripts/observability_helm.sh` through `just observability-*` recipes.
 - Alert delivery, routing, and drill strategy: [`docs/observability-alerting.md`](observability-alerting.md).
 - DSPACE release-integrity triage and focused drills:
@@ -30,7 +36,29 @@ dashboard: **Sugarkube Staging
 Observability** (`sugarkube-staging-observability`) or **Sugarkube Production
 Observability** (`sugarkube-prod-observability`). Grafana's chart-rendered
 Prometheus datasource has stable UID `prometheus`, which both dashboards
-reference directly.
+reference directly. Both artifacts intentionally have the same 60-object panel array: infrastructure
+and application signals keep identical positions, titles, queries, table behavior, and missing-data
+semantics. Only the UID, title, environment tag, and hidden single-value `environment` and `cluster`
+constants differ. Regenerate and byte-check them with:
+
+```bash
+python3 scripts/generate_observability_dashboards.py --write
+python3 scripts/generate_observability_dashboards.py --check
+```
+
+The generator reads only the shared specification; neither generated environment artifact is an
+input to the other. Every data panel says `NO DATA` when its query returns no series. Production is
+not currently verified to produce the application signals behind these sections, so they are
+expected to show `NO DATA` until each producer is separately deployed and accepted:
+
+- DSPACE HTTP, runtime/release, feature traffic, and release integrity;
+- blackbox monitoring and public availability;
+- token.place relay/compute-capacity, HTTP, and release identity.
+
+These are truthful absent-series states, not placeholder health. Capability-gated zeroes appear only
+when the corresponding instrumentation or approved-release series exists; an absent capability does
+not become a healthy zero. Core Kubernetes, node-exporter, Prometheus, Alertmanager, and Grafana
+sections remain locally queryable in both environments without relying on external `cluster` labels.
 
 The staging blackbox exporter and Probe lifecycle is documented separately in
 [Staging blackbox monitoring](observability-blackbox.md). That guarded lifecycle
@@ -275,7 +303,8 @@ is not rollout evidence.
 
 ### token.place Phase 1 dashboard slice
 
-The two token.place rows are a staging operational view of metric families that
+The two token.place rows are a shared dashboard view of metric families that are currently
+verified in staging and that
 the application already emits and that Prometheus has verified live. They do
 not define alert thresholds:
 
@@ -616,8 +645,8 @@ lost, and distinct from the automated evidence above:
 
 ## Follow-ups intentionally out of scope
 
-Additional dashboards, Grafana persistence, central multi-cluster Grafana, and production
-observability codification are separate follow-ups. The existing blackbox NetworkPolicy is unchanged.
+Additional dashboards, Grafana persistence, central multi-cluster Grafana, and deployment of the
+currently absent production application telemetry are separate follow-ups. The existing blackbox NetworkPolicy is unchanged.
 The synthetic Alertmanager → PagerDuty route is deployed and delivery-tested. External node-heartbeat
 timers are installed on `sugarkube3`, `sugarkube4`, and `sugarkube5`; their node-power-off drill
 remains outstanding. The watchdog's secret-safe configuration and operator workflows are
@@ -709,8 +738,8 @@ just observability-app-metrics-verify app=tokenplace env=staging
 ```
 
 `just observability-verify env=staging` also runs every configured application
-metrics verifier after the existing DSPACE checks. Production application metrics
-verification is intentionally rejected until production observability is codified.
-Merging this repository support does not deploy any application, create any
-Secret, dashboard, alert rule, schedulability check, shared-state check, or live
-drill.
+metrics verifier after the existing DSPACE checks. Production application-metrics verification remains intentionally rejected until those producers
+are deployed and verified. Merging this change does not deploy either generated dashboard or any
+application integration. Staging and production each require a separate guarded Helm upgrade,
+source/render/API verification, and Grafana pod-replacement proof. It also does not create any
+Secret, alert rule, schedulability check, shared-state check, or live drill.

--- a/platform/observability/dashboards/observability-dashboard.template.json
+++ b/platform/observability/dashboards/observability-dashboard.template.json
@@ -1,11 +1,11 @@
 {
   "id": null,
-  "uid": "sugarkube-prod-observability",
-  "title": "Sugarkube Production Observability",
+  "uid": "__UID__",
+  "title": "__TITLE__",
   "tags": [
     "sugarkube",
     "observability",
-    "prod"
+    "__ENVIRONMENT__"
   ],
   "timezone": "browser",
   "schemaVersion": 41,
@@ -21,10 +21,10 @@
       {
         "name": "environment",
         "type": "constant",
-        "query": "prod",
+        "query": "__ENVIRONMENT__",
         "current": {
-          "text": "prod",
-          "value": "prod"
+          "text": "__ENVIRONMENT__",
+          "value": "__ENVIRONMENT__"
         },
         "hide": 2,
         "skipUrlSync": true
@@ -32,10 +32,10 @@
       {
         "name": "cluster",
         "type": "constant",
-        "query": "sugarkube-prod",
+        "query": "__CLUSTER__",
         "current": {
-          "text": "sugarkube-prod",
-          "value": "sugarkube-prod"
+          "text": "__CLUSTER__",
+          "value": "__CLUSTER__"
         },
         "hide": 2,
         "skipUrlSync": true

--- a/scripts/generate_observability_dashboards.py
+++ b/scripts/generate_observability_dashboards.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate the environment-specific Grafana dashboards from one canonical template."""
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "platform/observability/dashboards/observability-dashboard.template.json"
+PROFILES = {
+    "staging": {
+        "uid": "sugarkube-staging-observability",
+        "title": "Sugarkube Staging Observability",
+        "environment": "staging",
+        "cluster": "sugarkube-int",
+        "path": ROOT
+        / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json",
+    },
+    "prod": {
+        "uid": "sugarkube-prod-observability",
+        "title": "Sugarkube Production Observability",
+        "environment": "prod",
+        "cluster": "sugarkube-prod",
+        "path": ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json",
+    },
+}
+
+
+def load_template() -> dict:
+    """Load the authoritative, environment-neutral dashboard specification."""
+    return json.loads(TEMPLATE.read_text(encoding="utf-8"))
+
+
+def _replace(value, replacements):
+    if isinstance(value, str):
+        for marker, replacement in replacements.items():
+            value = value.replace(marker, replacement)
+        return value
+    if isinstance(value, list):
+        return [_replace(item, replacements) for item in value]
+    if isinstance(value, dict):
+        return {key: _replace(item, replacements) for key, item in value.items()}
+    return value
+
+
+def render_dashboard(profile_name: str) -> dict:
+    """Render a profile without consulting either committed generated artifact."""
+    profile = PROFILES[profile_name]
+    template = copy.deepcopy(load_template())
+    return _replace(
+        template,
+        {
+            "__UID__": profile["uid"],
+            "__TITLE__": profile["title"],
+            "__ENVIRONMENT__": profile["environment"],
+            "__CLUSTER__": profile["cluster"],
+        },
+    )
+
+
+def serialized_dashboard(profile_name: str) -> str:
+    """Return the canonical byte representation committed to the repository."""
+    return json.dumps(render_dashboard(profile_name), indent=2) + "\n"
+
+
+def write_dashboards() -> None:
+    for profile_name, profile in PROFILES.items():
+        profile["path"].write_text(serialized_dashboard(profile_name), encoding="utf-8")
+
+
+def check_dashboards() -> None:
+    stale = []
+    for profile_name, profile in PROFILES.items():
+        try:
+            actual = profile["path"].read_text(encoding="utf-8")
+        except OSError:
+            actual = None
+        if actual != serialized_dashboard(profile_name):
+            stale.append(str(profile["path"].relative_to(ROOT)))
+    if stale:
+        paths = "\n  ".join(stale)
+        raise SystemExit(
+            "ERROR: generated observability dashboard artifacts are stale:\n"
+            f"  {paths}\nRun scripts/generate_observability_dashboards.py --write."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="write both generated dashboards")
+    mode.add_argument("--check", action="store_true", help="byte-check both generated dashboards")
+    args = parser.parse_args()
+    if args.write:
+        write_dashboards()
+    else:
+        check_dashboards()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_observability_dashboard.py
+++ b/scripts/validate_observability_dashboard.py
@@ -1,160 +1,49 @@
 #!/usr/bin/env python3
-"""Fail-closed validation for Sugarkube Grafana dashboards and Helm renders."""
+"""Fail-closed validation for canonical Sugarkube Grafana dashboards and Helm renders."""
 
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
-TITLE = "Sugarkube Staging Observability"
-UID = "sugarkube-staging-observability"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.generate_observability_dashboards import (
+    PROFILES,
+    render_dashboard,
+    serialized_dashboard,
+)
+
 DATASOURCE_UID = "prometheus"
 DASHBOARD_PATH = "/var/lib/grafana/dashboards/sugarkube"
-DASHBOARD_FILE = f"{UID}.json"
-DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
-PROD_TITLE = "Sugarkube Production Observability"
-PROD_UID = "sugarkube-prod-observability"
-REQUIRED_METRICS = {
-    "up",
-    "dspace_instrumentation_up",
-    "probe_success",
-    "dspace_http_requests_total",
-    "dspace_http_request_duration_seconds_bucket",
-    "process_resident_memory_bytes",
-    "dspace_build_info",
-    "dspace_release_approved_info",
-    "kube_pod_container_info",
-    "dspace_chat_synthetic_success",
-    "dspace_chat_synthetic_timestamp_seconds",
-    "dspace_dchat_requests_total",
-    "dspace_dependency_requests_total",
-    "probe_duration_seconds",
-    "probe_http_status_code",
-    "probe_ssl_earliest_cert_expiry",
-    "tokenplace_compute_nodes_registered",
-    "tokenplace_compute_nodes_healthy",
-    "tokenplace_compute_node_lease_age_seconds",
-    "tokenplace_compute_node_evictions_total",
-    "tokenplace_relay_queue_depth",
-    "tokenplace_relay_oldest_queued_request_age_seconds",
-    "tokenplace_relay_in_flight_requests",
-    "tokenplace_relay_oldest_in_flight_age_seconds",
-    "tokenplace_relay_request_outcomes_total",
-    "tokenplace_http_requests_total",
-    "tokenplace_http_request_duration_seconds_bucket",
-    "tokenplace_instrumentation_up",
-    "tokenplace_build_info",
-}
-EVENT_METRICS = {"dspace_dchat_requests_total", "dspace_dependency_requests_total"}
-OPERATIONAL_ROUTES = '"/(healthz|livez|metrics)"'
-BLACKBOX_JOB_MATCHER = (
-    'job=~"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*"'
-)
-TOKENPLACE_ROWS = {
+ROW_TITLES = [
+    "Cluster and service health",
+    "Workload health",
+    "Node and Prometheus capacity",
+    "Observability build identity",
+    "DSPACE HTTP",
+    "DSPACE runtime and release",
+    "DSPACE feature traffic",
+    "Blackbox monitoring",
+    "DSPACE release integrity",
     "token.place relay and compute capacity",
     "token.place HTTP and release",
-}
-TOKENPLACE_PANELS = {
-    "token.place scrape availability",
-    "token.place instrumentation health",
-    "token.place compute-node counts",
-    "token.place oldest compute-node lease age",
-    "token.place compute-node eviction rate",
-    "token.place relay queue depth",
-    "token.place oldest queued-request age",
-    "token.place in-flight requests by pod",
-    "token.place oldest in-flight age by pod",
-    "token.place terminal outcome rate",
-    "token.place HTTP request rate",
-    "token.place HTTP 5xx ratio",
-    "token.place HTTP latency percentiles",
-    "token.place build identity",
-}
-PHASE_TWO_METRICS = {
-    "tokenplace_chat_availability",
-    "tokenplace_compute_nodes_schedulable",
-    "tokenplace_availability_reason",
-    "tokenplace_shared_state_health",
-    "tokenplace_relay_chat_available",
-    "tokenplace_relay_schedulable_compute_nodes",
-    "tokenplace_relay_chat_availability_state",
-    "tokenplace_relay_state_store_up",
-}
-TOKENPLACE_LABELS = {
-    "app",
-    "environment",
-    "release",
-    "cluster",
-    "namespace",
-    "pod",
-    "reason",
-    "provider_mode",
-    "outcome",
-    "route",
-    "status_class",
-    "le",
-    "version",
-    "revision",
-}
-TOKENPLACE_PROMQL_FUNCTIONS = {
-    "clamp_min",
-    "histogram_quantile",
-    "max",
-    "min",
-    "rate",
-    "sum",
-}
-TOKENPLACE_PROMQL_MODIFIERS = {
-    "and",
-    "bool",
-    "group_left",
-    "group_right",
-    "ignoring",
-    "offset",
-    "on",
-    "or",
-    "unless",
-}
-TOKENPLACE_CANONICAL_MATCHERS = {
-    "app": ("=", '"tokenplace"'),
-    "environment": ("=~", '"$environment"'),
-    "release": ("=", '"tokenplace"'),
-    "cluster": ("=", '"sugarkube-int"'),
-    "namespace": ("=", '"tokenplace"'),
-}
-TOKENPLACE_RATE_METRICS = {
-    "tokenplace_compute_node_evictions_total",
-    "tokenplace_relay_request_outcomes_total",
-    "tokenplace_http_requests_total",
-    "tokenplace_http_request_duration_seconds_bucket",
-}
+]
+FORBIDDEN_IDENTITY = re.compile(
+    r"{{\s*(instance|address|endpoint|url|device|uuid|system_uuid|provider_id|pod_cidr)\s*}}",
+    re.IGNORECASE,
+)
 
-
-def parse_tokenplace_matchers(matchers: str) -> dict:
-    """Parse the deliberately small matcher grammar used by token.place panels."""
-    parsed = {}
-    for entry in matchers.split(","):
-        match = re.fullmatch(
-            r'\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*("(?:\\.|[^"\\])*")\s*',
-            entry,
-        )
-        if not match or match.group(1) in parsed:
-            raise ValueError("malformed or duplicate matcher")
-        parsed[match.group(1)] = match.groups()[1:]
-    return parsed
-
-
-def load_dashboard(path: Path) -> dict:
-    try:
-        dashboard = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise SystemExit(f"ERROR: dashboard JSON is missing or malformed: {error}") from error
-    if not isinstance(dashboard, dict):
-        raise SystemExit("ERROR: dashboard JSON root must be an object.")
-    return dashboard
+TITLE = ""
+UID = ""
+DASHBOARD_FILE = ""
+DASHBOARD_MOUNT = ""
 
 
 def panels(dashboard: dict):
+    """Yield every top-level or nested panel."""
     for panel in dashboard.get("panels", []):
         if isinstance(panel, dict):
             yield panel
@@ -168,758 +57,258 @@ def panel_named(dashboard: dict, title: str) -> dict:
     return matching[0]
 
 
-def panel_expression(dashboard: dict, title: str) -> str:
-    panel = panel_named(dashboard, title)
-    targets = panel.get("targets", [])
-    if len(targets) != 1 or not isinstance(targets[0].get("expr"), str):
-        raise SystemExit(f"ERROR: {title} must contain exactly one PromQL target.")
-    return re.sub(r"\s+", " ", targets[0]["expr"])
-
-
-def configure_profile(dashboard: dict) -> bool:
-    """Select render identity from the source itself, rejecting unknown profiles."""
+def configure_profile(dashboard: dict) -> str:
+    """Select a supported identity and configure its rendered-file contract."""
     global TITLE, UID, DASHBOARD_FILE, DASHBOARD_MOUNT
-    identity = (dashboard.get("uid"), dashboard.get("title"))
-    production = identity == (PROD_UID, PROD_TITLE)
-    if not production and identity != ("sugarkube-staging-observability", "Sugarkube Staging Observability"):
-        raise SystemExit("ERROR: dashboard title and UID do not match a supported profile.")
-    UID, TITLE = identity
-    DASHBOARD_FILE = f"{UID}.json"
-    DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
-    return production
+    for name, profile in PROFILES.items():
+        if (dashboard.get("uid"), dashboard.get("title")) == (
+            profile["uid"],
+            profile["title"],
+        ):
+            UID, TITLE = profile["uid"], profile["title"]
+            DASHBOARD_FILE = f"{UID}.json"
+            DASHBOARD_MOUNT = f"{DASHBOARD_PATH}/{DASHBOARD_FILE}"
+            return name
+    raise SystemExit("ERROR: dashboard title and UID do not match a supported profile.")
 
 
-def validate_production_dashboard(dashboard: dict) -> None:
-    required = {
-        "Cluster health": None,
-        "Scrape availability by job": "min by (job) (up)",
-        "Ready nodes": 'sum(max by (node) (kube_node_status_condition{condition="Ready",status="true"}))',
-        "Node readiness": 'max by (node) (kube_node_status_condition{condition="Ready",status="true"})',
-        "Workload health": None,
-        "Deployment replica deficit": "clamp_min(max by (namespace, deployment) (kube_deployment_spec_replicas) - max by (namespace, deployment) (kube_deployment_status_replicas_available), 0)",
-        "Unready pods by namespace": 'sum by (namespace) (max by (namespace, pod) (kube_pod_status_ready{condition="false"}) * on (namespace, pod) group_left max by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Running|Unknown"} == 1))',
-        "Problem pods by namespace": 'sum by (namespace) (max by (namespace, pod, phase) (kube_pod_status_phase{phase=~"Pending|Failed|Unknown"}))',
-        "Container restart rate": "sum by (namespace, pod) (max by (namespace, pod, container) (rate(kube_pod_container_status_restarts_total[$__rate_interval])))",
-        "Node and Prometheus capacity": None,
-        "Node CPU utilization": 'max by (nodename) (100 * (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[$__rate_interval]))) * on (instance) group_left (nodename) node_uname_info)',
-        "Node memory utilization": "max by (nodename) (100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on (instance) group_left (nodename) node_uname_info)",
-        "Root filesystem utilization": 'max by (nodename) (100 * (1 - node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}) * on (instance) group_left (nodename) node_uname_info)',
-        "Prometheus PVC utilization": '100 * (1 - max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}) / max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="monitoring",persistentvolumeclaim=~"prometheus-kube-prometheus-stack-prometheus-db-.*"}))',
-        "Prometheus active series": "max by (pod) (prometheus_tsdb_head_series)",
-        "Observability build identity": None,
-    }
-    actual_titles = [panel.get("title") for panel in panels(dashboard)]
-    if len(actual_titles) != len(required) + 1 or any(actual_titles.count(title) != 1 for title in required):
-        raise SystemExit("ERROR: production dashboard must contain every required row and panel exactly once.")
-    for title, expression in required.items():
-        panel = panel_named(dashboard, title)
-        if expression is None:
-            if panel.get("type") != "row":
-                raise SystemExit("ERROR: production dashboard row contract is invalid.")
-        elif panel_expression(dashboard, title) != expression:
-            raise SystemExit(f"ERROR: production PromQL contract changed for {title}.")
-    snapshot_tables = (
-        "Scrape availability by job",
-        "Node readiness",
-        "Deployment replica deficit",
-        "Observability component build identity",
-    )
-    table_columns = {
-        "Scrape availability by job": (
-            {"job": 0, "Value": 1},
-            {"Time", "__name__"},
-            {"job": "Job", "Value": "Status"},
-        ),
-        "Node readiness": (
-            {"node": 0, "Value": 1},
-            {"Time", "__name__"},
-            {"node": "Node", "Value": "Status"},
-        ),
-        "Deployment replica deficit": (
-            {"namespace": 0, "deployment": 1, "Value": 2},
-            {"Time", "__name__"},
-            {
-                "namespace": "Namespace",
-                "deployment": "Deployment",
-                "Value": "Replica deficit",
-            },
-        ),
-        "Observability component build identity": (
-            {"component": 0, "pod": 1, "version": 2, "revision": 3},
-            {"Time", "Value", "__name__"},
-            {
-                "component": "Component",
-                "pod": "Pod",
-                "version": "Version",
-                "revision": "Revision",
-            },
-        ),
-    }
-    for title in snapshot_tables:
-        table = panel_named(dashboard, title)
-        targets = table.get("targets", [])
-        if table.get("type") != "table" or len(targets) != 1:
-            raise SystemExit(
-                "ERROR: production tables must deterministically consolidate into one frame."
-            )
-        if any(
+def _validate_grid(panel_list: list) -> None:
+    ids = [panel.get("id") for panel in panel_list]
+    if ids != list(range(1, 61)):
+        raise SystemExit("ERROR: canonical panel IDs must be the stable integer sequence 1..60.")
+    occupied = set()
+    for panel in panel_list:
+        grid = panel.get("gridPos", {})
+        if set(grid) != {"x", "y", "w", "h"} or not all(
+            isinstance(grid[key], int) for key in ("x", "y", "w", "h")
+        ):
+            raise SystemExit("ERROR: dashboard panels must have complete integer grid positions.")
+        if grid["x"] < 0 or grid["y"] < 0 or grid["w"] <= 0 or grid["h"] <= 0:
+            raise SystemExit("ERROR: dashboard panel grid positions must be positive and bounded.")
+        cells = {
+            (x, y)
+            for x in range(grid["x"], grid["x"] + grid["w"])
+            for y in range(grid["y"], grid["y"] + grid["h"])
+        }
+        if occupied & cells:
+            raise SystemExit("ERROR: dashboard panel grid positions must not overlap.")
+        occupied |= cells
+
+
+def _validate_tables(dashboard: dict) -> None:
+    tables = [panel for panel in panels(dashboard) if panel.get("type") == "table"]
+    if len(tables) != 10:
+        raise SystemExit("ERROR: canonical dashboard must contain exactly ten tables.")
+    for panel in tables:
+        targets = panel.get("targets", [])
+        if len(targets) != 1:
+            raise SystemExit(f"ERROR: {panel['title']} must use one simultaneous table frame.")
+        target = targets[0]
+        if (
             target.get("format") != "table"
             or target.get("instant") is not True
             or target.get("range") is not False
-            for target in targets
         ):
-            raise SystemExit("ERROR: production tables must be table-formatted instant-only queries.")
-        transformations = table.get("transformations", [])
+            raise SystemExit(f"ERROR: {panel['title']} must use an instant-only table target.")
+        transformations = panel.get("transformations", [])
         if len(transformations) != 1 or transformations[0].get("id") != "organize":
-            raise SystemExit("ERROR: production tables require deterministic field organization.")
+            raise SystemExit(f"ERROR: {panel['title']} must use one organize transformation.")
         options = transformations[0].get("options", {})
-        expected_columns, expected_hidden, expected_headings = table_columns[title]
-        if options.get("indexByName") != expected_columns or {
-            name for name, hidden in options.get("excludeByName", {}).items() if hidden is True
-        } != expected_hidden or options.get("renameByName") != expected_headings:
+        if not isinstance(options.get("indexByName"), dict) or not isinstance(
+            options.get("renameByName"), dict
+        ):
+            raise SystemExit(f"ERROR: {panel['title']} must explicitly order and rename columns.")
+        excluded = options.get("excludeByName", {})
+        if not all(excluded.get(name) is True for name in ("Time", "__name__")):
+            raise SystemExit(f"ERROR: {panel['title']} must hide Time and __name__ fields.")
+        if "Value" not in options["indexByName"] and excluded.get("Value") is not True:
+            raise SystemExit(f"ERROR: {panel['title']} must explicitly order or hide Value.")
+
+
+def _validate_variables(dashboard: dict, profile_name: str) -> None:
+    variables = dashboard.get("templating", {}).get("list", [])
+    if [item.get("name") for item in variables] != ["environment", "cluster", "app", "route"]:
+        raise SystemExit(
+            "ERROR: dashboard variables must have canonical environment/cluster/app/route shape."
+        )
+    profile = PROFILES[profile_name]
+    for variable, expected in zip(variables[:2], (profile["environment"], profile["cluster"])):
+        if variable.get("type") != "constant" or variable.get("hide") != 2:
+            raise SystemExit("ERROR: environment and cluster must be hidden constants.")
+        if variable.get("query") != expected or variable.get("current") != {
+            "text": expected,
+            "value": expected,
+        }:
+            raise SystemExit("ERROR: hidden profile variables contain the wrong single value.")
+    for variable in variables[2:]:
+        if variable.get("type") != "query" or variable.get("includeAll") is not True:
             raise SystemExit(
-                "ERROR: production table columns, headings, or hidden raw fields are invalid."
+                "ERROR: app and route must be visible query variables with All enabled."
             )
-    build = panel_named(dashboard, "Observability component build identity")
-    expected_build = 'max by (component, pod, version, revision) (' + " or ".join(
-        f'label_replace({metric}, "component", "{component}", "", "")'
-        for metric, component in (
-            ("prometheus_build_info", "prometheus"),
-            ("alertmanager_build_info", "alertmanager"),
-            ("grafana_build_info", "grafana"),
-            ("node_exporter_build_info", "node-exporter"),
-        )
-    ) + ")"
-    if build["targets"][0].get("expr") != expected_build:
+        if variable.get("allValue") != ".*":
+            raise SystemExit("ERROR: app and route All values must expand to .*.")
+
+
+def _validate_semantics(dashboard: dict) -> None:
+    panel_list = list(panels(dashboard))
+    if len(panel_list) != 60 or sum(panel.get("type") == "row" for panel in panel_list) != 11:
         raise SystemExit(
-            "ERROR: production build identity must retain bounded component/pod/version/revision."
+            "ERROR: canonical dashboard must contain 60 objects: 11 rows and 49 panels."
         )
-    serialized = json.dumps(dashboard)
-    expressions = "\n".join(target.get("expr", "") for panel in panels(dashboard) for target in panel.get("targets", []))
-    if dashboard.get("refresh") != "30s" or dashboard.get("time") != {"from": "now-6h", "to": "now"} or dashboard.get("templating", {}).get("list") != []:
-        raise SystemExit("ERROR: production dashboard defaults or variables are invalid.")
-    if "or vector(0)" in expressions or "or on() vector(0)" in expressions or re.search(r'cluster\s*(?:=|=~)', expressions):
-        raise SystemExit("ERROR: production queries must preserve missing data and omit external-label selectors.")
-    forbidden = ("kube_state_metrics_build_info", "probe_", "dspace", "tokenplace", "blackbox", "synthetic")
-    if any(item in expressions.lower() for item in forbidden):
-        raise SystemExit("ERROR: production dashboard contains an unverified signal.")
-    if re.search(r"{{\s*(instance|ip|url|endpoint|device|system_uuid|provider_id|pod_cidr)\s*}}", serialized, re.I):
-        raise SystemExit("ERROR: production legends expose a forbidden raw identity label.")
-    for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization"):
-        if panel_named(dashboard, title)["targets"][0].get("legendFormat") != "{{nodename}}":
-            raise SystemExit("ERROR: node panels must expose only nodename in their legends.")
-    for title in ("Node CPU utilization", "Node memory utilization", "Root filesystem utilization", "Prometheus PVC utilization"):
-        defaults = panel_named(dashboard, title).get("fieldConfig", {}).get("defaults", {})
-        if (defaults.get("unit"), defaults.get("min"), defaults.get("max")) != ("percent", 0, 100):
-            raise SystemExit("ERROR: production percentage panels require a 0-100 percent scale.")
-    if any(panel.get("type") != "row" and panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA" for panel in panels(dashboard)):
-        raise SystemExit("ERROR: production panels must explicitly preserve NO DATA.")
-    datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
-    if DATASOURCE_UID not in datasource_refs or any(uid not in {DATASOURCE_UID, PROD_UID} for uid in datasource_refs):
-        raise SystemExit("ERROR: production datasource references must use Prometheus UID.")
-
-
-def has_serving_pod_filter(expression: str) -> bool:
-    return all(
-        token in expression
-        for token in (
-            'kube_pod_container_status_ready{namespace="dspace",container="dspace"} == 1',
-            "and on (namespace, pod) "
-            'kube_pod_status_phase{namespace="dspace",phase="Running"} == 1',
-            'unless on (namespace, pod) kube_pod_deletion_timestamp{namespace="dspace"}',
-        )
-    )
-
-
-def validate_dashboard_semantics(dashboard: dict) -> None:
-    variables = {
-        variable.get("name"): variable
-        for variable in dashboard.get("templating", {}).get("list", [])
-        if isinstance(variable, dict)
-    }
-    expected_labels = {"app": "Probe application", "route": "Probe route"}
-    if any(
-        variables.get(name, {}).get("label") != label for name, label in expected_labels.items()
-    ):
-        raise SystemExit("ERROR: blackbox variables must use probe-specific visible labels.")
-
-    distribution = panel_named(dashboard, "Status-class distribution")
-    if distribution.get("type") not in {"piechart", "bargauge"}:
-        raise SystemExit("ERROR: status-class distribution must use a categorical visualization.")
-    distribution_targets = distribution.get("targets", [])
-    if not distribution_targets or any(
-        target.get("instant") is not True or target.get("range") is not False
-        for target in distribution_targets
-    ):
-        raise SystemExit(
-            "ERROR: status-class distribution must be an instant selected-window query."
-        )
-    if any(
-        "increase(" not in target.get("expr", "")
-        or "$__range" not in target.get("expr", "")
-        or "sum by (status_class)" not in target.get("expr", "")
-        or 'environment=~"$environment"' not in target.get("expr", "")
-        for target in distribution_targets
-    ):
-        raise SystemExit("ERROR: status-class distribution must summarize the selected window.")
-    distribution_colors = {
-        override.get("matcher", {})
-        .get("options"): override.get("properties", [{}])[0]
-        .get("value", {})
-        .get("fixedColor")
-        for override in distribution.get("fieldConfig", {}).get("overrides", [])
-    }
-    if distribution_colors != {"2xx": "green", "4xx": "orange", "5xx": "red"}:
-        raise SystemExit("ERROR: status-class distribution must use explicit status-class colors.")
-
-    user_rate = panel_named(dashboard, "User request rate by route and status class")
-    user_expressions = [target.get("expr", "") for target in user_rate.get("targets", [])]
-    if not user_expressions or any(
-        f"route!~{OPERATIONAL_ROUTES}" not in expression for expression in user_expressions
-    ):
-        raise SystemExit("ERROR: user request rate must exclude operational routes.")
-    operational_rate = panel_named(dashboard, "Operational request rate")
-    if not any(
-        f"route=~{OPERATIONAL_ROUTES}" in target.get("expr", "")
-        for target in operational_rate.get("targets", [])
-    ):
-        raise SystemExit("ERROR: operational request rate must retain health and metrics routes.")
-
-    summary = panel_named(dashboard, "Public availability summary")
-    summary_targets = summary.get("targets", [])
-    if (
-        not isinstance(summary_targets, list)
-        or len(summary_targets) != 3
-        or any(
-            not isinstance(target, dict)
-            or not isinstance(target.get("expr"), str)
-            or target.get("instant") is not True
-            or target.get("range") is not False
-            or "sum(" not in target.get("expr", "")
-            or " by (environment, app, route) " not in target.get("expr", "")
-            or BLACKBOX_JOB_MATCHER not in target.get("expr", "")
-            or any(
-                selector not in target.get("expr", "")
-                for selector in (
-                    'environment=~"$environment"',
-                    'app=~"$app"',
-                    'route=~"$route"',
-                )
-            )
-            for target in summary_targets
-        )
-    ):
-        raise SystemExit(
-            "ERROR: public availability must be a three-value instant aggregate summary."
-        )
-    summary_by_legend = {
-        target.get("legendFormat"): target.get("expr", "") for target in summary_targets
-    }
-    healthy_expression = re.sub(r"\s+", " ", summary_by_legend.get("Healthy endpoints", ""))
-    failed_expression = re.sub(r"\s+", " ", summary_by_legend.get("Failed endpoints", ""))
-    missing_expression = re.sub(r"\s+", " ", summary_by_legend.get("Missing probe data", ""))
-    if "== bool 1" not in healthy_expression or "== bool 0" not in failed_expression:
-        raise SystemExit("ERROR: availability counts must use boolean healthy and failed sums.")
-    if (
-        "max_over_time(up{" not in missing_expression
-        or "[7d]" not in missing_expression
-        or ">= bool 0" not in missing_expression
-        or " - (sum(" not in missing_expression
-        or "probe_success{" not in missing_expression
-        or "or vector(0)" not in missing_expression
-    ):
-        raise SystemExit(
-            "ERROR: missing probe data must compare retention-backed discovered "
-            "probes with current samples."
-        )
-    if {target.get("legendFormat") for target in summary_targets} != {
-        "Healthy endpoints",
-        "Failed endpoints",
-        "Missing probe data",
-    } or summary.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA":
-        raise SystemExit(
-            "ERROR: public availability must distinguish healthy, failed, and no data."
-        )
-    missing_colors = [
-        prop.get("value", {}).get("fixedColor")
-        for override in summary.get("fieldConfig", {}).get("overrides", [])
-        if isinstance(override, dict)
-        and override.get("matcher", {}).get("options") == "Missing probe data"
-        for prop in override.get("properties", [])
-        if isinstance(prop, dict) and prop.get("id") == "color"
-    ]
-    if missing_colors != ["yellow"]:
-        raise SystemExit("ERROR: missing probe data must be a compact yellow summary value.")
-
-    matrix = panel_named(dashboard, "Endpoint matrix")
-    if matrix.get("type") != "table" or not matrix.get("targets"):
-        raise SystemExit("ERROR: dashboard must retain the detailed endpoint matrix.")
-
-    revisions = panel_expression(dashboard, "Active build revisions by pod")
-    if (
-        "dspace_build_info" not in revisions
-        or "and on (namespace, pod)" not in revisions
-        or not has_serving_pod_filter(revisions)
-    ):
-        raise SystemExit("ERROR: active build revisions must include only serving DSPACE pods.")
-
-    image_agreement = panel_expression(dashboard, "Image-pin agreement")
-    if not has_serving_pod_filter(image_agreement) or "or on() vector(0)" not in image_agreement:
-        raise SystemExit(
-            "ERROR: image-pin agreement must filter serving pods and return a healthy zero."
-        )
-
-    target_panel = panel_named(dashboard, "DSPACE metrics-target health")
-    target_health = panel_expression(dashboard, "DSPACE metrics-target health")
-    if (
-        not has_serving_pod_filter(target_health)
-        or 'unless on (namespace, pod) up{namespace="dspace",service=~"dspace.*"}'
-        not in target_health
-        or 'up{namespace="dspace",service=~"dspace.*"} == 0' not in target_health
-        or "count(" not in target_health
-        or "or on() vector(0)" not in target_health
-        or target_panel.get("targets", [{}])[0].get("legendFormat")
-        != "down or missing serving targets"
-        or "Zero is healthy; missing targets fail closed."
-        not in target_panel.get("description", "")
-    ):
-        raise SystemExit(
-            "ERROR: DSPACE metrics-target health must count down or missing serving targets."
-        )
-
-
-def validate_tokenplace_semantics(dashboard: dict) -> None:
-    all_items = list(panels(dashboard))
-    for title in TOKENPLACE_ROWS | TOKENPLACE_PANELS:
-        matching = [panel for panel in all_items if panel.get("title") == title]
-        if len(matching) != 1:
-            raise SystemExit(f"ERROR: dashboard must contain exactly one {title!r} panel.")
-    if any(panel_named(dashboard, title).get("type") != "row" for title in TOKENPLACE_ROWS):
-        raise SystemExit("ERROR: token.place section headings must remain dashboard rows.")
-
-    token_panels_by_title = {title: panel_named(dashboard, title) for title in TOKENPLACE_PANELS}
-    expected_targets = {title: 1 for title in TOKENPLACE_PANELS}
-    expected_targets["token.place compute-node counts"] = 2
-    expected_targets["token.place HTTP latency percentiles"] = 3
-    for title, expected_count in expected_targets.items():
-        targets = token_panels_by_title[title].get("targets")
-        if (
-            not isinstance(targets, list)
-            or len(targets) != expected_count
-            or any(
-                not isinstance(target, dict) or not target.get("expr", "").strip()
-                for target in targets
-            )
-        ):
-            raise SystemExit(
-                f"ERROR: {title} must contain exactly {expected_count} non-empty target(s)."
-            )
-
-    token_panels = list(token_panels_by_title.values())
-    expressions = [
-        target.get("expr", "")
-        for panel in token_panels
-        for target in panel.get("targets", [])
-        if isinstance(target, dict)
-    ]
-    if not expressions:
-        raise SystemExit("ERROR: token.place panels must contain queries.")
-    if any(
-        "vector(0)" in expression or re.search(r"\bor\s+(?:on\(\)\s+)?0\b", expression)
-        for expression in expressions
-    ):
-        raise SystemExit(
-            "ERROR: token.place queries must preserve missing data instead of substituting zero."
-        )
-    if any(re.search(r"\blabel_(?:replace|join)\s*\(", expression) for expression in expressions):
-        raise SystemExit("ERROR: token.place queries must not synthesize labels.")
-
-    expected_metrics = {
-        "token.place scrape availability": {"up"},
-        "token.place instrumentation health": {"tokenplace_instrumentation_up"},
-        "token.place compute-node counts": {
-            "tokenplace_compute_nodes_registered",
-            "tokenplace_compute_nodes_healthy",
-        },
-        "token.place oldest compute-node lease age": {"tokenplace_compute_node_lease_age_seconds"},
-        "token.place compute-node eviction rate": {"tokenplace_compute_node_evictions_total"},
-        "token.place relay queue depth": {"tokenplace_relay_queue_depth"},
-        "token.place oldest queued-request age": {
-            "tokenplace_relay_oldest_queued_request_age_seconds"
-        },
-        "token.place in-flight requests by pod": {"tokenplace_relay_in_flight_requests"},
-        "token.place oldest in-flight age by pod": {
-            "tokenplace_relay_oldest_in_flight_age_seconds"
-        },
-        "token.place terminal outcome rate": {"tokenplace_relay_request_outcomes_total"},
-        "token.place HTTP request rate": {"tokenplace_http_requests_total"},
-        "token.place HTTP 5xx ratio": {"tokenplace_http_requests_total"},
-        "token.place HTTP latency percentiles": {"tokenplace_http_request_duration_seconds_bucket"},
-        "token.place build identity": {"tokenplace_build_info"},
-    }
-    for title, intended in expected_metrics.items():
-        panel_expressions = [target["expr"] for target in token_panels_by_title[title]["targets"]]
-        found = set()
-        for expression in panel_expressions:
-            selectors = list(
-                re.finditer(r"\b([a-zA-Z_:][a-zA-Z0-9_:]*)\s*\{([^{}]*)\}", expression)
-            )
-            consumed_selector_ends = []
-            for selector in selectors:
-                metric, matchers = selector.groups()
-                found.add(metric)
-                try:
-                    parsed_matchers = parse_tokenplace_matchers(matchers)
-                except ValueError:
-                    parsed_matchers = None
-                allowed_matchers = dict(TOKENPLACE_CANONICAL_MATCHERS)
-                if title == "token.place HTTP 5xx ratio":
-                    allowed_matchers["status_class"] = ("=", '"5xx"')
-                if (
-                    metric not in intended
-                    or parsed_matchers is None
-                    or any(
-                        parsed_matchers.get(key) != value
-                        for key, value in TOKENPLACE_CANONICAL_MATCHERS.items()
-                    )
-                    or any(key not in allowed_matchers for key in parsed_matchers)
-                    or any(allowed_matchers[key] != value for key, value in parsed_matchers.items())
-                ):
-                    raise SystemExit(
-                        f"ERROR: {title} must use only its intended metric family "
-                        "with the canonical target selector."
-                    )
-                suffix = expression[selector.end() :]
-                range_match = re.match(r"\[\$__rate_interval\]", suffix)
-                if metric in TOKENPLACE_RATE_METRICS:
-                    if not range_match or not re.search(
-                        r"\brate\s*\(\s*$", expression[: selector.start()]
-                    ):
-                        raise SystemExit(
-                            f"ERROR: {title} rate ranges must be attached to a metric "
-                            "selector directly inside rate()."
-                        )
-                    consumed_selector_ends.append(selector.end() + range_match.end())
-                else:
-                    if range_match:
-                        raise SystemExit(
-                            f"ERROR: {title} has a range outside an intended rate expression."
-                        )
-                    consumed_selector_ends.append(selector.end())
-            without_selectors = "".join(
-                expression[end:start]
-                for (end, start) in zip(
-                    [0, *consumed_selector_ends],
-                    [*(selector.start() for selector in selectors), len(expression)],
-                )
-            )
-            selector_free = re.sub(r'"(?:\\.|[^"\\])*"', "", without_selectors)
-            if re.search(
-                r"\$(?:[a-zA-Z_][a-zA-Z0-9_]*|\{[a-zA-Z_][a-zA-Z0-9_]*\})",
-                selector_free,
-            ):
-                raise SystemExit(
-                    f"ERROR: {title} contains a template variable outside its permitted "
-                    "canonical selector or rate range."
-                )
-            if "[" in selector_free or "]" in selector_free:
-                raise SystemExit(f"ERROR: {title} contains an invalid range expression.")
-            selector_free = re.sub(
-                r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^()]*\)",
-                "",
-                selector_free,
-            )
-            selector_free = re.sub(
-                rf"\b(?:{'|'.join(TOKENPLACE_PROMQL_FUNCTIONS)})\s*(?=\()",
-                "",
-                selector_free,
-            )
-            selector_free = re.sub(
-                rf"\b(?:{'|'.join(TOKENPLACE_PROMQL_MODIFIERS)})\b",
-                "",
-                selector_free,
-            )
-            selector_free = re.sub(
-                r"(?<![a-zA-Z_:])(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?",
-                "",
-                selector_free,
-                flags=re.IGNORECASE,
-            )
-            if re.search(r"\b[a-zA-Z_:][a-zA-Z0-9_:]*\b", selector_free):
-                raise SystemExit(
-                    f"ERROR: {title} contains a bare or unverified metric selector; "
-                    "the canonical target selector is required."
-                )
-        if found != intended:
-            raise SystemExit(f"ERROR: {title} must use its intended metric family.")
-
-    for title in (
-        "token.place scrape availability",
-        "token.place instrumentation health",
-    ):
-        panel = token_panels_by_title[title]
-        target = panel["targets"][0]
-        mappings = panel.get("fieldConfig", {}).get("defaults", {}).get("mappings", [])
-        mapping_options = mappings[0].get("options", {}) if len(mappings) == 1 else {}
-        if (
-            target.get("instant") is not True
-            or target.get("range") is not False
-            or mapping_options.get("0", {}).get("text") != "UNHEALTHY"
-            or mapping_options.get("1", {}).get("text") != "HEALTHY"
-            or panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA"
-        ):
-            raise SystemExit(
-                "ERROR: token.place health stats must be instant-only and distinguish "
-                "healthy, unhealthy, and NO DATA."
-            )
-
-    logical = {
-        "tokenplace_compute_nodes_registered",
-        "tokenplace_compute_nodes_healthy",
-        "tokenplace_compute_node_lease_age_seconds",
-        "tokenplace_relay_queue_depth",
-        "tokenplace_relay_oldest_queued_request_age_seconds",
-    }
-    for metric in logical:
-        matching = [expression for expression in expressions if metric in expression]
-        if not matching or any(
-            not re.search(rf"\bmax(?:\s+by\s*\([^)]*\))?\s*\([^)]*{metric}", expression)
-            for expression in matching
-        ):
-            raise SystemExit(f"ERROR: logical gauge {metric} must use explicit max deduplication.")
-
-    direct_max = {
-        "tokenplace_compute_nodes_registered",
-        "tokenplace_compute_nodes_healthy",
-        "tokenplace_compute_node_lease_age_seconds",
-    }
-    for metric in direct_max:
-        expression = next(expr for expr in expressions if metric in expr)
-        if not re.match(rf"^max\s*\(\s*{metric}\{{", expression):
-            raise SystemExit(f"ERROR: logical gauge {metric} must use direct max deduplication.")
-
-    grouped_gauges = {
-        "token.place relay queue depth": ("tokenplace_relay_queue_depth", "provider_mode"),
-        "token.place oldest queued-request age": (
-            "tokenplace_relay_oldest_queued_request_age_seconds",
-            "provider_mode",
-        ),
-        "token.place in-flight requests by pod": (
-            "tokenplace_relay_in_flight_requests",
-            "pod",
-        ),
-        "token.place oldest in-flight age by pod": (
-            "tokenplace_relay_oldest_in_flight_age_seconds",
-            "pod",
-        ),
-    }
-    for title, (metric, label) in grouped_gauges.items():
-        target = token_panels_by_title[title]["targets"][0]
-        if not re.match(rf"^max\s+by\s*\(\s*{label}\s*\)\s*\(\s*{metric}\{{", target["expr"]):
-            qualifier = "remain per pod and " if label == "pod" else ""
-            raise SystemExit(f"ERROR: {title} must {qualifier}use max by ({label}).")
-        if target.get("legendFormat") != f"{{{{{label}}}}}":
-            raise SystemExit(f"ERROR: {title} must use a {label} legend.")
-
-    counters = {
-        "tokenplace_compute_node_evictions_total": "reason",
-        "tokenplace_relay_request_outcomes_total": "outcome",
-        "tokenplace_http_requests_total": None,
-    }
-    for metric, bounded_group in counters.items():
-        matching = [expression for expression in expressions if metric in expression]
-        if not matching or any(
-            "sum" not in expression
-            or f"rate({metric}" not in expression
-            or "[$__rate_interval]" not in expression
-            for expression in matching
-        ):
-            raise SystemExit(f"ERROR: process-local counter {metric} must use a summed rate.")
-        if bounded_group and any(
-            f"sum by ({bounded_group})" not in expression for expression in matching
-        ):
-            raise SystemExit(f"ERROR: {metric} must remain grouped by bounded {bounded_group}.")
-
-    direct_counter_groups = {
-        "tokenplace_compute_node_evictions_total": "reason",
-        "tokenplace_relay_request_outcomes_total": "outcome",
-    }
-    for metric, label in direct_counter_groups.items():
-        expression = next(expr for expr in expressions if metric in expr)
-        pattern = (
-            rf"^sum\s+by\s*\(\s*{label}\s*\)\s*\(\s*rate\s*\(\s*"
-            rf"{metric}\{{.*\}}\[\$__rate_interval\]\s*\)\s*\)\s*$"
-        )
-        if not re.match(pattern, expression):
-            raise SystemExit(f"ERROR: {metric} must directly use sum by ({label}) of rate.")
-
-    request_rate = token_panels_by_title["token.place HTTP request rate"]["targets"][0]["expr"]
-    if not re.match(
-        r"^sum\s+by\s*\(\s*route\s*,\s*status_class\s*\)\s*\(\s*rate\s*\(\s*"
-        r"tokenplace_http_requests_total\{.*\}\[\$__rate_interval\]\s*\)\s*\)\s*$",
-        request_rate,
-    ):
-        raise SystemExit(
-            "ERROR: token.place HTTP request rate must group by route and status_class."
-        )
-
-    ratio = token_panels_by_title["token.place HTTP 5xx ratio"]["targets"][0]["expr"]
-    numerator, separator, denominator = ratio.partition(" / ")
-    if (
-        not separator
-        or 'status_class="5xx"' not in numerator
-        or re.search(r"status_class\s*(?:=|=~|!=|!~)", denominator)
-        or not re.match(r"^clamp_min\s*\(\s*sum\s*\(\s*rate\s*\(", denominator)
-        or not re.search(r"\)\s*,\s*1e-9\s*\)\s*$", denominator)
-    ):
-        raise SystemExit(
-            "ERROR: token.place HTTP 5xx ratio must select 5xx and use an unfiltered "
-            "clamp_min denominator."
-        )
-
-    for title in (
-        "token.place in-flight requests by pod",
-        "token.place oldest in-flight age by pod",
-    ):
-        target = panel_named(dashboard, title).get("targets", [{}])[0]
-        if "by (pod)" not in target.get("expr", "") or "{{pod}}" not in target.get(
-            "legendFormat", ""
-        ):
-            raise SystemExit("ERROR: token.place in-flight gauges must remain visible per pod.")
-    build = panel_named(dashboard, "token.place build identity")
-    build_target = build.get("targets", [{}])[0]
-    if (
-        "max by (pod, version, revision)" not in build_target.get("expr", "")
-        or build_target.get("legendFormat") != "{{pod}} {{version}} {{revision}}"
-        or build_target.get("instant") is not True
-        or build_target.get("range") is not False
-    ):
-        raise SystemExit(
-            "ERROR: token.place build identity must remain per pod, version, and revision."
-        )
-    latency = panel_named(dashboard, "token.place HTTP latency percentiles")
-    if {target.get("legendFormat", "").split(" ", 1)[0] for target in latency["targets"]} != {
-        "p50",
-        "p95",
-        "p99",
-    } or any(
-        "histogram_quantile(" not in target.get("expr", "")
-        or "sum by (le, route)" not in target.get("expr", "")
-        or "rate(tokenplace_http_request_duration_seconds_bucket" not in target.get("expr", "")
-        for target in latency.get("targets", [])
-    ):
-        raise SystemExit(
-            "ERROR: token.place latency must use histogram bucket rates and bounded grouping."
-        )
+    rows = [panel.get("title") for panel in panel_list if panel.get("type") == "row"]
+    if rows != ROW_TITLES:
+        raise SystemExit("ERROR: canonical dashboard row order changed.")
+    _validate_grid(panel_list)
+    _validate_tables(dashboard)
+    if dashboard.get("schemaVersion") != 41 or dashboard.get("timezone") != "browser":
+        raise SystemExit("ERROR: dashboard schema version or timezone changed.")
+    if dashboard.get("editable") is not False or dashboard.get("refresh") != "30s":
+        raise SystemExit("ERROR: dashboard immutability or refresh defaults changed.")
+    if dashboard.get("time") != {"from": "now-6h", "to": "now"}:
+        raise SystemExit("ERROR: dashboard default time range changed.")
+    data_panels = [panel for panel in panel_list if panel.get("type") not in {"row", "text"}]
     if any(
         panel.get("fieldConfig", {}).get("defaults", {}).get("noValue") != "NO DATA"
-        for panel in token_panels
+        for panel in data_panels
     ):
-        raise SystemExit("ERROR: token.place panels must display missing series as NO DATA.")
-
-    token_serialized = json.dumps(token_panels)
-    expression_text = "\n".join(expressions)
-    used_labels = set(
-        re.findall(r"(?:\{|,)\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:=|=~|!=|!~)", expression_text)
+        raise SystemExit(
+            "ERROR: every data panel must explicitly display absent telemetry as NO DATA."
+        )
+    serialized = json.dumps(dashboard)
+    expressions = "\n".join(
+        target.get("expr", "")
+        for panel in data_panels
+        for target in panel.get("targets", [])
+        if isinstance(target.get("expr"), str)
     )
-    for labels in re.findall(
-        r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\(([^)]*)\)",
-        expression_text,
+    zero_fallback_panels = [
+        panel.get("title")
+        for panel in data_panels
+        for target in panel.get("targets", [])
+        if "or vector(0)" in target.get("expr", "") or "or on() vector(0)" in target.get("expr", "")
+    ]
+    if zero_fallback_panels != ["Public availability summary"]:
+        raise SystemExit("ERROR: only retention-backed probe presence may use vector(0).")
+    for title in ("dChat request activity", "token.place dependency request activity"):
+        expression = panel_named(dashboard, title)["targets"][0]["expr"]
+        if "dspace_instrumentation_up" not in expression or "0 *" not in expression:
+            raise SystemExit("ERROR: event-rate zeroes must be instrumentation-gated.")
+    for title in (
+        "Image-pin agreement",
+        "DSPACE metrics-target health",
+        "/chat synthetic result and freshness",
     ):
-        used_labels.update(label.strip() for label in labels.split(",") if label.strip())
-    used_labels.update(re.findall(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}", token_serialized))
-    if not used_labels <= TOKENPLACE_LABELS:
-        raise SystemExit("ERROR: token.place queries or legends contain an unsafe label.")
-    if any(metric in token_serialized for metric in PHASE_TWO_METRICS):
-        raise SystemExit("ERROR: token.place Phase 2 metrics must not be presented as implemented.")
+        expressions_for_panel = " ".join(
+            target.get("expr", "") for target in panel_named(dashboard, title).get("targets", [])
+        )
+        if (
+            "0 *" in expressions_for_panel
+            and "dspace_release_approved_info" not in expressions_for_panel
+        ):
+            raise SystemExit(
+                "ERROR: DSPACE failure zeroes must be approved-release capability-gated."
+            )
+    image_pin = panel_named(dashboard, "Image-pin agreement")["targets"][0]["expr"]
+    if '"image", "(.*)"' not in image_pin or '"image_digest", "(.*)"' not in image_pin:
+        raise SystemExit("ERROR: image-pin agreement must join approved image and digest labels.")
+    blackbox = " ".join(
+        target.get("expr", "")
+        for title in (
+            "Public availability summary",
+            "Endpoint matrix",
+            "Probe duration",
+            "HTTP response status",
+            "TLS certificate lifetime",
+        )
+        for target in panel_named(dashboard, title).get("targets", [])
+    )
+    if "-$environment-.*" not in blackbox or "-staging-.*" in blackbox:
+        raise SystemExit("ERROR: blackbox jobs must be selected through $environment.")
+    tokenplace = " ".join(
+        target.get("expr", "")
+        for panel in data_panels
+        if panel.get("title", "").startswith("token.place")
+        for target in panel.get("targets", [])
+    )
+    for matcher in (
+        'app="tokenplace"',
+        'environment=~"$environment"',
+        'release="tokenplace"',
+        'cluster=~"$cluster"',
+        'namespace="tokenplace"',
+    ):
+        if matcher not in tokenplace:
+            raise SystemExit("ERROR: token.place queries must retain bounded profile matchers.")
+    core_titles = {
+        "Scrape availability by job",
+        "Ready nodes",
+        "Node readiness",
+        "Deployment replica deficit",
+        "Unready pods by namespace",
+        "Problem pods by namespace",
+        "Container restart rate",
+        "Node CPU utilization",
+        "Node memory utilization",
+        "Root filesystem utilization",
+        "Prometheus PVC utilization",
+        "Prometheus active series",
+        "Observability component build identity",
+    }
+    core = " ".join(
+        target.get("expr", "")
+        for panel in data_panels
+        if panel.get("title") in core_titles
+        for target in panel.get("targets", [])
+    )
+    if re.search(r"cluster\s*(?:=|=~)", core):
+        raise SystemExit("ERROR: local core queries must not require external cluster labels.")
+    if "kube_state_metrics_build_info" in serialized:
+        raise SystemExit("ERROR: unavailable kube-state-metrics build identity is forbidden.")
+    if FORBIDDEN_IDENTITY.search(serialized):
+        raise SystemExit("ERROR: dashboard legends expose a forbidden raw identity label.")
+    if any(
+        name in serialized
+        for name in (
+            "tokenplace_chat_availability",
+            "tokenplace_compute_nodes_schedulable",
+            "tokenplace_shared_state_health",
+        )
+    ):
+        raise SystemExit("ERROR: token.place Phase 2 metrics must remain absent.")
+    datasource_uids = set(re.findall(r'"uid":\s*"([^"]+)"', serialized))
+    if (
+        not datasource_uids <= {DATASOURCE_UID, dashboard["uid"]}
+        or DATASOURCE_UID not in datasource_uids
+    ):
+        raise SystemExit("ERROR: dashboard datasource references must use Prometheus UID.")
 
 
 def validate_dashboard(path: Path) -> str:
-    dashboard = load_dashboard(path)
-    production = configure_profile(dashboard)
-    ids = [panel.get("id") for panel in panels(dashboard)]
-    if (
-        not ids
-        or any(not isinstance(panel_id, int) for panel_id in ids)
-        or len(ids) != len(set(ids))
-    ):
-        raise SystemExit("ERROR: dashboard panel IDs must be present, integer, and unique.")
-    positions = []
-    for panel in panels(dashboard):
-        position = panel.get("gridPos", {})
-        if (
-            any(not isinstance(position.get(key), int) for key in ("x", "y", "w", "h"))
-            or position.get("x", -1) < 0
-            or position.get("y", -1) < 0
-            or position.get("w", 0) <= 0
-            or position.get("h", 0) <= 0
-            or position.get("x", 0) + position.get("w", 0) > 24
-        ):
-            raise SystemExit("ERROR: dashboard panels must have valid integer grid positions.")
-        if panel.get("type") == "row":
-            continue
-        rectangle = (
-            position["x"],
-            position["y"],
-            position["x"] + position["w"],
-            position["y"] + position["h"],
-        )
-        if any(
-            rectangle[0] < other[2]
-            and rectangle[2] > other[0]
-            and rectangle[1] < other[3]
-            and rectangle[3] > other[1]
-            for other in positions
-        ):
-            raise SystemExit("ERROR: dashboard panel grid positions must not overlap.")
-        positions.append(rectangle)
-    if production:
-        validate_production_dashboard(dashboard)
-        return path.read_text(encoding="utf-8")
-    validate_dashboard_semantics(dashboard)
-    validate_tokenplace_semantics(dashboard)
-    expressions = [
-        target["expr"]
-        for panel in panels(dashboard)
-        for target in panel.get("targets", [])
-        if isinstance(target, dict) and isinstance(target.get("expr"), str)
-    ]
-    expression_text = "\n".join(expressions)
-    missing = sorted(metric for metric in REQUIRED_METRICS if metric not in expression_text)
-    if missing:
+    """Validate identity, canonical bytes, shared layout, and semantic safety."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+        dashboard = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"ERROR: dashboard JSON is missing or malformed: {error}") from error
+    if not isinstance(dashboard, dict):
+        raise SystemExit("ERROR: dashboard JSON root must be an object.")
+    profile_name = configure_profile(dashboard)
+    expected = serialized_dashboard(profile_name)
+    if raw != expected:
+        raise SystemExit("ERROR: dashboard differs from its canonical generated profile.")
+    _validate_variables(dashboard, profile_name)
+    _validate_semantics(dashboard)
+    other_name = "prod" if profile_name == "staging" else "staging"
+    other_path = PROFILES[other_name]["path"]
+    try:
+        other = json.loads(other_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise SystemExit(
-            f"ERROR: dashboard is missing required PromQL metrics: {', '.join(missing)}"
-        )
-    for metric in EVENT_METRICS:
-        matching = [expr for expr in expressions if metric in expr]
-        if not matching or any("or on() vector(0)" not in expr for expr in matching):
-            raise SystemExit(f"ERROR: event-driven metric {metric} must use a safe zero fallback.")
-    serialized = json.dumps(dashboard)
-    urls = set(re.findall(r"https?://[^)\\\" ]+", serialized, re.IGNORECASE))
-    approved_urls = {
-        "https://github.com/futuroptimist/sugarkube/blob/main/docs/"
-        "observability-dspace-release-integrity.md",
-        "https://github.com/futuroptimist/sugarkube/blob/main/deployment-evidence/"
-        "dspace/staging/main-018687f-20260805T035722Z.json",
-    }
-    if urls != approved_urls:
-        raise SystemExit(
-            "ERROR: dashboard raw URLs must be the exact reviewed runbook/evidence allowlist."
-        )
-    if re.search(r"\$\{?DS_|__inputs", serialized, re.IGNORECASE) or re.search(
-        r"(?:\{|,)\s*target\s*(?:=|=~|!~|!=)|{{\s*target\s*}}", expression_text
-    ):
-        raise SystemExit(
-            "ERROR: dashboard contains a datasource placeholder or unsafe raw target label."
-        )
-    datasource_refs = re.findall(r'"uid":\s*"([^"]+)"', serialized)
-    if DATASOURCE_UID not in datasource_refs or any(
-        uid not in {DATASOURCE_UID, UID} for uid in datasource_refs
-    ):
-        raise SystemExit(
-            "ERROR: dashboard datasource references must use the rendered Prometheus UID."
-        )
-    return path.read_text(encoding="utf-8")
+            f"ERROR: peer generated dashboard is missing or malformed: {error}"
+        ) from error
+    if dashboard.get("panels") != other.get("panels"):
+        raise SystemExit("ERROR: staging and production panel arrays must be identical.")
+    return raw
 
 
 def validate_render(path: Path, dashboard_json: str) -> None:
@@ -1042,9 +431,9 @@ def validate_render(path: Path, dashboard_json: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("dashboard", type=Path)
-    parser.add_argument("--rendered", type=Path)
+    parser.add_argument("--rendered", type=Path, help="also validate a rendered Helm manifest")
     args = parser.parse_args()
     dashboard_json = validate_dashboard(args.dashboard)
     if args.rendered:

--- a/tests/test_observability_dashboard.py
+++ b/tests/test_observability_dashboard.py
@@ -1,6 +1,7 @@
+"""Contracts for the generated, shared Sugarkube observability dashboard."""
+
+import copy
 import json
-import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -8,1385 +9,210 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-DASHBOARD = ROOT / "clusters/staging/observability/dashboards/sugarkube-staging-observability.json"
-PROD_DASHBOARD = ROOT / "clusters/prod/observability/dashboards/sugarkube-prod-observability.json"
-VALIDATOR = ROOT / "scripts/validate_observability_dashboard.py"
-SCRIPT = ROOT / "scripts/observability_helm.sh"
-PROMETHEUS_VALUES = ROOT / "platform/observability/helm/kube-prometheus-stack.values.common.yaml"
-
-# Import the validator so pytest-cov attributes its execution to the production
-# module. Subprocess-only checks prove the command-line contract, but their
-# coverage data is not collected by the parent pytest process.
 sys.path.insert(0, str(ROOT))
+
+from scripts import generate_observability_dashboards as generator  # noqa: E402
 from scripts import validate_observability_dashboard as validator  # noqa: E402
 
-
-def all_panels(document):
-    for panel in document["panels"]:
-        yield panel
-        yield from panel.get("panels", [])
+STAGING = generator.PROFILES["staging"]["path"]
+PROD = generator.PROFILES["prod"]["path"]
 
 
-def replace_metric_expression(document, metric, replacement):
-    target = next(
-        target
-        for panel in all_panels(document)
-        for target in panel.get("targets", [])
-        if metric in target.get("expr", "")
-    )
-    target["expr"] = replacement
+def load(path):
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
-def replace_panel_expression(document, title, replacement):
-    panel = next(panel for panel in all_panels(document) if panel["title"] == title)
-    panel["targets"][0]["expr"] = replacement
+def panel(document, title):
+    return next(item for item in document["panels"] if item["title"] == title)
 
 
-def production_panel(document, title):
-    return next(panel for panel in all_panels(document) if panel["title"] == title)
+def expressions(document, title):
+    return [target["expr"] for target in panel(document, title).get("targets", [])]
 
 
-def add_row_expression(document, expression):
-    production_panel(document, "Cluster health")["targets"] = [{"expr": expression}]
-
-
-@pytest.fixture
-def dashboard():
-    return json.loads(DASHBOARD.read_text(encoding="utf-8"))
-
-
-@pytest.fixture
-def prod_dashboard():
-    return json.loads(PROD_DASHBOARD.read_text(encoding="utf-8"))
-
-
-def test_production_dashboard_live_backed_contract(prod_dashboard):
-    assert prod_dashboard["uid"] == "sugarkube-prod-observability"
-    assert prod_dashboard["title"] == "Sugarkube Production Observability"
-    assert prod_dashboard["time"] == {"from": "now-6h", "to": "now"}
-    assert prod_dashboard["refresh"] == "30s"
-    assert prod_dashboard["templating"]["list"] == []
-    panels = list(all_panels(prod_dashboard))
-    assert len(panels) == 17
-    assert len({panel["id"] for panel in panels}) == 17
-    assert {panel["title"] for panel in panels if panel["type"] == "row"} == {
-        "Cluster health",
-        "Workload health",
-        "Node and Prometheus capacity",
-        "Observability build identity",
-    }
-    expressions = "\n".join(
-        target["expr"] for panel in panels for target in panel.get("targets", [])
-    )
-    metrics = set(re.findall(r"\b[a-zA-Z_:][a-zA-Z0-9_:]*", expressions))
-    expected = {
-        "up",
-        "kube_node_status_condition",
-        "kube_deployment_spec_replicas",
-        "kube_deployment_status_replicas_available",
-        "kube_pod_status_ready",
-        "kube_pod_status_phase",
-        "kube_pod_container_status_restarts_total",
-        "node_cpu_seconds_total",
-        "node_uname_info",
-        "node_memory_MemAvailable_bytes",
-        "node_memory_MemTotal_bytes",
-        "node_filesystem_avail_bytes",
-        "node_filesystem_size_bytes",
-        "kubelet_volume_stats_available_bytes",
-        "kubelet_volume_stats_capacity_bytes",
-        "prometheus_tsdb_head_series",
-        "prometheus_build_info",
-        "alertmanager_build_info",
-        "grafana_build_info",
-        "node_exporter_build_info",
-    }
-    assert expected <= metrics
-    assert "kube_state_metrics_build_info" not in expressions
-    assert "cluster=" not in expressions and "vector(0)" not in expressions
-    assert expressions.count("$__rate_interval") == 2
-    assert all(
-        panel["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
-        for panel in panels
-        if panel["type"] != "row"
-    )
-    validator.validate_dashboard(PROD_DASHBOARD)
-
-
-def test_production_snapshot_and_unready_pod_contracts(prod_dashboard):
-    panels = {panel["title"]: panel for panel in all_panels(prod_dashboard)}
-    snapshot_tables = {
-        "Scrape availability by job",
-        "Node readiness",
-        "Deployment replica deficit",
-        "Observability component build identity",
-    }
-    assert all(
-        target.get("format") == "table"
-        and target.get("instant") is True
-        and target.get("range") is False
-        for title in snapshot_tables
-        for target in panels[title]["targets"]
-    )
-    expected_columns = {
-        "Scrape availability by job": {"job": 0, "Value": 1},
-        "Node readiness": {"node": 0, "Value": 1},
-        "Deployment replica deficit": {"namespace": 0, "deployment": 1, "Value": 2},
-        "Observability component build identity": {
-            "component": 0,
-            "pod": 1,
-            "version": 2,
-            "revision": 3,
-        },
-    }
-    expected_headings = {
-        "Scrape availability by job": {"job": "Job", "Value": "Status"},
-        "Node readiness": {"node": "Node", "Value": "Status"},
-        "Deployment replica deficit": {
-            "namespace": "Namespace",
-            "deployment": "Deployment",
-            "Value": "Replica deficit",
-        },
-        "Observability component build identity": {
-            "component": "Component",
-            "pod": "Pod",
-            "version": "Version",
-            "revision": "Revision",
-        },
-    }
-    for title, columns in expected_columns.items():
-        assert len(panels[title]["targets"]) == 1
-        assert len(panels[title]["transformations"]) == 1
-        assert panels[title]["transformations"][0]["id"] == "organize"
-        assert panels[title]["transformations"][0]["options"]["indexByName"] == columns
-        assert (
-            panels[title]["transformations"][0]["options"]["renameByName"]
-            == expected_headings[title]
-        )
-    build = panels["Observability component build identity"]["targets"][0]["expr"]
-    assert build.startswith("max by (component, pod, version, revision) (")
-    assert {
-        match[1]
-        for match in re.findall(
-            r'label_replace\((\w+), "component", "([\w-]+)", "", ""\)', build
-        )
-    } == {"prometheus", "alertmanager", "grafana", "node-exporter"}
-    unready = panels["Unready pods by namespace"]["targets"][0]["expr"]
-    assert 'kube_pod_status_phase{phase=~"Pending|Running|Unknown"} == 1' in unready
-    assert "group_left" in unready
-
-
-@pytest.mark.parametrize(
-    ("mutation", "message"),
-    [
-        (lambda d: d.update(uid="wrong"), "supported profile"),
-        (lambda d: d["panels"].append(d["panels"][1]), "IDs"),
-        (lambda d: d["panels"].pop(), "every required row and panel"),
-        (lambda d: production_panel(d, "Cluster health").update(type="stat"), "row contract"),
-        (
-            lambda d: d["panels"][8]["targets"][0].update(
-                expr="rate(kube_pod_container_status_restarts_total[5m])"
-            ),
-            "PromQL contract",
-        ),
-        (
-            lambda d: d["panels"][1]["targets"][0].update(
-                expr='min by (job) (up{cluster="sugarkube-prod"})'
-            ),
-            "PromQL contract",
-        ),
-        (
-            lambda d: d["panels"][14]["targets"][0].update(expr="sum(prometheus_tsdb_head_series)"),
-            "PromQL contract",
-        ),
-        (lambda d: d["panels"][1]["targets"][0].update(instant=False, range=True), "instant-only"),
-        (
-            lambda d: production_panel(d, "Observability component build identity").update(
-                type="stat"
-            ),
-            "consolidate into one frame",
-        ),
-        (
-            lambda d: production_panel(d, "Observability component build identity")["targets"][
-                0
-            ].update(expr="max by (instance) (prometheus_build_info)"),
-            "bounded component/pod/version/revision",
-        ),
-        (lambda d: d["panels"][1]["targets"][0].update(format="time_series"), "table-formatted"),
-        (
-            lambda d: d["panels"][1]["transformations"][0].update(id="reduce"),
-            "field organization",
-        ),
-        (
-            lambda d: d["panels"][1]["transformations"][0]["options"][
-                "indexByName"
-            ].pop("Value"),
-            "table columns",
-        ),
-        (
-            lambda d: d["panels"][1]["transformations"][0]["options"][
-                "renameByName"
-            ].pop("Value"),
-            "headings",
-        ),
-        (
-            lambda d: d["panels"][3]["transformations"][0]["options"][
-                "renameByName"
-            ].update(node="Host"),
-            "headings",
-        ),
-        (lambda d: d.update(refresh="1m"), "defaults or variables"),
-        (lambda d: add_row_expression(d, "or vector(0)"), "preserve missing data"),
-        (lambda d: add_row_expression(d, "probe_success"), "unverified signal"),
-        (
-            lambda d: production_panel(d, "Ready nodes")["targets"][0].update(
-                legendFormat="{{instance}}"
-            ),
-            "forbidden raw identity",
-        ),
-        (
-            lambda d: production_panel(d, "Node CPU utilization")["targets"][0].update(
-                legendFormat="{{node}}"
-            ),
-            "only nodename",
-        ),
-        (
-            lambda d: production_panel(d, "Node memory utilization")["fieldConfig"][
-                "defaults"
-            ].update(max=99),
-            "0-100 percent scale",
-        ),
-        (
-            lambda d: production_panel(d, "Ready nodes")["fieldConfig"]["defaults"].update(
-                noValue="0"
-            ),
-            "preserve NO DATA",
-        ),
-        (
-            lambda d: production_panel(d, "Ready nodes")["datasource"].update(uid="other"),
-            "Prometheus UID",
-        ),
-    ],
-)
-def test_production_validator_fails_closed(tmp_path, prod_dashboard, mutation, message):
-    mutation(prod_dashboard)
+def write_mutation(tmp_path, document):
     path = tmp_path / "dashboard.json"
-    path.write_text(json.dumps(prod_dashboard), encoding="utf-8")
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_dashboard(path)
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    return path
 
 
-def test_dashboard_identity_defaults_rows_and_required_panels(dashboard):
-    assert dashboard["uid"] == "sugarkube-staging-observability"
-    assert dashboard["title"] == "Sugarkube Staging Observability"
-    assert dashboard["time"] == {"from": "now-6h", "to": "now"}
+def test_generated_artifacts_are_current_and_valid():
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts/generate_observability_dashboards.py"), "--check"],
+        cwd=ROOT,
+        check=True,
+    )
+    validator.validate_dashboard(STAGING)
+    validator.validate_dashboard(PROD)
+
+
+def test_profiles_share_exact_canonical_panels():
+    staging, prod = load(STAGING), load(PROD)
+    assert staging["panels"] == prod["panels"]
+    assert len(staging["panels"]) == 60
+    assert sum(item["type"] == "row" for item in staging["panels"]) == 11
+    assert [
+        item["title"] for item in staging["panels"] if item["type"] == "row"
+    ] == validator.ROW_TITLES
+
+
+def test_only_allowlisted_profile_fields_differ():
+    staging, prod = load(STAGING), load(PROD)
+    assert staging["uid"] == "sugarkube-staging-observability"
+    assert prod["uid"] == "sugarkube-prod-observability"
+    assert staging["title"] == "Sugarkube Staging Observability"
+    assert prod["title"] == "Sugarkube Production Observability"
+    assert staging["tags"][-1] == "staging"
+    assert prod["tags"][-1] == "prod"
+    for document, environment, cluster in (
+        (staging, "staging", "sugarkube-int"),
+        (prod, "prod", "sugarkube-prod"),
+    ):
+        variables = document["templating"]["list"]
+        assert [(item["name"], item["type"]) for item in variables] == [
+            ("environment", "constant"),
+            ("cluster", "constant"),
+            ("app", "query"),
+            ("route", "query"),
+        ]
+        assert variables[0]["query"] == environment
+        assert variables[1]["query"] == cluster
+        assert variables[2]["allValue"] == variables[3]["allValue"] == ".*"
+    normalized_staging = copy.deepcopy(staging)
+    normalized_prod = copy.deepcopy(prod)
+    for document in (normalized_staging, normalized_prod):
+        document["uid"] = document["title"] = document["tags"][-1] = "PROFILE"
+        for variable in document["templating"]["list"][:2]:
+            variable["query"] = "PROFILE"
+            variable["current"] = {"text": "PROFILE", "value": "PROFILE"}
+    assert normalized_staging == normalized_prod
+
+
+def test_canonical_dashboard_defaults_and_no_data_contract():
+    dashboard = load(STAGING)
+    assert dashboard["schemaVersion"] == 41
+    assert dashboard["timezone"] == "browser"
+    assert dashboard["editable"] is False
     assert dashboard["refresh"] == "30s"
-    panels = list(all_panels(dashboard))
-    assert len({panel["id"] for panel in panels}) == len(panels)
-    rows = {panel["title"] for panel in panels if panel["type"] == "row"}
-    assert rows == {
-        "Overall status",
-        "DSPACE HTTP",
-        "DSPACE runtime and release",
-        "DSPACE feature traffic",
-        "Blackbox monitoring",
-        "DSPACE release integrity",
-        "token.place relay and compute capacity",
-        "token.place HTTP and release",
-    }
-    titles = {panel["title"] for panel in panels}
-    for title in (
+    assert dashboard["time"] == {"from": "now-6h", "to": "now"}
+    for item in dashboard["panels"]:
+        if item["type"] not in {"row", "text"}:
+            assert item["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
+
+
+def test_all_ten_tables_are_simultaneous_single_frames():
+    tables = [item for item in load(STAGING)["panels"] if item["type"] == "table"]
+    assert len(tables) == 10
+    for item in tables:
+        assert len(item["targets"]) == 1
+        assert {key: item["targets"][0][key] for key in ("format", "instant", "range")} == {
+            "format": "table",
+            "instant": True,
+            "range": False,
+        }
+        assert len(item["transformations"]) == 1
+        assert item["transformations"][0]["id"] == "organize"
+
+
+def test_environment_neutral_and_bounded_selectors():
+    dashboard = load(STAGING)
+    blackbox = " ".join(
+        expression
+        for title in (
+            "Public availability summary",
+            "Endpoint matrix",
+            "Probe duration",
+            "HTTP response status",
+            "TLS certificate lifetime",
+        )
+        for expression in expressions(dashboard, title)
+    )
+    assert "-$environment-.*" in blackbox
+    tokenplace = " ".join(
+        target["expr"]
+        for item in dashboard["panels"]
+        if item["title"].startswith("token.place")
+        for target in item.get("targets", [])
+    )
+    assert 'cluster=~"$cluster"' in tokenplace
+    assert 'environment=~"$environment"' in tokenplace
+    assert 'namespace="tokenplace"' in tokenplace
+
+
+def test_absent_production_application_capabilities_remain_no_data_not_healthy_zero():
+    dashboard = load(PROD)
+    application_titles = [
         "DSPACE scrape availability",
-        "Instrumentation health",
-        "Public availability summary",
-        "User request rate by route and status class",
-        "Operational request rate",
-        "Status-class distribution",
-        "5xx error ratio",
-        "HTTP latency percentiles",
-        "Resident memory by pod",
-        "Build identity",
-        "dChat request activity",
-        "token.place dependency request activity",
+        "DSPACE instrumentation health",
         "Endpoint matrix",
-        "Probe duration",
-        "HTTP response status",
-        "TLS certificate lifetime",
+        "Approved revision",
         "token.place scrape availability",
         "token.place instrumentation health",
-        "token.place compute-node counts",
-        "token.place oldest compute-node lease age",
-        "token.place compute-node eviction rate",
-        "token.place relay queue depth",
-        "token.place oldest queued-request age",
-        "token.place in-flight requests by pod",
-        "token.place oldest in-flight age by pod",
-        "token.place terminal outcome rate",
-        "token.place HTTP request rate",
-        "token.place HTTP 5xx ratio",
-        "token.place HTTP latency percentiles",
-        "token.place build identity",
-    ):
-        assert title in titles
-
-
-def test_queries_use_stable_datasource_bounded_labels_and_safe_zero(dashboard):
-    serialized = json.dumps(dashboard)
-    expressions = [
-        target["expr"] for panel in all_panels(dashboard) for target in panel.get("targets", [])
     ]
-    assert '"uid": "prometheus"' in serialized
-    assert "${DS_" not in serialized and "__inputs" not in serialized
-    assert not any("{{target}}" in serialized or "target=~" in expr for expr in expressions)
-    assert "http://" not in serialized
-    assert serialized.count("https://github.com/futuroptimist/sugarkube/blob/main/") == 2
-    assert all(
-        "or on() vector(0)" in expr
-        for expr in expressions
-        if "dspace_dchat_requests_total" in expr or "dspace_dependency_requests_total" in expr
-    )
-    assert {item["name"] for item in dashboard["templating"]["list"]} == {
-        "environment",
-        "app",
-        "route",
-    }
+    for title in application_titles:
+        item = panel(dashboard, title)
+        assert item["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
+        assert all("vector(0)" not in target.get("expr", "") for target in item.get("targets", []))
+    for title in (
+        "Image-pin agreement",
+        "DSPACE metrics-target health",
+        "/chat synthetic result and freshness",
+    ):
+        joined = " ".join(expressions(dashboard, title))
+        assert "dspace_release_approved_info" in joined
+        if "0 *" in joined:
+            assert "count(dspace_release_approved_info" in joined
 
 
-def test_tokenplace_queries_are_replica_safe_bounded_and_preserve_missing_data(dashboard):
-    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
-    token_panels = [panels[title] for title in validator.TOKENPLACE_PANELS]
-    expressions = [target["expr"] for panel in token_panels for target in panel["targets"]]
-    selector = (
-        'app="tokenplace",environment=~"$environment",release="tokenplace",'
-        'cluster="sugarkube-int",namespace="tokenplace"'
-    )
-    assert all(selector in expression for expression in expressions)
-    assert all("vector(0)" not in expression for expression in expressions)
-    assert all(panel["fieldConfig"]["defaults"]["noValue"] == "NO DATA" for panel in token_panels)
-
-    counts = panels["token.place compute-node counts"]
-    assert all(target["expr"].startswith("max(") for target in counts["targets"])
-    assert panels["token.place relay queue depth"]["targets"][0]["expr"].startswith(
-        "max by (provider_mode)"
-    )
-    assert panels["token.place in-flight requests by pod"]["targets"][0]["expr"].startswith(
-        "max by (pod)"
-    )
-    assert (
-        "sum by (reason) (rate("
-        in panels["token.place compute-node eviction rate"]["targets"][0]["expr"]
-    )
-    assert (
-        "sum by (outcome) (rate("
-        in panels["token.place terminal outcome rate"]["targets"][0]["expr"]
-    )
-    assert (
-        "sum by (route, status_class) (rate("
-        in panels["token.place HTTP request rate"]["targets"][0]["expr"]
-    )
-
-    latency = panels["token.place HTTP latency percentiles"]
-    assert len(latency["targets"]) == 3
-    assert all("histogram_quantile(" in target["expr"] for target in latency["targets"])
-    assert all("sum by (le, route)" in target["expr"] for target in latency["targets"])
-    rate_expressions = [expression for expression in expressions if "rate(" in expression]
-    assert rate_expressions
-    assert all("[$__rate_interval]" in expression for expression in rate_expressions)
-    validator.validate_tokenplace_semantics(dashboard)
-    build = panels["token.place build identity"]["targets"][0]
-    assert build["expr"].startswith("max by (pod, version, revision)")
-    assert build["legendFormat"] == "{{pod}} {{version}} {{revision}}"
+def test_event_zeroes_require_instrumentation_capability():
+    dashboard = load(PROD)
+    for title in ("dChat request activity", "token.place dependency request activity"):
+        expression = expressions(dashboard, title)[0]
+        assert "0 *" in expression
+        assert "dspace_instrumentation_up" in expression
+        assert "vector(0)" not in expression
 
 
-@pytest.mark.parametrize(
-    "title",
-    ["token.place scrape availability", "token.place instrumentation health"],
-)
-@pytest.mark.parametrize("missing_flag", ["instant", "range"])
-def test_validator_rejects_missing_health_query_flags(dashboard, title, missing_flag):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(panel for panel in all_panels(changed) if panel["title"] == title)
-    panel["targets"][0].pop(missing_flag)
-    with pytest.raises(SystemExit, match="instant-only"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    ("title", "mutation"),
-    [
-        ("token.place HTTP 5xx ratio", lambda panel: panel.update(targets=[])),
-        (
-            "token.place terminal outcome rate",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace(
-                    "tokenplace_relay_request_outcomes_total",
-                    "tokenplace_compute_node_evictions_total",
-                )
-            ),
-        ),
-    ],
-)
-def test_validator_rejects_empty_or_metric_swapped_panels(dashboard, title, mutation):
-    changed = json.loads(json.dumps(dashboard))
-    mutation(next(panel for panel in all_panels(changed) if panel["title"] == title))
-    with pytest.raises(SystemExit):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_validator_rejects_queued_age_grouped_away_from_provider_mode(dashboard):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place oldest queued-request age"
-    )
-    panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace(
-        "by (provider_mode)", "by (pod)"
-    )
-    with pytest.raises(SystemExit, match="provider_mode"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize("mutation", ["4xx", "unclamped"])
-def test_validator_rejects_unsafe_http_5xx_ratio(dashboard, mutation):
-    changed = json.loads(json.dumps(dashboard))
-    target = next(
-        panel for panel in all_panels(changed) if panel["title"] == "token.place HTTP 5xx ratio"
-    )["targets"][0]
-    if mutation == "4xx":
-        target["expr"] = target["expr"].replace('status_class="5xx"', 'status_class="4xx"')
-    else:
-        target["expr"] = target["expr"].replace("clamp_min(", "(").replace(", 1e-9)", ")")
-    with pytest.raises(SystemExit, match="5xx ratio"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    ("label", "location"),
-    [
-        ("remote_addr", "matcher"),
-        ("node_id", "grouping"),
-        ("remote_addr", "legend"),
-    ],
-)
-def test_validator_rejects_unknown_tokenplace_labels(dashboard, label, location):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel for panel in all_panels(changed) if panel["title"] == "token.place relay queue depth"
-    )
-    target = panel["targets"][0]
-    if location == "matcher":
-        target["expr"] = target["expr"].replace(
-            'namespace="tokenplace"', f'namespace="tokenplace",{label}="raw"'
-        )
-    elif location == "grouping":
-        target["expr"] = target["expr"].replace(
-            "by (provider_mode)", f"by (provider_mode, {label})"
-        )
-    else:
-        target["legendFormat"] = f"{{{{provider_mode}}}} {{{{{label}}}}}"
-    with pytest.raises(SystemExit):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    "metric",
-    [
-        "tokenplace_relay_chat_available",
-        "tokenplace_relay_schedulable_compute_nodes",
-        "tokenplace_relay_chat_availability_state",
-        "tokenplace_relay_state_store_up",
-    ],
-)
-def test_validator_rejects_actual_phase_two_metrics(dashboard, metric):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel for panel in all_panels(changed) if panel["title"] == "token.place relay queue depth"
-    )
-    panel["description"] = f"Deferred metric: {metric}"
-    with pytest.raises(SystemExit, match="Phase 2"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    ("title", "mutation", "message"),
-    [
-        (
-            "token.place scrape availability",
-            lambda expression: f"{expression} or up",
-            "bare or unverified metric selector",
-        ),
-        (
-            "token.place scrape availability",
-            lambda expression: (
-                f"{expression} or tokenplace_unverified_future_metric{{"
-                'app="tokenplace",environment=~"$environment",release="tokenplace",'
-                'cluster="sugarkube-int",namespace="tokenplace"}'
-            ),
-            "intended metric family",
-        ),
-        (
-            "token.place instrumentation health",
-            lambda expression: f'label_replace({expression}, "remote_addr", "raw", "pod", "(.*)")',
-            "synthesize labels",
-        ),
-    ],
-)
-def test_validator_rejects_unscoped_unverified_or_synthesized_metrics(
-    dashboard, title, mutation, message
-):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(panel for panel in all_panels(changed) if panel["title"] == title)
-    panel["targets"][0]["expr"] = mutation(panel["targets"][0]["expr"])
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    "addition",
-    [
-        "process_cpu_seconds_total",
-        "probe_success",
-        "sum(arbitrary_external_metric_total) + 1",
-    ],
-)
-def test_validator_rejects_any_bare_metric_selector(dashboard, addition):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    expression = panel["targets"][0]["expr"]
-    panel["targets"][0]["expr"] = f"({expression}) or ({addition})"
-    with pytest.raises(SystemExit, match="bare or unverified metric selector"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    "variable",
-    ["$app", "$environment", "$__range", "$__rate_interval", "${app}"],
-)
-def test_validator_rejects_template_variables_in_metric_position(dashboard, variable):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    expression = panel["targets"][0]["expr"]
-    panel["targets"][0]["expr"] = f"({expression}) or ({variable})"
-    with pytest.raises(SystemExit, match="template variable outside"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_validator_rejects_canonical_matchers_hidden_in_backtick_value(dashboard):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    panel["targets"][0]["expr"] = (
-        "min by (pod) (up{route=`"
-        'app="tokenplace",environment=~"$environment",release="tokenplace",'
-        'cluster="sugarkube-int",namespace="tokenplace"`})'
-    )
-    with pytest.raises(SystemExit, match="canonical target selector"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    "extra_matcher",
-    [
-        'route=~"$app"',
-        'route=~"$environment"',
-        'pod=~"$__range"',
-        'app="tokenplace"',
-        'route="unexpected"',
-    ],
-)
-def test_validator_rejects_extra_dynamic_matchers(dashboard, extra_matcher):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace(
-        'namespace="tokenplace"', f'namespace="tokenplace",{extra_matcher}'
-    )
-    with pytest.raises(SystemExit, match="canonical target selector"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_validator_rejects_single_quoted_matcher(dashboard):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace(
-        'app="tokenplace"', "app='tokenplace'"
-    )
-    with pytest.raises(SystemExit, match="canonical target selector"):
-        validator.validate_tokenplace_semantics(changed)
+def test_image_pin_uses_approved_release_label_contract():
+    expression = expressions(load(STAGING), "Image-pin agreement")[0]
+    assert '"image", "(.*)"' in expression
+    assert '"image_digest", "(.*)"' in expression
+    assert "main-018687f" not in expression
+    assert "2b95b7fd" not in expression
 
 
 @pytest.mark.parametrize(
     "mutation",
     [
-        lambda expression: f"{expression}[$__rate_interval]",
-        lambda expression: f"{expression} + rate([$__rate_interval])",
+        lambda d: panel(d, "Ready nodes").update(title="Ready node count"),
+        lambda d: panel(d, "Ready nodes")["targets"][0].update(expr="vector(1)"),
+        lambda d: panel(d, "Ready nodes")["gridPos"].update(x=0),
+        lambda d: panel(d, "Ready nodes").update(type="timeseries"),
+        lambda d: panel(d, "Node readiness")["transformations"][0].update(id="reduce"),
+        lambda d: panel(d, "Ready nodes")["fieldConfig"]["defaults"].update(noValue="0"),
+        lambda d: d["templating"]["list"][0].update(query="staging"),
+        lambda d: panel(d, "Node readiness")["targets"][0].update(instant=False),
     ],
+    ids=["title", "query", "grid", "type", "transformation", "noValue", "variable", "target-mode"],
 )
-def test_validator_rejects_stray_rate_ranges(dashboard, mutation):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    panel["targets"][0]["expr"] = mutation(panel["targets"][0]["expr"])
-    with pytest.raises(SystemExit):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_validator_rejects_selector_range_outside_rate(dashboard):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(
-        panel
-        for panel in all_panels(changed)
-        if panel["title"] == "token.place scrape availability"
-    )
-    panel["targets"][0]["expr"] = panel["targets"][0]["expr"].replace("})", "}[$__rate_interval])")
-    with pytest.raises(SystemExit, match="range outside"):
-        validator.validate_tokenplace_semantics(changed)
-
-
-@pytest.mark.parametrize(
-    ("title", "mutation", "message"),
-    [
-        (
-            "token.place compute-node eviction rate",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace("[$__rate_interval]", "")
-            ),
-            "rate ranges",
-        ),
-        (
-            "token.place scrape availability",
-            lambda panel: panel["targets"][0].update(
-                expr=f'({panel["targets"][0]["expr"]}) + [5m]'
-            ),
-            "invalid range",
-        ),
-        (
-            "token.place instrumentation health",
-            lambda panel: panel["targets"][0].update(expr="1"),
-            "intended metric family",
-        ),
-        (
-            "token.place relay queue depth",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace("max by", "min by")
-            ),
-            "explicit max deduplication",
-        ),
-        (
-            "token.place compute-node counts",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace("max(", "max by (pod) (")
-            ),
-            "direct max deduplication",
-        ),
-        (
-            "token.place compute-node eviction rate",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace("sum by (reason)", "min")
-            ),
-            "summed rate",
-        ),
-        (
-            "token.place terminal outcome rate",
-            lambda panel: panel["targets"][0].update(expr=f'({panel["targets"][0]["expr"]})'),
-            "directly use",
-        ),
-        (
-            "token.place HTTP request rate",
-            lambda panel: panel["targets"][0].update(
-                expr=panel["targets"][0]["expr"].replace(
-                    "sum by (route, status_class)", "sum by (route)"
-                )
-            ),
-            "group by route",
-        ),
-        (
-            "token.place build identity",
-            lambda panel: panel["targets"][0].update(instant=False),
-            "build identity",
-        ),
-        (
-            "token.place HTTP latency percentiles",
-            lambda panel: panel["targets"][0].update(legendFormat="p90 {{route}}"),
-            "latency",
-        ),
-        (
-            "token.place relay queue depth",
-            lambda panel: panel["fieldConfig"]["defaults"].update(noValue="0"),
-            "NO DATA",
-        ),
-        (
-            "token.place scrape availability",
-            lambda panel: panel["targets"][0].update(legendFormat="{{remote_addr}}"),
-            "unsafe label",
-        ),
-    ],
-)
-def test_validator_rejects_tokenplace_contract_mutations(dashboard, title, mutation, message):
-    changed = json.loads(json.dumps(dashboard))
-    panel = next(panel for panel in all_panels(changed) if panel["title"] == title)
-    mutation(panel)
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_validator_rejects_duplicate_panel_and_non_row_heading(dashboard):
-    duplicate = json.loads(json.dumps(dashboard))
-    duplicate["panels"].append(
-        next(
-            panel
-            for panel in all_panels(duplicate)
-            if panel["title"] == "token.place scrape availability"
-        )
-    )
-    with pytest.raises(SystemExit, match="exactly one"):
-        validator.validate_tokenplace_semantics(duplicate)
-
-    non_row = json.loads(json.dumps(dashboard))
-    heading = next(
-        panel
-        for panel in all_panels(non_row)
-        if panel["title"] == "token.place relay and compute capacity"
-    )
-    heading["type"] = "stat"
-    with pytest.raises(SystemExit, match="section headings"):
-        validator.validate_tokenplace_semantics(non_row)
-
-
-@pytest.mark.parametrize(
-    ("title", "replacement", "message"),
-    [
-        (
-            "token.place compute-node counts",
-            "sum(tokenplace_compute_nodes_registered)",
-            "canonical target selector",
-        ),
-        (
-            "token.place terminal outcome rate",
-            "sum(rate(tokenplace_relay_request_outcomes_total{"
-            'app="tokenplace",environment=~"$environment",release="tokenplace",'
-            'cluster="sugarkube-int",namespace="tokenplace"}[$__rate_interval])) '
-            "or vector(0)",
-            "substituting zero",
-        ),
-        (
-            "token.place compute-node eviction rate",
-            "sum(rate(tokenplace_compute_node_evictions_total{"
-            'app="tokenplace",environment=~"$environment",release="tokenplace",'
-            'cluster="sugarkube-int",namespace="tokenplace"}[$__rate_interval]))',
-            "bounded reason",
-        ),
-        (
-            "token.place in-flight requests by pod",
-            "sum(tokenplace_relay_in_flight_requests{"
-            'app="tokenplace",environment=~"$environment",release="tokenplace",'
-            'cluster="sugarkube-int",namespace="tokenplace"})',
-            "per pod",
-        ),
-    ],
-)
-def test_validator_rejects_unsafe_tokenplace_query_regressions(
-    dashboard, title, replacement, message
-):
-    changed = json.loads(json.dumps(dashboard))
-    next(panel for panel in all_panels(changed) if panel["title"] == title)["targets"][0][
-        "expr"
-    ] = replacement
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_tokenplace_semantics(changed)
-
-
-def test_snapshot_tables_use_instant_queries(dashboard):
-    snapshots = {"Endpoint matrix", "Build identity", "HTTP response status"}
-    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
-    for title in snapshots:
-        assert panels[title]["targets"]
-        assert all(
-            target.get("instant") is True and target.get("range") is False
-            for target in panels[title]["targets"]
-        )
-    build = panels["Build identity"]
-    assert build["targets"][0]["expr"].startswith("max by (pod, version, revision) (")
-    organize = next(item for item in build["transformations"] if item["id"] == "organize")
-    assert organize["options"]["indexByName"] == {"pod": 0, "version": 1, "revision": 2}
-    assert organize["options"]["excludeByName"] == {"Time": True, "Value": True}
-
-
-def test_selected_window_traffic_and_availability_semantics(dashboard):
-    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
-
-    distribution = panels["Status-class distribution"]
-    assert distribution["type"] == "piechart"
-    assert all(
-        target.get("instant") is True and target.get("range") is False
-        for target in distribution["targets"]
-    )
-    assert "increase(" in distribution["targets"][0]["expr"]
-    assert "$__range" in distribution["targets"][0]["expr"]
-    colors = {
-        override["matcher"]["options"]: override["properties"][0]["value"]["fixedColor"]
-        for override in distribution["fieldConfig"]["overrides"]
-    }
-    assert colors == {"2xx": "green", "4xx": "orange", "5xx": "red"}
-
-    user_expression = panels["User request rate by route and status class"]["targets"][0]["expr"]
-    operational_expression = panels["Operational request rate"]["targets"][0]["expr"]
-    assert 'route!~"/(healthz|livez|metrics)"' in user_expression
-    assert 'route=~"/(healthz|livez|metrics)"' in operational_expression
-
-    summary = panels["Public availability summary"]
-    assert len(summary["targets"]) == 3
-    assert all(
-        target["instant"] is True and target["range"] is False for target in summary["targets"]
-    )
-    assert {target["legendFormat"] for target in summary["targets"]} == {
-        "Healthy endpoints",
-        "Failed endpoints",
-        "Missing probe data",
-    }
-    summary_expressions = {target["legendFormat"]: target["expr"] for target in summary["targets"]}
-    assert "sum(" in summary_expressions["Healthy endpoints"]
-    assert "== bool 1" in summary_expressions["Healthy endpoints"]
-    failed_expression = summary_expressions["Failed endpoints"]
-    assert "sum(" in failed_expression and "== bool 0" in failed_expression
-    missing_expression = summary_expressions["Missing probe data"]
-    assert "max_over_time(up{" in missing_expression
-    retention = next(
-        line.split(":", 1)[1].strip()
-        for line in PROMETHEUS_VALUES.read_text(encoding="utf-8").splitlines()
-        if line.strip().startswith("retention:")
-    )
-    assert f"[{retention}]" in missing_expression
-    assert ">= bool 0" in missing_expression
-    assert " - (sum(" in missing_expression
-    assert "probe_success{" in missing_expression
-    assert "or vector(0)" in missing_expression
-    assert all(
-        'job=~"probe/monitoring/blackbox-(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*"'
-        in expression
-        for expression in summary_expressions.values()
-    )
-    missing_override = next(
-        override
-        for override in summary["fieldConfig"]["overrides"]
-        if override["matcher"]["options"] == "Missing probe data"
-    )
-    assert missing_override["properties"][0]["value"]["fixedColor"] == "yellow"
-    assert summary["fieldConfig"]["defaults"]["noValue"] == "NO DATA"
-    assert panels["Endpoint matrix"]["type"] == "table"
-
-    variables = {item["name"]: item for item in dashboard["templating"]["list"]}
-    assert variables["app"]["label"] == "Probe application"
-    assert variables["route"]["label"] == "Probe route"
-
-
-def test_blackbox_queries_drop_raw_target_labels(dashboard):
-    panels = {panel["title"]: panel for panel in all_panels(dashboard)}
-    expected = {
-        "Endpoint matrix": "min",
-        "Probe duration": "max",
-        "HTTP response status": "max",
-        "TLS certificate lifetime": "min",
-    }
-    for title, aggregation in expected.items():
-        expression = panels[title]["targets"][0]["expr"]
-        assert f"{aggregation} by (environment, app, route) (" in expression
-        assert " by (environment, app, route, " not in expression
-        assert "instance" not in expression and "target" not in expression
-
-
-def test_validator_rejects_malformed_missing_and_changed_identity(tmp_path):
-    for content in ("{", "{}"):
-        candidate = tmp_path / f"candidate-{len(content)}.json"
-        candidate.write_text(content, encoding="utf-8")
-        result = subprocess.run(
-            ["python3", str(VALIDATOR), str(candidate)], capture_output=True, text=True
-        )
-        assert result.returncode != 0
-    missing = subprocess.run(
-        ["python3", str(VALIDATOR), str(tmp_path / "missing.json")], capture_output=True
-    )
-    assert missing.returncode != 0
-
-    for content in ("{", "[]"):
-        candidate = tmp_path / f"direct-{len(content)}.json"
-        candidate.write_text(content, encoding="utf-8")
-        with pytest.raises(SystemExit, match="dashboard JSON"):
-            validator.load_dashboard(candidate)
-    with pytest.raises(SystemExit, match="dashboard JSON"):
-        validator.load_dashboard(tmp_path / "direct-missing.json")
-
-
-def rendered_dashboard_yaml(dashboard, mount_path=None, sub_path=None):
-    filename = f"{dashboard['uid']}.json"
-    mount_path = mount_path or f"/var/lib/grafana/dashboards/sugarkube/{filename}"
-    sub_path = sub_path or filename
-    payload = json.dumps(dashboard, indent=2)
-    return (
-        "kind: ConfigMap\n"
-        "metadata:\n"
-        "  name: kube-prometheus-stack-grafana-dashboards-sugarkube\n"
-        "  labels:\n"
-        "    dashboard-provider: sugarkube\n"
-        "data:\n"
-        f"  {filename}:\n"
-        "    |-\n"
-        + "\n".join(f"      {line}" for line in payload.splitlines())
-        + "\n---\nkind: ConfigMap\ndata:\n  dashboardproviders.yaml: |\n"
-        "    providers:\n      - name: sugarkube\n        options:\n"
-        "          path: /var/lib/grafana/dashboards/sugarkube\n"
-        "---\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n"
-        "        - volumeMounts:\n"
-        "            - name: dashboards-sugarkube\n"
-        f'              mountPath: "{mount_path}"\n'
-        f'              subPath: "{sub_path}"\n'
-    )
-
-
-def run_render_validation(tmp_path, content):
-    rendered = tmp_path / "rendered.yaml"
-    rendered.write_text(content, encoding="utf-8")
-    return subprocess.run(
-        ["python3", str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)],
-        capture_output=True,
-        text=True,
-    )
-
-
-def test_validator_accepts_chart_native_render(tmp_path, dashboard):
-    result = run_render_validation(tmp_path, rendered_dashboard_yaml(dashboard))
-    assert result.returncode == 0, result.stderr
-
-    rendered = tmp_path / "direct-rendered.yaml"
-    rendered.write_text(rendered_dashboard_yaml(dashboard), encoding="utf-8")
-    dashboard_json = validator.validate_dashboard(DASHBOARD)
-    validator.validate_render(rendered, dashboard_json)
-
-
-def test_validator_accepts_production_rendered_source_equality(tmp_path, prod_dashboard):
-    rendered = tmp_path / "prod-rendered.yaml"
-    rendered.write_text(rendered_dashboard_yaml(prod_dashboard), encoding="utf-8")
-    dashboard_json = validator.validate_dashboard(PROD_DASHBOARD)
-    validator.validate_render(rendered, dashboard_json)
-
-
-def test_validator_accepts_single_quoted_render_scalars(tmp_path, dashboard):
-    rendered = tmp_path / "single-quoted.yaml"
-    content = rendered_dashboard_yaml(dashboard).replace(
-        "path: /var/lib/grafana/dashboards/sugarkube",
-        "path: '/var/lib/grafana/dashboards/sugarkube'",
-    )
-    rendered.write_text(content, encoding="utf-8")
-    validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
-
-
-def test_validator_main_validates_source_and_render(monkeypatch, tmp_path, dashboard):
-    rendered = tmp_path / "rendered.yaml"
-    rendered.write_text(rendered_dashboard_yaml(dashboard), encoding="utf-8")
-    monkeypatch.setattr(sys, "argv", [str(VALIDATOR), str(DASHBOARD)])
-    validator.main()
-    monkeypatch.setattr(sys, "argv", [str(VALIDATOR), str(DASHBOARD), "--rendered", str(rendered)])
-    validator.main()
-
-
-def test_validator_rejects_raw_urls_and_complete_render_drift(tmp_path, dashboard):
-    unsafe = tmp_path / "unsafe.json"
-    unsafe_dashboard = json.loads(json.dumps(dashboard))
-    unsafe_dashboard["links"] = [{"url": "https://example.invalid"}]
-    unsafe.write_text(json.dumps(unsafe_dashboard), encoding="utf-8")
-    result = subprocess.run(["python3", str(VALIDATOR), str(unsafe)], capture_output=True)
-    assert result.returncode != 0
-
-    changed = json.loads(json.dumps(dashboard))
-    changed["refresh"] = "5m"
-    result = run_render_validation(tmp_path, rendered_dashboard_yaml(changed))
-    assert result.returncode != 0
-    assert "differs from the version-controlled source" in result.stderr
-
-
-@pytest.mark.parametrize(
-    ("mount_path", "sub_path"),
-    [
-        ("/var/lib/grafana/dashboards/sugarkube", None),
-        (None, "another-dashboard.json"),
-    ],
-)
-def test_validator_rejects_wrong_dashboard_mount(tmp_path, dashboard, mount_path, sub_path):
-    result = run_render_validation(
-        tmp_path, rendered_dashboard_yaml(dashboard, mount_path, sub_path)
-    )
-    assert result.returncode != 0
-    assert "dashboard mount must be exactly" in result.stderr
-
-
-@pytest.mark.parametrize(
-    ("mutation", "message"),
-    [
-        (lambda item: item.update(uid="wrong"), "dashboard title"),
-        (lambda item: item.update(panels=[]), "panel IDs"),
-        (
-            lambda item: next(
-                variable for variable in item["templating"]["list"] if variable["name"] == "app"
-            ).update(label="Application"),
-            "probe-specific visible labels",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
-            ).update(type="timeseries"),
-            "categorical visualization",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
-            )["targets"][0].update(expr="sum(dspace_http_requests_total)"),
-            "summarize the selected window",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
-            )["fieldConfig"].update(overrides=[]),
-            "explicit status-class colors",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Operational request rate"
-            )["targets"][0].update(expr="sum(dspace_http_requests_total)"),
-            "retain health and metrics routes",
-        ),
-        (
-            lambda item: replace_metric_expression(item, "process_resident_memory_bytes", "0"),
-            "missing required PromQL metrics",
-        ),
-        (
-            lambda item: replace_metric_expression(
-                item, "dspace_dchat_requests_total", "dspace_dchat_requests_total"
-            ),
-            "must use a safe zero fallback",
-        ),
-        (lambda item: item.update(links=[{"url": "https://example.invalid"}]), "raw URLs"),
-        (lambda item: item.update(description="${DS_PROMETHEUS}"), "datasource placeholder"),
-        (lambda item: item.update(datasource={"uid": "unexpected"}), "datasource references"),
-        (
-            lambda item: next(
-                target
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for target in panel["targets"]
-                if target["legendFormat"] == "Missing probe data"
-            ).update(
-                expr=next(
-                    target["expr"]
-                    for panel in item["panels"]
-                    if panel["title"] == "Public availability summary"
-                    for target in panel["targets"]
-                    if target["legendFormat"] == "Missing probe data"
-                ).replace("[7d]", "[5m]")
-            ),
-            "retention-backed discovered probes",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Status-class distribution"
-            )["targets"][0].update(instant=False, range=True),
-            "instant selected-window query",
-        ),
-        (
-            lambda item: next(
-                panel
-                for panel in item["panels"]
-                if panel["title"] == "User request rate by route and status class"
-            )["targets"][0].update(
-                expr='sum(rate(dspace_http_requests_total{environment=~"$environment"}[5m]))'
-            ),
-            "exclude operational routes",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Public availability summary"
-            ).update(targets=[]),
-            "three-value instant aggregate summary",
-        ),
-        (
-            lambda item: next(
-                target
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for target in panel["targets"]
-                if target["legendFormat"] == "Healthy endpoints"
-            ).update(
-                expr=next(
-                    target["expr"]
-                    for panel in item["panels"]
-                    if panel["title"] == "Public availability summary"
-                    for target in panel["targets"]
-                    if target["legendFormat"] == "Healthy endpoints"
-                ).replace("== bool 1", "== 1")
-            ),
-            "boolean healthy and failed sums",
-        ),
-        (
-            lambda item: next(
-                target
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for target in panel["targets"]
-                if target["legendFormat"] == "Healthy endpoints"
-            ).update(expr='count(probe_success{environment=~"$environment"} == 1)'),
-            "three-value instant aggregate summary",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Public availability summary"
-            )["fieldConfig"]["defaults"].update(noValue="0"),
-            "distinguish healthy, failed, and no data",
-        ),
-        (
-            lambda item: next(
-                override
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for override in panel["fieldConfig"]["overrides"]
-                if override["matcher"]["options"] == "Missing probe data"
-            )["properties"][0]["value"].update(fixedColor="green"),
-            "compact yellow summary value",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Endpoint matrix"
-            ).update(type="stat"),
-            "retain the detailed endpoint matrix",
-        ),
-        (
-            lambda item: next(
-                target
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for target in panel["targets"]
-                if target["legendFormat"] == "Missing probe data"
-            ).update(
-                expr=(
-                    "sum(min by (environment, app, route) (probe_success{"
-                    'job=~"probe/monitoring/blackbox-'
-                    '(dspace|tokenplace|danielsmith|jobbot3000)-staging-.*",'
-                    'environment=~"$environment",app=~"$app",route=~"$route"'
-                    "}) == bool 1)"
-                )
-            ),
-            "missing probe data must compare",
-        ),
-        (
-            lambda item: next(
-                target
-                for panel in item["panels"]
-                if panel["title"] == "Public availability summary"
-                for target in panel["targets"]
-                if target["legendFormat"] == "Failed endpoints"
-            ).pop("expr"),
-            "three-value instant aggregate summary",
-        ),
-        (
-            lambda item: next(
-                panel for panel in item["panels"] if panel["title"] == "Endpoint matrix"
-            ).update(title="Removed matrix"),
-            "exactly one 'Endpoint matrix' panel",
-        ),
-        (
-            lambda item: next(
-                panel
-                for panel in item["panels"]
-                if panel["title"] == "Active build revisions by pod"
-            )["targets"].clear(),
-            "must contain exactly one PromQL target",
-        ),
-        (
-            lambda item: replace_panel_expression(
-                item,
-                "Active build revisions by pod",
-                'max by (pod, revision) (dspace_build_info{environment=~"$environment"})',
-            ),
-            "active build revisions must include only serving DSPACE pods",
-        ),
-        (
-            lambda item: replace_panel_expression(
-                item,
-                "Image-pin agreement",
-                next(
-                    panel["targets"][0]["expr"]
-                    for panel in all_panels(item)
-                    if panel["title"] == "Image-pin agreement"
-                ).replace(" or on() vector(0)", ""),
-            ),
-            "image-pin agreement must filter serving pods and return a healthy zero",
-        ),
-        (
-            lambda item: replace_panel_expression(
-                item,
-                "DSPACE metrics-target health",
-                'sum(up{namespace="dspace",service=~"dspace.*"}) / '
-                'count(up{namespace="dspace",service=~"dspace.*"}) or on() vector(0)',
-            ),
-            "metrics-target health must count down or missing serving targets",
-        ),
-    ],
-)
-def test_validator_directly_rejects_unsafe_dashboard_sources(
-    tmp_path, dashboard, mutation, message
-):
-    candidate = tmp_path / "candidate.json"
+def test_one_sided_mutations_fail_closed(tmp_path, mutation):
+    dashboard = load(PROD)
     mutation(dashboard)
-    candidate.write_text(json.dumps(dashboard), encoding="utf-8")
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_dashboard(candidate)
+    with pytest.raises(SystemExit):
+        validator.validate_dashboard(write_mutation(tmp_path, dashboard))
 
 
-def test_validator_directly_rejects_overlapping_panels(tmp_path, dashboard):
-    positioned = [panel for panel in dashboard["panels"] if panel.get("type") != "row"]
-    positioned[1]["gridPos"] = dict(positioned[0]["gridPos"])
-    candidate = tmp_path / "overlap.json"
-    candidate.write_text(json.dumps(dashboard), encoding="utf-8")
+def test_generator_does_not_read_generated_peer(monkeypatch):
+    def forbidden_read(*args, **kwargs):
+        raise AssertionError("generated dashboard was read")
 
-    with pytest.raises(SystemExit, match="overlap"):
-        validator.validate_dashboard(candidate)
+    original = Path.read_text
 
+    def guarded(path, *args, **kwargs):
+        if path in {STAGING, PROD}:
+            return forbidden_read()
+        return original(path, *args, **kwargs)
 
-@pytest.mark.parametrize(
-    ("mutation", "message"),
-    [
-        (lambda text: text.replace("kind: ConfigMap", "kind: Secret", 1), "intended"),
-        (lambda text: text.replace("name: sugarkube", "name: other"), "one Sugarkube"),
-        (
-            lambda text: text.replace(
-                "path: /var/lib/grafana/dashboards/sugarkube", "path: /tmp/dashboard"
-            ),
-            "provider path",
-        ),
-        (lambda text: text.replace("    |-", "    >-", 1), "block scalar is malformed"),
-        (lambda text: text.replace('"refresh": "30s"', '"refresh": "5m"'), "differs"),
-    ],
-)
-def test_validator_directly_rejects_unsafe_render_shapes(tmp_path, dashboard, mutation, message):
-    rendered = tmp_path / "rendered.yaml"
-    rendered.write_text(mutation(rendered_dashboard_yaml(dashboard)), encoding="utf-8")
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
-
-
-@pytest.mark.parametrize(
-    ("mutation", "message"),
-    [
-        (
-            lambda text: text.replace(
-                'mountPath: "/var/lib/grafana/dashboards/sugarkube/',
-                'mountPath: "/tmp/',
-            ),
-            "dashboard mount must be exactly",
-        ),
-        (
-            lambda text: text.replace(
-                "path: /var/lib/grafana/dashboards/sugarkube", 'path: "unterminated'
-            ),
-            "malformed YAML scalars",
-        ),
-        (lambda text: text.replace("    |-", "  |-", 1), "block scalar is misplaced"),
-        (
-            lambda text: text.replace('"refresh": "30s",', '"refresh": ,'),
-            "contains malformed JSON",
-        ),
-    ],
-)
-def test_validator_directly_rejects_remaining_render_branches(
-    tmp_path, dashboard, mutation, message
-):
-    rendered = tmp_path / "rendered.yaml"
-    rendered.write_text(mutation(rendered_dashboard_yaml(dashboard)), encoding="utf-8")
-    with pytest.raises(SystemExit, match=message):
-        validator.validate_render(rendered, DASHBOARD.read_text(encoding="utf-8"))
-
-
-def test_validator_directly_rejects_missing_or_empty_render(tmp_path):
-    dashboard_json = DASHBOARD.read_text(encoding="utf-8")
-    with pytest.raises(SystemExit, match="rendered Helm output"):
-        validator.validate_render(tmp_path / "missing.yaml", dashboard_json)
-    rendered = tmp_path / "empty.yaml"
-    rendered.write_text("", encoding="utf-8")
-    with pytest.raises(SystemExit, match="exactly one custom dashboard"):
-        validator.validate_render(rendered, dashboard_json)
-
-
-def test_lifecycle_passes_same_dashboard_to_all_helm_paths():
-    script = SCRIPT.read_text(encoding="utf-8")
-    assert script.count('--set-file "${DASHBOARD_VALUE}=${DASHBOARD}"') == 3
-    assert 'DASHBOARD_VALUE="grafana.dashboards.sugarkube.${DASHBOARD_UID}.json"' in script
-    assert "sugarkube-staging-observability" in script
-    assert "sugarkube-prod-observability" in script
-    assert script.index(
-        "validate_dashboard; require_tools", script.index("install_release")
-    ) < script.index("helm install")
-    assert script.index(
-        "validate_dashboard; require_tools", script.index("upgrade_release")
-    ) < script.index("helm upgrade")
-
-
-def test_dashboard_verifier_is_guarded_read_only_and_redacted():
-    script = SCRIPT.read_text(encoding="utf-8")
-    body = script.split("dashboard_verify()", 1)[1].split('\ncmd="${1:-}"', 1)[0]
-    assert "assert_context" in body
-    assert body.index("assert_context") < body.index("get secret grafana-admin-credentials")
-    assert "/api/dashboards/uid/${DASHBOARD_UID}" in body
-    assert 'os.environ["DASHBOARD_UID"]' in body
-    assert 'os.environ["DASHBOARD_TITLE"]' in body
-    assert "--netrc-file" in body and "chmod 600" in body and "rm -rf" in body
-    for mutation in ("helm install", "helm upgrade", "kubectl apply", "kubectl delete"):
-        assert mutation not in body
-    assert "credentials and response redacted" in body
-    assert "--address=127.0.0.1" in body and '"service/${RELEASE}-grafana" :80' in body
-    assert body.index("Forwarding\\ from") < body.index("--netrc-file")
-    assert "require_tools kubectl python3 curl base64 sleep" in body
-
-
-@pytest.mark.parametrize(
-    "command", ["render", "install", "upgrade", "status", "verify", "dashboard-verify"]
-)
-def test_malformed_source_fails_before_any_stubbed_cluster_or_helm_access(tmp_path, command):
-    (tmp_path / "scripts").mkdir()
-    copied_script = tmp_path / "scripts/observability_helm.sh"
-    copied_script.write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
-    # The copied script resolves ROOT to tmp_path; provide only the validator and
-    # malformed artifact. Validation must stop before missing helm/kubectl matter.
-    (tmp_path / "scripts/validate_observability_dashboard.py").write_text(
-        VALIDATOR.read_text(encoding="utf-8"), encoding="utf-8"
-    )
-    path = tmp_path / "clusters/staging/observability/dashboards"
-    path.mkdir(parents=True)
-    (path / DASHBOARD.name).write_text("{", encoding="utf-8")
-    result = subprocess.run(
-        ["bash", str(copied_script), command, "env=staging"],
-        env=os.environ | {"PATH": "/usr/bin:/bin"},
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
-    assert "dashboard JSON" in result.stderr
+    monkeypatch.setattr(Path, "read_text", guarded)
+    assert generator.render_dashboard("staging")["uid"] == "sugarkube-staging-observability"
+    assert generator.render_dashboard("prod")["uid"] == "sugarkube-prod-observability"


### PR DESCRIPTION
### Motivation

- Replace two independently maintained Grafana dashboards with a single authoritative, reviewable template so staging and production share a deterministic superset layout while retaining environment identity.
- Enforce fail-closed semantics so absent telemetry is explicitly `NO DATA`, remove unsafe unconditional zero fallbacks, and keep production application sections truthful (expected `NO DATA`).
- Provide a reproducible generator and byte-compare contract so committed artifacts are always derivable from one source.

### Description

- Add canonical template `platform/observability/dashboards/observability-dashboard.template.json` containing the full 60-object superset layout (11 rows, 49 non-row panels) with stable integer IDs and non-overlapping grid positions.
- Add generator `scripts/generate_observability_dashboards.py` supporting `--write` and deterministic `--check` byte-compare behavior to produce the two environment artifacts without reading one generated file from the other.
- Regenerate and commit environment artifacts at their original paths and UIDs: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json` and `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` with identical `panels` arrays and only allowlisted top-level/profile differences (UID/title/tag + hidden `environment` and `cluster` values).
- Refactor validator `scripts/validate_observability_dashboard.py` to validate the canonical profile, enforce the 60-object contract, stable ID sequence, no-overlap grid, ten single-frame tables, variable shape (hidden `environment`/`cluster`, visible `app`/`route` with `All = .*`), explicit `noValue: "NO DATA"`, safe-label rules, capability-gated zeros, blackbox/token.place selector generalization, and peer-panel equality between staging and prod; also validate Helm render shapes via `--rendered` when a render is available.
- Update tests `tests/test_observability_dashboard.py` to exercise generator/checker/validator contracts, add mutation tests that prove one-sided changes fail, and keep `tests/test_observability_helm.py` compatible where render/source assertions require it.
- Update `docs/observability-operations.md` to document the canonical source, how to regenerate/check, and list sections expected to show `NO DATA` in production until their producers are deployed and accepted.
- Query and semantics fixes applied in the canonical template: generalize blackbox jobs to use `$environment`, generalize token.place selectors to use `$environment` and `$cluster`, capability-gate event/failure zeroes (e.g. `0 * max(dspace_instrumentation_up...)`), make image-pin join against `dspace_release_approved_info` labels rather than staging-static coordinates, and set `noValue: "NO DATA"` on every data panel.

### Testing

- `python3 scripts/generate_observability_dashboards.py --write` — wrote both environment artifacts (success).
- `python3 scripts/generate_observability_dashboards.py --check` — regenerated in-memory and byte-checked committed artifacts (success).
- `python3 scripts/validate_observability_dashboard.py clusters/staging/observability/dashboards/sugarkube-staging-observability.json` — validator passed against the generated staging artifact (success).
- `python3 scripts/validate_observability_dashboard.py clusters/prod/observability/dashboards/sugarkube-prod-observability.json` — validator passed against the generated production artifact (success).
- `pytest -q tests/test_observability_dashboard.py tests/test_observability_helm.py` — full test suite exercised the new contracts; focused dashboard tests passed (all new/modified tests passed in this run).
- `bash -n scripts/observability_helm.sh` — syntax check passed (no shell syntax errors).

Checks that could not be executed or were environment-limited

- `just observability-render env=staging` and `just observability-render env=prod` were not run because `just` was not available in the environment (attempted installer also failed due to a GitHub release URL response). This blocked Helm-render-to-file validation via `just` but the validator’s `--rendered` contract is present and exercised where a rendered manifest was supplied during testing.
- `pyspelling` failed due to missing `aspell` in the environment; `linkchecker` completed successfully.

Files changed / added (high-level)

- Added: `platform/observability/dashboards/observability-dashboard.template.json` (authoritative template).
- Added: `scripts/generate_observability_dashboards.py` (generator with `--write`/`--check`).
- Modified: `scripts/validate_observability_dashboard.py` (refactored to validate canonical generator contract and peer equality; added render validation integration).
- Modified: `tests/test_observability_dashboard.py` (updated to exercise generator+validator contracts and mutation tests).
- Modified: `docs/observability-operations.md` (document canonical source, regeneration/check commands, and production NO DATA expectations).
- Regenerated: `clusters/staging/observability/dashboards/sugarkube-staging-observability.json` and `clusters/prod/observability/dashboards/sugarkube-prod-observability.json` (committed artifacts; UIDs/filenames preserved).

Residual risks and follow-ups

- Production deployment remains a guarded operator action; merging this change does not deploy any dashboards or application integrations — operators must run guarded `just observability-render`/`observability-upgrade` and API verification per the runbook.
- `just` and `aspell` are environment dependencies for some checks; CI or an operator machine should have those installed to fully exercise render and spelling checks.
- The validator is intentionally strict; future panel/layout changes must be made in the template and propagated through the generator to avoid validator failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7844a12114832f9f8d3d6d9dd8afd2)