### PR TITLE
ci: fix claude job sandbox initialization

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -236,12 +236,14 @@ jobs:
       issues: read
       actions: read
       id-token: write
+    env:
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
     steps:
       - name: Install required sandbox dependencies
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap shellcheck just aspell aspell-en
+          sudo apt-get install -y --no-install-recommends bubblewrap socat shellcheck just aspell aspell-en
           if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi


### PR DESCRIPTION
### Motivation

A real @claude code-change request on #2563 (https://github.com/futuroptimist/sugarkube/pull/2563#issuecomment-5230922818) failed: Claude reported \`bwrap: Can't create file at /home/.mcp.json: Permission denied\` on every Bash attempt, and every Edit/Write attempt was denied — meaning it could not actually validate or commit anything, despite the job itself reporting "success". This went undetected until now because every prior test only asked Claude to reply/confirm, never to actually edit files or run the trusted wrapper.

### Root cause

Diffed against jobbot3000's \`claude\` job — the only sibling repo with proven real commits (not just replies) — and found two things missing here: the job-level env var \`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"\`, and \`socat\` alongside \`bubblewrap\` in the sandbox dependency install.

### Description

Add both to the \`claude\` job.

### Testing

- \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml'))"\` — YAML parses.
- Real verification requires re-triggering \`@claude\` with an actual code-change request (e.g. on #2563) after this merges.