### PR TITLE
Fix Cloudflare WAN drill Just argument forwarding

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set export := true
+set positional-arguments := true
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
@@ -728,7 +729,6 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-[positional-arguments]
 cf-tunnel-wan-dependency-loss-drill *args:
     scripts/cloudflare_wan_dependency_loss_drill.sh "$@"
 

--- a/justfile
+++ b/justfile
@@ -728,8 +728,8 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-cf-tunnel-wan-dependency-loss-drill env='staging' *args='':
-    scripts/cloudflare_wan_dependency_loss_drill.sh --env={{ quote(env) }} {{ args }}
+cf-tunnel-wan-dependency-loss-drill *args='':
+    scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set export := true
-set positional-arguments := true
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
@@ -729,6 +728,7 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
+[positional-arguments]
 cf-tunnel-wan-dependency-loss-drill *args:
     scripts/cloudflare_wan_dependency_loss_drill.sh "$@"
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set export := true
+set positional-arguments := true
 
 export SUGARKUBE_CLUSTER := env('SUGARKUBE_CLUSTER', 'sugar')
 export SUGARKUBE_SERVERS := env('SUGARKUBE_SERVERS', '1')
@@ -728,8 +729,8 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-cf-tunnel-wan-dependency-loss-drill *args='':
-    scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}
+cf-tunnel-wan-dependency-loss-drill *args:
+    scripts/cloudflare_wan_dependency_loss_drill.sh "$@"
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -12,8 +12,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.usefixtures("ensure_just_available")
-
 ROOT = Path(__file__).resolve().parents[1]
 DRILL = ROOT / "scripts" / "cloudflare_wan_dependency_loss_drill.sh"
 TEXT = DRILL.read_text()
@@ -722,12 +720,15 @@ def test_node_execution_does_not_weaken_authentication() -> None:
 
 
 @pytest.mark.parametrize("arguments", [[], ["env=staging"]])
