### PR TITLE
Fix Just recipe arg forwarding for Cloudflare WAN drill

### DIFF
--- a/justfile
+++ b/justfile
@@ -728,8 +728,8 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-cf-tunnel-wan-dependency-loss-drill env='staging' *args='':
-    scripts/cloudflare_wan_dependency_loss_drill.sh --env={{ quote(env) }} {{ args }}
+cf-tunnel-wan-dependency-loss-drill *args='':
+    scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -719,7 +719,37 @@ def test_node_execution_does_not_weaken_authentication() -> None:
     assert "CF_DRILL_NODE_EXECUTOR" in TEXT
 
 
-def test_recipe_is_clearly_named_and_defaults_to_plan() -> None:
-    justfile = (ROOT / "justfile").read_text()
-    assert "cf-tunnel-wan-dependency-loss-drill env='staging' *args=''" in justfile
-    assert "cloudflare_wan_dependency_loss_drill.sh" in justfile
+@pytest.mark.parametrize("arguments", [[], ["env=staging"]])
+def test_recipe_invocation_defaults_to_staging_plan(arguments: list[str]) -> None:
+    assert shutil.which("just"), "just is required for recipe contract tests"
+    result = subprocess.run(
+        ["just", "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PLAN ONLY -- no cluster or node command was run." in result.stdout
+    assert "--env=env=staging" not in result.stdout + result.stderr
+
+
+def test_recipe_dry_run_forwards_helper_arguments_once_and_unchanged() -> None:
+    assert shutil.which("just"), "just is required for recipe contract tests"
+    arguments = [
+        "env=staging",
+        "--manual-node-plan",
+        "--execute",
+        "--confirm=confirmation-sentinel",
+        "--evidence-dir=/tmp/evidence-sentinel",
+    ]
+    result = subprocess.run(
+        ["just", "--dry-run", "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    rendered = result.stdout + result.stderr
+    for argument in arguments:
+        assert rendered.count(argument) == 1
+    assert "--env=env=staging" not in rendered


### PR DESCRIPTION
### Motivation

- The `cf-tunnel-wan-dependency-loss-drill` Just recipe consumed the operator `env=staging` token as a positional `env` and then re-prefixed it, producing `--env=env=staging` and failing the staging-only gate early.  This violated the established operator-facing invocation and caused an unexpected error despite being non-mutating. 
- The change should be minimal and preserve the helper script's own `env=staging`/`--env=staging` parser, staging safety guards, and all existing safety contracts.

### Description

- Adjusted the Just recipe to forward all operator inputs as plain arguments by changing the recipe from `cf-tunnel-wan-dependency-loss-drill env='staging' *args=''` to `cf-tunnel-wan-dependency-loss-drill *args=''` and forwarding `{{ args }}` unchanged to the helper. 
- Added recipe-level contract tests in `tests/test_cloudflare_wan_dependency_loss_drill.py` that (1) exercise the real Just recipe boundary for both no-argument and `env=staging` invocations and assert the helper prints the non-mutating plan message, and (2) use `just --dry-run` to assert `env=staging`, `--manual-node-plan`, `--execute`, `--confirm=...`, and `--evidence-dir=...` are each rendered exactly once and unmodified. 
- Kept the helper script, docs, and all guardrails unchanged so the helper remains authoritative for parsing and safety checks.

### Testing

- Ran a shell syntax check: `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` (passed). 
- Verified the real recipe produces the staging plan message with both invocations: `just cf-tunnel-wan-dependency-loss-drill` and `just cf-tunnel-wan-dependency-loss-drill env=staging` (both printed `PLAN ONLY -- no cluster or node command was run.` and did not render `--env=env=staging`).
- Ran the focused pytest suite: `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py` (94 passed).
- Verified formatting and repository checks: `just --unstable --fmt --check` (passed); note that `just --fmt --check` is unstable in this environment and requires the `--unstable` flag as in CI. 
- Ran docs checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (both passed). 
- Ran secret and diff checks: `git diff --check` and `git diff "$(git merge-base HEAD origin/main)" | ./scripts/scan-secrets.py` (no secrets detected in the diff introduced by this change). 
- Pre-commit: `pre-commit run --files justfile tests/test_cloudflare_wan_dependency_loss_drill.py` passed for the touched files, while `pre-commit run --all-files` remains blocked by unrelated, pre-existing, repository-wide linter issues outside this focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78c27143cc832f9ff42ba58ee84842)