### PR TITLE
Fix WAN drill Just argument forwarding

### DIFF
--- a/justfile
+++ b/justfile
@@ -728,8 +728,8 @@ cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
-cf-tunnel-wan-dependency-loss-drill env='staging' *args='':
-    scripts/cloudflare_wan_dependency_loss_drill.sh --env={{ quote(env) }} {{ args }}
+cf-tunnel-wan-dependency-loss-drill *args='':
+    scripts/cloudflare_wan_dependency_loss_drill.sh {{ args }}
 
 # Hard reset the Cloudflare Tunnel resources in the cluster for a fresh cf-tunnel-install.
 cf-tunnel-reset:

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -719,7 +719,35 @@ def test_node_execution_does_not_weaken_authentication() -> None:
     assert "CF_DRILL_NODE_EXECUTOR" in TEXT
 
 
-def test_recipe_is_clearly_named_and_defaults_to_plan() -> None:
-    justfile = (ROOT / "justfile").read_text()
-    assert "cf-tunnel-wan-dependency-loss-drill env='staging' *args=''" in justfile
-    assert "cloudflare_wan_dependency_loss_drill.sh" in justfile
+@pytest.mark.parametrize("args", [[], ["env=staging"]])
+def test_recipe_defaults_to_staging_plan(args: list[str]) -> None:
+    result = subprocess.run(
+        ["just", "cf-tunnel-wan-dependency-loss-drill", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PLAN ONLY -- no cluster or node command was run." in result.stdout
+    assert "--env=env=staging" not in result.stdout + result.stderr
+
+
+def test_recipe_forwards_helper_arguments_once_and_unchanged() -> None:
+    helper_args = [
+        "env=staging",
+        "--manual-node-plan",
+        "--execute",
+        f"--confirm={CONFIRM}",
+        "--evidence-dir=/tmp/cf-wan-evidence",
+    ]
+    result = subprocess.run(
+        ["just", "--dry-run", "cf-tunnel-wan-dependency-loss-drill", *helper_args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+    rendered = result.stdout + result.stderr
+    for arg in helper_args:
+        assert rendered.count(arg) == 1
+    assert "--env=env=staging" not in rendered


### PR DESCRIPTION
### Motivation

- The Just recipe for the Cloudflare WAN dependency-loss drill was declaring a positional `env` parameter and also injecting a `--env=` flag, causing operator invocations like `just cf-tunnel-wan-dependency-loss-drill env=staging` to render `--env=env=staging` and fail the staging-only guard before any read-only preflight.

### Description

- Remove the positional `env` parameter from the recipe and make the recipe variadic so all operator args are forwarded verbatim to the helper, preserving the helper parser as authoritative (change in `justfile`).
- Add recipe-bound regression tests that run the recipe both with no args and with `env=staging` and assert the helper prints the non-mutating plan message and does not render `--env=env=staging` (`tests/test_cloudflare_wan_dependency_loss_drill.py`).
- Add a deterministic `just --dry-run` test that proves helper flags (`env=staging`, `--manual-node-plan`, `--execute`, `--confirm=...`, `--evidence-dir=...`) are each forwarded exactly once and unchanged without executing the drill (`tests/test_cloudflare_wan_dependency_loss_drill.py`).

### Testing

- Ran `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` which succeeded.
- Verified operator invocations: `just cf-tunnel-wan-dependency-loss-drill` and `just cf-tunnel-wan-dependency-loss-drill env=staging` both exit and print `PLAN ONLY -- no cluster or node command was run.`.
- Ran the updated tests: `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py` and the targeted suite passed (tests covering the drill and related verifiers passed).
- Ran `just --dry-run cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan --execute --confirm="DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY" --evidence-dir=/tmp/cf-wan-evidence` and confirmed the rendered command contains each helper argument once and never `--env=env=staging`.
- Notes: `just --fmt --check` reported repository-wide Justfile formatting drift unrelated to this focused change, and `pre-commit run --all-files` and `pyspelling` surfaced pre-existing repository-wide issues (YAML/doc tooling / missing `aspell`) which were not changed by this PR.


Residual risk / follow-ups: the change is intentionally minimal and keeps all safety gates in the helper unchanged; after merge operators can run the documented `just cf-tunnel-wan-dependency-loss-drill env=staging` workflow again to resume authorized WAN drill work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78c27e3f78832fa4aef200117ce08a)