### PR TITLE
Fix WAN drill just argument forwarding

### DIFF
--- a/justfile
+++ b/justfile
@@ -728,8 +728,8 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-cf-tunnel-wan-dependency-loss-drill env='staging' *args='':
-    scripts/cloudflare_wan_dependency_loss_drill.sh --env={{ quote(env) }} {{ args }}
+cf-tunnel-wan-dependency-loss-drill *args='env=staging':
+    scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -719,7 +719,35 @@ def test_node_execution_does_not_weaken_authentication() -> None:
     assert "CF_DRILL_NODE_EXECUTOR" in TEXT
 
 
-def test_recipe_is_clearly_named_and_defaults_to_plan() -> None:
-    justfile = (ROOT / "justfile").read_text()
-    assert "cf-tunnel-wan-dependency-loss-drill env='staging' *args=''" in justfile
-    assert "cloudflare_wan_dependency_loss_drill.sh" in justfile
+@pytest.mark.parametrize("recipe_args", [[], ["env=staging"]])
+def test_recipe_defaults_to_staging_plan(recipe_args: list[str]) -> None:
+    result = subprocess.run(
+        ["just", "cf-tunnel-wan-dependency-loss-drill", *recipe_args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PLAN ONLY -- no cluster or node command was run." in result.stdout
+    assert "--env=env=staging" not in result.stdout + result.stderr
+
+
+def test_recipe_dry_run_forwards_helper_arguments_once_and_unchanged() -> None:
+    helper_args = [
+        "env=staging",
+        "--manual-node-plan",
+        "--execute",
+        "--confirm=typed-confirmation",
+        "--evidence-dir=/tmp/cf-wan-evidence",
+    ]
+    result = subprocess.run(
+        ["just", "--dry-run", "cf-tunnel-wan-dependency-loss-drill", *helper_args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (result.stdout + result.stderr).split() == [
+        "scripts/cloudflare_wan_dependency_loss_drill.sh",
+        *helper_args,
+    ]


### PR DESCRIPTION
### Motivation

- A merged recipe consumed `env=staging` twice and rendered `--env=env=staging`, preventing the staging-only preflight and producing an operator-facing invocation mismatch. 
- The intent is to preserve the operator contract `just cf-tunnel-wan-dependency-loss-drill env=staging` and the no-argument default plan while letting the helper remain authoritative for parsing `env=...` vs `--env=...`.

### Description

- Update the `justfile` recipe so variadic args default to `env=staging` and are forwarded directly to the helper once by changing the recipe to `cf-tunnel-wan-dependency-loss-drill *args='env=staging':` and running `scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}`. 
- Add recipe-bound regression tests in `tests/test_cloudflare_wan_dependency_loss_drill.py` that exercise both the default and explicit `env=staging` invocations and assert the plan message is printed and `--env=env=staging` is not rendered. 
- Add a dry-run contract test that runs `just --dry-run cf-tunnel-wan-dependency-loss-drill ...` and asserts helper flags (`env=staging`, `--manual-node-plan`, `--execute`, `--confirm=...`, `--evidence-dir=...`) are forwarded exactly once and unchanged. 
- Make the minimal change necessary and do not modify the helper script, docs, cloud, Kubernetes, Helm, or Secret handling or any safety guards.

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` passed with no syntax errors. 
- `just cf-tunnel-wan-dependency-loss-drill` and `just cf-tunnel-wan-dependency-loss-drill env=staging` both ran and printed `PLAN ONLY -- no cluster or node command was run.` as expected. 
- Dry-run verification with `just --dry-run cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan --execute --confirm=typed-confirmation --evidence-dir=/tmp/cf-wan-evidence` produced the single helper invocation `scripts/cloudflare_wan_dependency_loss_drill.sh` followed by the exact helper arguments once and unchanged. 
- `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py` completed successfully (all tests passed). 
- `JUST_UNSTABLE=1 just --fmt --check`, `git diff --check`, and the repository `./scripts/scan-secrets.py` checks used here passed for the focused change, while a full `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide linter/YAML issues that were not part of this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78c2796670832fb7bd31405be48785)