### PR TITLE
Require approved observability Helm revision for Cloudflare WAN drill

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -534,13 +534,32 @@ part of this rollout.
    rule and never flushes a ruleset.
 
    Execution remains **blocked unless every preflight passes**. In addition to `--execute`, the operator
-   must provide the approved Git revision, a safe executable node-command adapter, and the exact typed
-   confirmation printed by `--help`. The adapter boundary is intentional: the repository does not assume
+   must provide the approved Git revision, an explicitly approved observability Helm revision, a safe
+   executable node-command adapter, and the exact typed confirmation printed by `--help`. The adapter boundary is intentional: the repository does not assume
    unattended remote access, weaken host-key checking, create keys, or handle login credentials. If
    authenticated privileged execution on both nodes cannot be guaranteed, stop at the plan and run
    nothing.
 
-   Before disruption, the helper records only sanitized pod, image, metric, Helm, Secret-metadata, and
+   Obtain the current observability revision through a **separate, read-only approval gate**. First,
+   review `helm -n monitoring history kube-prometheus-stack -o json` outside the drill and confirm that
+   exactly one entry is deployed. Record its positive numeric revision in the authorization record; do
+   not pipe or derive that value into the drill automatically. After another operator has reviewed and
+   approved the coordinate, render the live, read-only manual node plan by replacing
+   `<approved-observability-revision>` with that reviewed integer:
+
+   ```bash
+   CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
+   CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<approved-observability-revision> \
+   just cf-tunnel-wan-dependency-loss-drill --manual-node-plan env=staging
+   ```
+
+   The helper has no observability revision default and does not discover an approved value. A later
+   release is supplied through the same environment coordinate after a fresh review; no revision is a
+   permanent documentation or source-code constant. The manual-node-plan path performs live read-only
+   preflights, but does not require or invoke `CF_DRILL_NODE_EXECUTOR` and does not mutate the cluster.
+
+   Before disruption, the helper records the expected and observed observability revisions plus only
+   sanitized pod, image, metric, Helm, Secret-metadata, and
    endpoint evidence, both Helm histories, and a canonical Deployment projection. It resolves each CRI
    sandbox to its PID and network-namespace inode, revalidates those three identities before every
    privileged namespace operation, and rejects an ambiguous sandbox or pre-existing owner table. Each
@@ -554,7 +573,8 @@ part of this rollout.
    commands. The disruption is limited to three minutes, below the shortest five-minute alert threshold.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
-   Helm histories, Secret metadata, and Deployment state must be unchanged; and
+   the observability release must still have exactly one deployed entry at the explicitly approved
+   revision; Cloudflare Helm history, Secret metadata, and Deployment state must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -30,6 +30,7 @@ Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
 
 The default is a non-mutating plan. Execution also requires:
   CF_DRILL_APPROVED_REVISION=<full git revision>
+  CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<separately reviewed Helm revision>
   CF_DRILL_NODE_EXECUTOR=<executable accepting NODE and COMMAND arguments>
 The executor is deliberately not SSH: authentication and sudo must be established separately.
 It must execute the supplied command verbatim on the named node and must not log credentials.