-def test_recipe_defaults_to_staging_plan(arguments: list[str]) -> None:
+def test_recipe_defaults_to_staging_plan(
+    arguments: list[str], ensure_just_available: Path,
+) -> None:
     result = subprocess.run(
         ["just", "cf-tunnel-wan-dependency-loss-drill", *arguments],
         cwd=ROOT,
         text=True,
         capture_output=True,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
@@ -735,7 +736,36 @@ def test_recipe_defaults_to_staging_plan(arguments: list[str]) -> None:
     assert "--env=env=staging" not in result.stdout + result.stderr
 
 
-def test_recipe_forwards_helper_arguments_once_and_unchanged(tmp_path: Path) -> None:
+def test_recipe_accepts_multiword_confirmation(
+    ensure_just_available: Path,
+) -> None:
+    result = subprocess.run(
+        [
+            "just",
+            "cf-tunnel-wan-dependency-loss-drill",
+            "env=staging",
+            "--manual-node-plan",
+            "--execute",
+            f"--confirm={CONFIRM}",
+            "--evidence-dir=/tmp/evidence-marker",
+            "--help",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Usage:" in output
+    assert "unknown argument" not in output.lower()
+    assert "--env=env=staging" not in output
+
+
+def test_recipe_forwards_helper_arguments_once_and_unchanged(
+    tmp_path: Path, ensure_just_available: Path,
+) -> None:
     arguments = [
         "env=staging",
         "--manual-node-plan",
@@ -750,14 +780,23 @@ def test_recipe_forwards_helper_arguments_once_and_unchanged(tmp_path: Path) -> 
     helper.chmod(0o755)
     justfile = shutil.copy(ROOT / "justfile", tmp_path / "justfile")
     result = subprocess.run(
-        ["just", "--justfile", str(justfile),
-         "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        [
+            "just",
+            "--justfile",
+            str(justfile),
+            "cf-tunnel-wan-dependency-loss-drill",
+            *arguments,
+        ],
         cwd=tmp_path,
         text=True,
         capture_output=True,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr
     forwarded = result.stdout.splitlines()
     assert forwarded == arguments
+    assert forwarded.count(f"--confirm={CONFIRM}") == 1
     assert "--env=env=staging" not in forwarded
+    recipe = (ROOT / "justfile").read_text()
+    assert recipe.count('scripts/cloudflare_wan_dependency_loss_drill.sh "$@"') == 1

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("ensure_just_available")
+
 ROOT = Path(__file__).resolve().parents[1]
 DRILL = ROOT / "scripts" / "cloudflare_wan_dependency_loss_drill.sh"
 TEXT = DRILL.read_text()
@@ -719,7 +721,37 @@ def test_node_execution_does_not_weaken_authentication() -> None:
     assert "CF_DRILL_NODE_EXECUTOR" in TEXT
 
 
-def test_recipe_is_clearly_named_and_defaults_to_plan() -> None:
-    justfile = (ROOT / "justfile").read_text()
-    assert "cf-tunnel-wan-dependency-loss-drill env='staging' *args=''" in justfile
-    assert "cloudflare_wan_dependency_loss_drill.sh" in justfile
+@pytest.mark.parametrize("arguments", [[], ["env=staging"]])
+def test_recipe_defaults_to_staging_plan(arguments: list[str]) -> None:
+    result = subprocess.run(
+        ["just", "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PLAN ONLY -- no cluster or node command was run." in result.stdout
+    assert "--env=env=staging" not in result.stdout + result.stderr
+
+
+def test_recipe_forwards_helper_arguments_once_and_unchanged() -> None:
+    arguments = [
+        "env=staging",
+        "--manual-node-plan",
+        "--execute",
+        "--confirm=confirmation-marker",
+        "--evidence-dir=/tmp/evidence-marker",
+    ]
+    result = subprocess.run(
+        ["just", "--dry-run", "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    rendered = result.stdout + result.stderr
+    for argument in arguments:
+        assert rendered.count(argument) == 1
+    assert "--env=env=staging" not in rendered

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -735,23 +735,29 @@ def test_recipe_defaults_to_staging_plan(arguments: list[str]) -> None:
     assert "--env=env=staging" not in result.stdout + result.stderr
 
 
-def test_recipe_forwards_helper_arguments_once_and_unchanged() -> None:
+def test_recipe_forwards_helper_arguments_once_and_unchanged(tmp_path: Path) -> None:
     arguments = [
         "env=staging",
         "--manual-node-plan",
         "--execute",
-        "--confirm=confirmation-marker",
+        f"--confirm={CONFIRM}",
         "--evidence-dir=/tmp/evidence-marker",
     ]
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    helper = scripts / "cloudflare_wan_dependency_loss_drill.sh"
+    helper.write_text("#!/usr/bin/env bash\nprintf '%s\\n' \"$@\"\n")
+    helper.chmod(0o755)
+    justfile = shutil.copy(ROOT / "justfile", tmp_path / "justfile")
     result = subprocess.run(
-        ["just", "--dry-run", "cf-tunnel-wan-dependency-loss-drill", *arguments],
-        cwd=ROOT,
+        ["just", "--justfile", str(justfile),
+         "cf-tunnel-wan-dependency-loss-drill", *arguments],
+        cwd=tmp_path,
         text=True,
         capture_output=True,
     )
 
     assert result.returncode == 0, result.stderr
-    rendered = result.stdout + result.stderr
-    for argument in arguments:
-        assert rendered.count(argument) == 1
-    assert "--env=env=staging" not in rendered
+    forwarded = result.stdout.splitlines()
+    assert forwarded == arguments
+    assert "--env=env=staging" not in forwarded


### PR DESCRIPTION
### Motivation

The documented operator invocation:

`just cf-tunnel-wan-dependency-loss-drill env=staging`

was previously parsed as a positional `env` value and then prefixed again by the recipe, producing `--env=env=staging`. The staging-only helper rejected that value before its live read-only preflight, so the failed attempt did not change any node, nftables rule, Kubernetes resource, Helm release, Secret, Cloudflare configuration, or production resource.

### Changes

- Enable Just positional arguments using the global `set positional-arguments := true` syntax supported by the repository’s CI-installed Just 1.21.0.
- Change `cf-tunnel-wan-dependency-loss-drill` to accept variadic arguments and forward the original argument vector exactly once through `"$@"`.
- Preserve both supported plan invocations:
  - `just cf-tunnel-wan-dependency-loss-drill`
  - `just cf-tunnel-wan-dependency-loss-drill env=staging`
- Preserve exact forwarding for `--manual-node-plan`, `--execute`, the required space-containing `--confirm=...` value, and `--evidence-dir=...`.
- Keep `scripts/cloudflare_wan_dependency_loss_drill.sh` unchanged and authoritative for environment normalization and every existing safety gate.

### Regression coverage

`tests/test_cloudflare_wan_dependency_loss_drill.py` now:

- exercises the real Just recipe boundary with the default and explicit staging invocations;
- requires both invocations to print `PLAN ONLY -- no cluster or node command was run.`;
- safely passes the full multiword confirmation through the real helper with `--help`, which exits during argument parsing before any preflight or mutation path;
- uses a capturing helper to verify the complete argv vector is forwarded once and unchanged;
- verifies the required confirmation remains one argument;
- rejects the `--env=env=staging` regression;
- limits the `ensure_just_available` fixture to recipe-boundary tests and applies bounded subprocess timeouts.

### Verification

- `just --version` — verified with Ubuntu’s Just 1.21.0
- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh`
- `just --unstable --fmt --check`
- `just cf-tunnel-wan-dependency-loss-drill`
- `just cf-tunnel-wan-dependency-loss-drill env=staging`
- `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/scripts/test_just_up.py`
- `./scripts/test-helm-oci-install.sh`
- `git diff --check`
- `git diff "$(git merge-base HEAD origin/main)" | ./scripts/scan-secrets.py`

The focused Python verification completed with 96 passing tests.

### Safety and follow-up

No manual-node plan or mutating drill was executed against a real cluster. No operational evidence or credentials are included.

This PR does not close #2407. The authorized live WAN drill and broader node-loss investigation remain separate operational work after this invocation-contract fix merges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78c27b9c1c832f906470679bb47a52)