@@ -49,6 +50,8 @@ render_manual_node_plan() {
   local -a disruptions=() cleanups=()
   table="$(table_for)"
   printf 'MANUAL NODE PLAN -- commands were rendered but NOT EXECUTED.\n'
+  printf 'Observability Helm revision: expected=%s observed=%s\n' \
+    "${expected_observability_revision}" "${observed_observability_revision}"
   printf 'Run each record through a separately authenticated, host-key-verified session for its exact node.\n'
   printf 'Complete and verify both watchdog commands successfully before running either DISRUPTION command.\n'
   printf 'After the observation window, run both CLEANUP commands.\n'
@@ -137,6 +140,11 @@ owner="cfwandrill-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 if ((execute)); then
   [[ "${confirmation}" == "${CONFIRMATION}" ]] || die "confirmation must exactly equal: ${CONFIRMATION}"
 fi
+expected_observability_revision="${CF_DRILL_EXPECTED_OBSERVABILITY_REVISION:-}"
+[[ -n "${expected_observability_revision}" ]] || \
+  die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required for live preflight'
+[[ "${expected_observability_revision}" =~ ^[1-9][0-9]*$ ]] || \
+  die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION must be a canonical positive decimal integer (for example, 10)'
 [[ -n "${CF_DRILL_APPROVED_REVISION:-}" ]] || die 'CF_DRILL_APPROVED_REVISION is required'
 [[ "$(kubectl config current-context)" == "${EXPECTED_CONTEXT}" ]] || die "context must be ${EXPECTED_CONTEXT}"
 [[ -z "$(git status --porcelain)" ]] || die 'repository worktree must be clean'
@@ -150,7 +158,18 @@ releases="$(helm -n cloudflare list -o json)"
 cf_history="$(helm -n cloudflare history cloudflare-tunnel -o json)"
 [[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${cf_history}")" == "${EXPECTED_HELM_REVISION}" ]] || die 'Cloudflare Helm revision must be 2'
 obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
-[[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${obs_history}")" == 9 ]] || die 'observability Helm revision must be 9'
+observed_observability_revision="$(jq -r '
+  [.[] | select(.status=="deployed")] as $deployed |
+  if ($deployed|length)==1 and ($deployed[0].revision|type)=="number" and
+     ($deployed[0].revision|floor)==$deployed[0].revision and $deployed[0].revision>0
+  then ($deployed[0].revision|tostring) else empty end
+' <<<"${obs_history}")"
+[[ -n "${observed_observability_revision}" ]] || \
+  die 'observability Helm history must contain exactly one deployed entry with a positive numeric revision'
+[[ "${observed_observability_revision}" == "${expected_observability_revision}" ]] || \
+  die "observability Helm revision mismatch: expected=${expected_observability_revision} observed=${observed_observability_revision}"
+printf 'Observability Helm revision approved: expected=%s observed=%s\n' \
+  "${expected_observability_revision}" "${observed_observability_revision}"
 
 deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 jq -e --arg image "${EXPECTED_IMAGE}" '
@@ -230,10 +249,12 @@ done
 evidence_dir="${evidence_dir:-${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-${owner}}"
 umask 077; mkdir -p "${evidence_dir}"
 jq -n --arg owner "${owner}" --arg revision "${head_revision}" --arg secret "${secret_metadata}" \
+  --arg expectedObservabilityRevision "${expected_observability_revision}" \
+  --arg observedObservabilityRevision "${observed_observability_revision}" \
   --argjson pods "$(for i in 0 1; do jq -n --arg name "${pod_names[$i]}" --arg uid "${pod_uids[$i]}" --arg node "${pod_nodes[$i]}" --arg sandbox "${pod_sandboxes[$i]}" --arg pid "${pod_pids[$i]}" --arg netns "${pod_netns[$i]}" --argjson restartCount "${pod_restarts[$i]}" --arg image "${EXPECTED_IMAGE}" '{name:$name,uid:$uid,node:$node,sandbox:$sandbox,pid:$pid,netns:$netns,restartCount:$restartCount,image:$image}'; done | jq -s .)" \
   --argjson deployment "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,status:{observedGeneration:.status.observedGeneration}}' <<<"${deployment}")" \
   --argjson metrics "$(jq -n --arg targets "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"0"')" --arg ha "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1]//"0"')" '{targets:$targets,ha:$ha}')" \
-  '{owner:$owner,revision:$revision,secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
+  '{owner:$owner,revision:$revision,expectedObservabilityRevision:$expectedObservabilityRevision,observedObservabilityRevision:$observedObservabilityRevision,secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
 printf '%s\n' "${preflight_http[@]}" >"${evidence_dir}/endpoints-before.tsv"
 printf '%s\n' "${cf_history}" >"${evidence_dir}/cloudflare-helm-history.json"
 printf '%s\n' "${obs_history}" >"${evidence_dir}/observability-helm-history.json"
@@ -316,8 +337,18 @@ done
 prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' >"${evidence_dir}/recovery-metrics.json"
 [[ "$(kubectl -n cloudflare get secret tunnel-token -o jsonpath='{.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\t"}{.metadata.creationTimestamp}{"\n"}')" == "${secret_metadata}" ]] || die 'Secret metadata changed'
 [[ "$(helm -n cloudflare history cloudflare-tunnel -o json)" == "${cf_history}" ]] || die 'Cloudflare Helm history changed'
-[[ "$(helm -n monitoring history kube-prometheus-stack -o json)" == "${obs_history}" ]] || die 'observability Helm history changed'
+final_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
+final_observed_observability_revision="$(jq -r --arg expected "${expected_observability_revision}" '
+  [.[] | select(.status=="deployed")] as $deployed |
+  if ($deployed|length)==1 and ($deployed[0].revision|type)=="number" and
+     ($deployed[0].revision|floor)==$deployed[0].revision and
+     ($deployed[0].revision|tostring)==$expected
+  then ($deployed[0].revision|tostring) else empty end
+' <<<"${final_obs_history}")"
+[[ "${final_observed_observability_revision}" == "${expected_observability_revision}" ]] || \
+  die "observability Helm revision drift after cleanup: expected=${expected_observability_revision} observed=$(jq -r '[.[]|select(.status=="deployed")|.revision]|join(",")' <<<"${final_obs_history}")"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 [[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
 just cf-tunnel-verify env=staging
-printf 'PASS: same cloudflared processes recovered; sanitized evidence: %s\n' "${evidence_dir}"
+printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' \
+  "${expected_observability_revision}" "${final_observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -31,6 +31,8 @@ class StatefulDrillHarness:
         state = {
             "context": "sugar-staging", "revision": "approved", "dirty": False,
             "image_ok": True, "helm_revision": 2, "pod_count": 2,
+            "observability_revision": 9, "observability_deployed_count": 1,
+            "observability_revision_after_cleanup": None, "was_disrupted": False,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
@@ -50,6 +52,7 @@ class StatefulDrillHarness:
             "HARNESS_STATE": str(self.state),
             "HARNESS_LOG": str(self.log),
             "CF_DRILL_APPROVED_REVISION": "approved",
+            "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "9",
             "CF_DRILL_NODE_EXECUTOR": str(node),
         }
 
@@ -127,7 +130,11 @@ if name == "git":
 elif name == "helm":
     if "list" in args: out(json.dumps([{"name":"cloudflare-tunnel","status":"deployed","chart":"cloudflare-tunnel-0.3.2"}]))
     elif "cloudflare-tunnel" in args: out(json.dumps([{"status":"deployed","revision":state["helm_revision"]}]))
-    else: out('[{"status":"deployed","revision":9}]')
+    else:
+        revision = state["observability_revision"]
+        if state["was_disrupted"] and state["observability_revision_after_cleanup"] is not None:
+            revision = state["observability_revision_after_cleanup"]
+        out(json.dumps([{"status":"deployed","revision":revision} for _ in range(state["observability_deployed_count"])]))
 elif name == "just": sys.exit(0)
 elif name == "ruby":
     for i in range(16): out(f"https://endpoint-{i}.test")
@@ -179,7 +186,7 @@ elif name == "node-executor":
         event("watchdog", node=node, verified=True)
         out(str(501+idx))
     elif "add table inet" in command:
-        state["tables"][idx]=True; save(); event("table", node=node, present=True)
+        state["tables"][idx]=True; state["was_disrupted"]=True; save(); event("table", node=node, present=True)
         if state["install_fail"] == idx: sys.exit(44)
     elif "delete table inet" in command:
         state["tables"][idx]=False; save(); event("table", node=node, present=False); out("")
@@ -215,7 +222,57 @@ def test_dry_run_performs_no_mutation_or_external_preflight(tmp_path: Path) -> N
     assert not marker.exists(), "dry-run should not even invoke cluster/node stubs"
 
 
-def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -> dict[str, str]:
+@pytest.mark.parametrize("mode", ["--manual-node-plan", "--execute"])
+def test_live_modes_require_explicit_observability_revision(
+    tmp_path: Path, mode: str
+) -> None:
+    env = manual_plan_environment(tmp_path)
+    env.pop("CF_DRILL_EXPECTED_OBSERVABILITY_REVISION")
+    args = [mode]
+    if mode == "--execute":
+        args.append(f"--confirm={CONFIRM}")
+    result = run(*args, env=env)
+    assert result.returncode != 0
+    assert "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required" in result.stderr
+    assert not (tmp_path / "node-executor-called").exists()
+
+
+@pytest.mark.parametrize(
+    "value", ["", "0", "-1", "+1", "01", " 9", "9 ", "nine", "9x"]
+)
+def test_live_preflight_rejects_noncanonical_observability_revision(
+    tmp_path: Path, value: str
+) -> None:
+    env = manual_plan_environment(tmp_path)
+    env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = value
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    expected = "is required" if value == "" else "canonical positive decimal integer"
+    assert expected in result.stderr
+    assert not any(path.name == "node-executor-called" for path in tmp_path.iterdir())
+
+
+def test_manual_plan_accepts_later_reviewed_revision_without_source_change(tmp_path: Path) -> None:
+    result = run(
+        "--manual-node-plan",
+        env=manual_plan_environment(tmp_path, observability_revision=27),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Observability Helm revision: expected=27 observed=27" in result.stdout
+
+
+def test_manual_plan_revision_mismatch_fails_before_node_execution(tmp_path: Path) -> None:
+    env = manual_plan_environment(tmp_path, observability_revision=27)
+    env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = "26"
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "expected=26 observed=27" in result.stderr
+    assert "WATCHDOG " not in result.stdout
+
+
+def manual_plan_environment(
+    tmp_path: Path, *, context: str = "sugar-staging", observability_revision: int = 9
+) -> dict[str, str]:
     image = TEXT.split("readonly EXPECTED_IMAGE='", 1)[1].split("'", 1)[0]
     deployment = {
         "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "app.kubernetes.io/name": "cloudflare-tunnel", "app.kubernetes.io/instance": "cloudflare-tunnel"}},
@@ -236,13 +293,17 @@ def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -
         path.chmod(0o755)
 
     stub("git", "case \"$*\" in *status*) exit 0;; *rev-parse*) echo approved;; esac\n")
-    stub("helm", "case \"$*\" in *' list '*) printf '%s\\n' '[{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}]';; *cloudflare-tunnel*) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":2}]';; *) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":9}]';; esac\n")
+    stub("helm", f"case \"$*\" in *' list '*) printf '%s\\n' '[{{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}}]';; *cloudflare-tunnel*) printf '%s\\n' '[{{\"status\":\"deployed\",\"revision\":2}}]';; *) printf '%s\\n' '[{{\"status\":\"deployed\",\"revision\":{observability_revision}}}]';; esac\n")
     stub("kubectl", f"case \"$*\" in *current-context*) echo {context};; *'get deployment'*) printf '%s\\n' {json.dumps(json.dumps(deployment))};; *'get pods'*) printf '%s\\n' {json.dumps(json.dumps(pods))};; *'get secret'*) printf 'secret-uid\\t12\\t2026-08-09T00:00:00Z\\n';; *ALERTS*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"0\"]}}]}}}}';; *get\\ --raw*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"2\"]}}]}}}}';; esac\n")
     stub("just", "exit 0\n")
     stub("ruby", "i=1; while [ $i -le 16 ]; do echo https://endpoint-$i.test; i=$((i+1)); done\n")
     stub("curl", "printf 200\n")
     stub("date", "printf 20260809T000000Z\n")
-    return {"PATH": f"{tmp_path}:/usr/bin:/bin", "CF_DRILL_APPROVED_REVISION": "approved"}
+    return {
+        "PATH": f"{tmp_path}:/usr/bin:/bin",
+        "CF_DRILL_APPROVED_REVISION": "approved",
+        "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": str(observability_revision),
+    }
 
 
 def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_commands(tmp_path: Path) -> None:
@@ -266,6 +327,7 @@ def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_co
     assert all("systemctl" in lines[i] and "MainPID" in lines[i] for i in disruptions)
     assert all("delete\\ table\\ inet" in lines[i] and "list\\ ruleset" in lines[i] and "length\\ ==\\ 0" in lines[i] for i in cleanups)
     assert "BLOCKED: manual-node plan only; the drill was not executed and has not passed." in result.stdout
+    assert "Observability Helm revision: expected=9 observed=9" in result.stdout
 
 
 def test_manual_node_plan_preflight_failure_emits_no_actionable_commands(tmp_path: Path) -> None:
@@ -563,6 +625,9 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
+    assert preflight["expectedObservabilityRevision"] == "9"
+    assert preflight["observedObservabilityRevision"] == "9"
+    assert "observability revision expected=9 observed=9" in result.stdout
     assert (harness.evidence / "interruption-metrics.json").exists()
     assert (harness.evidence / "recovery-metrics.json").exists()
 
@@ -594,6 +659,33 @@ def test_actual_helper_preflights_fail_closed(
         "add table inet" in entry["args"][1]
         for entry in harness.commands() if entry["tool"] == "node-executor"
     )
+
+
+@pytest.mark.parametrize("deployed_count", [0, 2])
+def test_observability_history_requires_exactly_one_deployed_entry_before_executor(
+    tmp_path: Path, deployed_count: int
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, observability_deployed_count=deployed_count)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "exactly one deployed entry" in result.stderr
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+def test_observability_revision_mismatch_fails_before_executor(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, observability_revision=10)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "expected=9 observed=10" in result.stderr
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+def test_post_cleanup_observability_revision_drift_fails_closed(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, observability_revision_after_cleanup=10)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "revision drift after cleanup: expected=9 observed=10" in result.stderr
+    assert harness.current()["tables"] == [False, False]
 
 
 def test_actual_helper_rejects_confirmation_without_external_calls(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- The drill contained a stale hard-coded observability Helm revision (9) while live observability evidence showed revision 10, and the diagnostic capture is at `/home/pi/operator-evidence/cloudflare-wan-observability-revision-diagnostic-20260809T235722Z`.
- The change enforces an explicit operator-supplied coordinate so live preflights cannot silently accept or derive a revision constant from Helm or source state.

### Description

- Replace the hard-coded observability check with a required environment coordinate `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION` that must be supplied for any live preflight or execution, and validate it as a canonical positive decimal integer (rejecting zero, negative, signed, leading-zero, whitespace, and non-numeric values). (edited: `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- During live preflight read `helm -n monitoring history kube-prometheus-stack -o json`, require exactly one deployed entry, parse its numeric revision, and require it to equal the approved `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION`; report expected vs observed and fail closed on ambiguity or mismatch without reading Secret values. (edited: `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Preserve and record the expected and observed revisions in the manual plan text, `evidence/preflight.json`, completion summary, and post-cleanup revalidation that the observability release remains at the same approved revision. (edited: `scripts/cloudflare_wan_dependency_loss_drill.sh`) 
- Document the separate read-only approval step and show how an operator passes the reviewed coordinate, explicitly avoiding any implicit default or embedding of revision 10. (edited: `docs/cloudflare_tunnel.md`)
- Add focused offline tests and shim enhancements to cover missing/invalid/mismatched/ambiguous coordinates, later valid revisions, executor isolation, evidence output, and post-cleanup drift without performing any real cluster/SSH/systemd/nftables mutations. (edited: `tests/test_cloudflare_wan_dependency_loss_drill.py`)
- Commit: `408a827ee060ce1caf56e24ee027b3c2d48b9990` on branch `codex/cloudflare-observability-revision`; changed paths: `docs/cloudflare_tunnel.md`, `scripts/cloudflare_wan_dependency_loss_drill.sh`, `tests/test_cloudflare_wan_dependency_loss_drill.py`; note push to create a remote PR failed due to missing GitHub credentials so no public PR URL was created from this environment.

- Exact documented read-only manual-node-plan command to run after separate operator review (replace `<approved-observability-revision>` with the reviewed positive integer):

  `CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
  CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<approved-observability-revision> \
  just cf-tunnel-wan-dependency-loss-drill --manual-node-plan env=staging`

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — syntax check passed.
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — focused offline test suite passed and covers missing/invalid/mismatched/ambiguous revisions, executor isolation, expected/observed evidence, and post-cleanup drift checks.
- `pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_justfile_formatting.py` — affected Cloudflare/Just recipe tests executed and passed in this environment.
- Live read-only invocation guards exercised: `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION bash scripts/cloudflare_wan_dependency_loss_drill.sh` and `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION just cf-tunnel-wan-dependency-loss-drill env=staging` were run to verify offline-plan behavior and required-variable failure modes. 
- Docs and link checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed.
- Repository-wide `pre-commit run --all-files` was attempted but surfaced unrelated, pre-existing YAML/formatting/flake8 issues across the repository; unrelated auto-fixes appeared and were not included beyond the scoped changes in this PR (only the three intended files were staged and committed).
- No live infrastructure was changed: no Kubernetes mutation, Helm deployment/rollback, SSH/node execution, systemd, or nftables operations were performed, and the tests use an offline shim to prevent any real cluster or node mutations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7914da60d4832fb5ca2ff5a3e71190)