### PR TITLE
Require explicit observability Helm revision for Cloudflare WAN drill

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -533,12 +533,39 @@ part of this rollout.
    path and without signaling, deleting, or restarting cloudflared. It never adds a broad node firewall
    rule and never flushes a ruleset.
 
-   Execution remains **blocked unless every preflight passes**. In addition to `--execute`, the operator
-   must provide the approved Git revision, a safe executable node-command adapter, and the exact typed
-   confirmation printed by `--help`. The adapter boundary is intentional: the repository does not assume
+   Execution remains **blocked unless every preflight passes**. Before any live preflight (including
+   `--manual-node-plan`), obtain the current `monitoring/kube-prometheus-stack` Helm revision through a
+   separate read-only gate, review that capture, and explicitly approve the single deployed revision.
+   For example, capture it without starting this drill:
+
+   ```bash
+   helm -n monitoring history kube-prometheus-stack -o json | \
+     jq '[.[] | select(.status == "deployed") | {revision, status, updated, chart, app_version}]'
+   ```
+
+   Stop unless the reviewed result has exactly one deployed entry and its revision is a positive decimal
+   integer. The helper does not default, infer, or discover the approved coordinate. Pass the separately
+   reviewed value explicitly when rendering the live, read-only manual-node plan:
+
+   ```bash
+   CF_DRILL_APPROVED_REVISION=<approved-git-sha> \
+   CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<approved-observability-revision> \
+     just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
+   ```
+
+   This command performs cluster preflights and renders node commands, but does not invoke a node executor
+   or perform disruption. The default invocation without `--manual-node-plan` remains fully offline and
+   does not require either coordinate. A later execution additionally requires a safe executable
+   `CF_DRILL_NODE_EXECUTOR` and the exact typed confirmation printed by `--help`. The adapter boundary is
+   intentional: the repository does not assume
    unattended remote access, weaken host-key checking, create keys, or handle login credentials. If
    authenticated privileged execution on both nodes cannot be guaranteed, stop at the plan and run
    nothing.
+
+   During live preflight, the helper reads the observability Helm history, requires exactly one deployed
+   entry, and compares it with the explicitly approved coordinate. The rendered manual plan and sanitized
+   evidence record both expected and observed revisions. Recovery revalidates the same approved revision
+   after exact cleanup and fails closed on drift.
 
    Before disruption, the helper records only sanitized pod, image, metric, Helm, Secret-metadata, and
    endpoint evidence, both Helm histories, and a canonical Deployment projection. It resolves each CRI

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -21,6 +21,8 @@ declare -a attempted_indices=()
 declare -a pod_names=() pod_uids=() pod_nodes=() pod_restarts=() pod_sandboxes=() pod_pids=() pod_netns=()
 cleanup_failed=0
 declare -a preflight_http=()
+expected_observability_revision=''
+observed_observability_revision=''
 
 usage() {
   cat <<'EOF'
@@ -28,8 +30,9 @@ Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
        cloudflare_wan_dependency_loss_drill.sh --manual-node-plan [--env staging]
        [--confirm 'DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY']
 
-The default is a non-mutating plan. Execution also requires:
+The default is a non-mutating offline plan. Any live preflight or execution requires:
   CF_DRILL_APPROVED_REVISION=<full git revision>
+  CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<separately reviewed positive Helm revision>
   CF_DRILL_NODE_EXECUTOR=<executable accepting NODE and COMMAND arguments>
 The executor is deliberately not SSH: authentication and sudo must be established separately.
 It must execute the supplied command verbatim on the named node and must not log credentials.
@@ -37,6 +40,23 @@ EOF
 }
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+validate_observability_coordinate() {
+  expected_observability_revision="${CF_DRILL_EXPECTED_OBSERVABILITY_REVISION:-}"
+  [[ "${expected_observability_revision}" =~ ^[1-9][0-9]*$ ]] ||
+    die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION must be supplied as a canonical positive decimal integer (for example, 10; no zero, signs, whitespace, or leading zeros)'
+}
+read_observability_revision() {
+  local history="$1"
+  local -a deployed_revisions=()
+  mapfile -t deployed_revisions < <(jq -r '.[] | select(.status=="deployed") | .revision | tostring' <<<"${history}")
+  [[ "${#deployed_revisions[@]}" == 1 ]] ||
+    die "expected exactly one deployed observability Helm-history entry; expected revision ${expected_observability_revision}, observed deployed entries ${#deployed_revisions[@]}"
+  observed_observability_revision="${deployed_revisions[0]}"
+  [[ "${observed_observability_revision}" =~ ^[1-9][0-9]*$ ]] ||
+    die "observability Helm history has a non-canonical deployed revision; expected ${expected_observability_revision}, observed ${observed_observability_revision}"
+  [[ "${observed_observability_revision}" == "${expected_observability_revision}" ]] ||
+    die "observability Helm revision mismatch: expected ${expected_observability_revision}, observed ${observed_observability_revision}"
+}
 node_exec() { "${CF_DRILL_NODE_EXECUTOR}" "$1" "$2"; }
 table_for() {
   local digest
@@ -49,6 +69,7 @@ render_manual_node_plan() {
   local -a disruptions=() cleanups=()
   table="$(table_for)"
   printf 'MANUAL NODE PLAN -- commands were rendered but NOT EXECUTED.\n'
+  printf 'OBSERVABILITY expected_revision=%q observed_revision=%q\n' "${expected_observability_revision}" "${observed_observability_revision}"
   printf 'Run each record through a separately authenticated, host-key-verified session for its exact node.\n'
   printf 'Complete and verify both watchdog commands successfully before running either DISRUPTION command.\n'
   printf 'After the observation window, run both CLEANUP commands.\n'
@@ -137,6 +158,7 @@ owner="cfwandrill-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 if ((execute)); then
   [[ "${confirmation}" == "${CONFIRMATION}" ]] || die "confirmation must exactly equal: ${CONFIRMATION}"
 fi
+validate_observability_coordinate
 [[ -n "${CF_DRILL_APPROVED_REVISION:-}" ]] || die 'CF_DRILL_APPROVED_REVISION is required'
 [[ "$(kubectl config current-context)" == "${EXPECTED_CONTEXT}" ]] || die "context must be ${EXPECTED_CONTEXT}"
 [[ -z "$(git status --porcelain)" ]] || die 'repository worktree must be clean'
@@ -150,7 +172,7 @@ releases="$(helm -n cloudflare list -o json)"
 cf_history="$(helm -n cloudflare history cloudflare-tunnel -o json)"
 [[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${cf_history}")" == "${EXPECTED_HELM_REVISION}" ]] || die 'Cloudflare Helm revision must be 2'
 obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
-[[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${obs_history}")" == 9 ]] || die 'observability Helm revision must be 9'
+read_observability_revision "${obs_history}"
 
 deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 jq -e --arg image "${EXPECTED_IMAGE}" '
@@ -230,10 +252,11 @@ done
 evidence_dir="${evidence_dir:-${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-${owner}}"
 umask 077; mkdir -p "${evidence_dir}"
 jq -n --arg owner "${owner}" --arg revision "${head_revision}" --arg secret "${secret_metadata}" \
+  --arg expectedObservabilityRevision "${expected_observability_revision}" --arg observedObservabilityRevision "${observed_observability_revision}" \
   --argjson pods "$(for i in 0 1; do jq -n --arg name "${pod_names[$i]}" --arg uid "${pod_uids[$i]}" --arg node "${pod_nodes[$i]}" --arg sandbox "${pod_sandboxes[$i]}" --arg pid "${pod_pids[$i]}" --arg netns "${pod_netns[$i]}" --argjson restartCount "${pod_restarts[$i]}" --arg image "${EXPECTED_IMAGE}" '{name:$name,uid:$uid,node:$node,sandbox:$sandbox,pid:$pid,netns:$netns,restartCount:$restartCount,image:$image}'; done | jq -s .)" \
   --argjson deployment "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,status:{observedGeneration:.status.observedGeneration}}' <<<"${deployment}")" \
   --argjson metrics "$(jq -n --arg targets "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"0"')" --arg ha "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1]//"0"')" '{targets:$targets,ha:$ha}')" \
-  '{owner:$owner,revision:$revision,secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
+  '{owner:$owner,revision:$revision,observability:{expectedRevision:$expectedObservabilityRevision,observedRevision:$observedObservabilityRevision},secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
 printf '%s\n' "${preflight_http[@]}" >"${evidence_dir}/endpoints-before.tsv"
 printf '%s\n' "${cf_history}" >"${evidence_dir}/cloudflare-helm-history.json"
 printf '%s\n' "${obs_history}" >"${evidence_dir}/observability-helm-history.json"
@@ -316,8 +339,10 @@ done
 prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' >"${evidence_dir}/recovery-metrics.json"
 [[ "$(kubectl -n cloudflare get secret tunnel-token -o jsonpath='{.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\t"}{.metadata.creationTimestamp}{"\n"}')" == "${secret_metadata}" ]] || die 'Secret metadata changed'
 [[ "$(helm -n cloudflare history cloudflare-tunnel -o json)" == "${cf_history}" ]] || die 'Cloudflare Helm history changed'
-[[ "$(helm -n monitoring history kube-prometheus-stack -o json)" == "${obs_history}" ]] || die 'observability Helm history changed'
+final_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
+read_observability_revision "${final_obs_history}"
+[[ "${final_obs_history}" == "${obs_history}" ]] || die 'observability Helm history changed'
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 [[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
 just cf-tunnel-verify env=staging
-printf 'PASS: same cloudflared processes recovered; sanitized evidence: %s\n' "${evidence_dir}"
+printf 'PASS: same cloudflared processes recovered; observability expected revision %s, observed revision %s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -30,7 +30,9 @@ class StatefulDrillHarness:
         self.evidence = tmp_path / "evidence"
         state = {
             "context": "sugar-staging", "revision": "approved", "dirty": False,
-            "image_ok": True, "helm_revision": 2, "pod_count": 2,
+            "image_ok": True, "helm_revision": 2,
+            "observability_history": [{"status": "deployed", "revision": 10}],
+            "observability_history_after": None, "observability_calls": 0, "pod_count": 2,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
@@ -50,6 +52,7 @@ class StatefulDrillHarness:
             "HARNESS_STATE": str(self.state),
             "HARNESS_LOG": str(self.log),
             "CF_DRILL_APPROVED_REVISION": "approved",
+            "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "10",
             "CF_DRILL_NODE_EXECUTOR": str(node),
         }
 
@@ -127,7 +130,12 @@ if name == "git":
 elif name == "helm":
     if "list" in args: out(json.dumps([{"name":"cloudflare-tunnel","status":"deployed","chart":"cloudflare-tunnel-0.3.2"}]))
     elif "cloudflare-tunnel" in args: out(json.dumps([{"status":"deployed","revision":state["helm_revision"]}]))
-    else: out('[{"status":"deployed","revision":9}]')
+    else:
+        state["observability_calls"] += 1
+        history = state["observability_history"]
+        if state["observability_calls"] > 1 and state.get("observability_history_after") is not None:
+            history = state["observability_history_after"]
+        save(); out(json.dumps(history))
 elif name == "just": sys.exit(0)
 elif name == "ruby":
     for i in range(16): out(f"https://endpoint-{i}.test")
@@ -215,6 +223,33 @@ def test_dry_run_performs_no_mutation_or_external_preflight(tmp_path: Path) -> N
     assert not marker.exists(), "dry-run should not even invoke cluster/node stubs"
 
 
+
+@pytest.mark.parametrize("mode", ["--manual-node-plan", "--execute"])
+def test_live_modes_require_explicit_observability_revision(tmp_path: Path, mode: str) -> None:
+    env = manual_plan_environment(tmp_path)
+    env.pop("CF_DRILL_EXPECTED_OBSERVABILITY_REVISION")
+    args = [mode]
+    if mode == "--execute":
+        args.append(f"--confirm={CONFIRM}")
+    result = run(*args, env=env)
+    assert result.returncode != 0
+    assert "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION must be supplied" in result.stderr
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "+1", "01", " 1", "1 ", "1.0", "ten", "10x"])
+def test_live_preflight_rejects_noncanonical_observability_revision(
+    tmp_path: Path, value: str
+) -> None:
+    env = manual_plan_environment(tmp_path) | {
+        "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": value,
+        "CF_DRILL_NODE_EXECUTOR": str(tmp_path / "must-not-run"),
+    }
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "canonical positive decimal integer" in result.stderr
+    assert not (tmp_path / "must-not-run").exists()
+
+
 def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -> dict[str, str]:
     image = TEXT.split("readonly EXPECTED_IMAGE='", 1)[1].split("'", 1)[0]
     deployment = {
@@ -242,7 +277,11 @@ def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -
     stub("ruby", "i=1; while [ $i -le 16 ]; do echo https://endpoint-$i.test; i=$((i+1)); done\n")
     stub("curl", "printf 200\n")
     stub("date", "printf 20260809T000000Z\n")
-    return {"PATH": f"{tmp_path}:/usr/bin:/bin", "CF_DRILL_APPROVED_REVISION": "approved"}
+    return {
+        "PATH": f"{tmp_path}:/usr/bin:/bin",
+        "CF_DRILL_APPROVED_REVISION": "approved",
+        "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "9",
+    }
 
 
 def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_commands(tmp_path: Path) -> None:
@@ -717,6 +756,64 @@ def test_node_execution_does_not_weaken_authentication() -> None:
     assert "sshpass" not in TEXT
     assert "authorized_keys" not in TEXT
     assert "CF_DRILL_NODE_EXECUTOR" in TEXT
+
+
+def test_matching_explicit_observability_revision_is_recorded_in_plan(tmp_path: Path) -> None:
+    env = manual_plan_environment(tmp_path)
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode == 0, result.stderr
+    assert "OBSERVABILITY expected_revision=9 observed_revision=9" in result.stdout
+
+
+def test_later_explicit_observability_revision_needs_no_source_change(tmp_path: Path) -> None:
+    env = manual_plan_environment(tmp_path) | {"CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "27"}
+    helm = tmp_path / "helm"
+    helm.write_text(helm.read_text().replace('"revision":9', '"revision":27'))
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode == 0, result.stderr
+    assert "expected_revision=27 observed_revision=27" in result.stdout
+    assert "== 27" not in TEXT
+
+
+@pytest.mark.parametrize(
+    ("history", "message"),
+    [
+        ([{"status": "deployed", "revision": 11}], "expected 10, observed 11"),
+        ([], "observed deployed entries 0"),
+        (
+            [{"status": "deployed", "revision": 10}, {"status": "deployed", "revision": 11}],
+            "observed deployed entries 2",
+        ),
+    ],
+)
+def test_observability_history_failures_precede_node_executor(
+    tmp_path: Path, history: list[dict[str, object]], message: str
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, observability_history=history)
+    result = harness.run()
+    assert result.returncode != 0
+    assert message in result.stderr
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+def test_expected_and_observed_observability_revisions_are_in_evidence(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    result = harness.run()
+    assert result.returncode == 0, result.stderr
+    preflight = json.loads((harness.evidence / "preflight.json").read_text())
+    assert preflight["observability"] == {"expectedRevision": "10", "observedRevision": "10"}
+    assert "observability expected revision 10, observed revision 10" in result.stdout
+
+
+def test_post_cleanup_observability_revision_drift_is_rejected(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(
+        tmp_path,
+        observability_history_after=[{"status": "deployed", "revision": 11}],
+    )
+    result = harness.run()
+    assert result.returncode != 0
+    assert "expected 10, observed 11" in result.stderr
+    assert harness.current()["tables"] == [False, False]
 
 
 @pytest.mark.parametrize("arguments", [[], ["env=staging"]])


### PR DESCRIPTION
### Motivation

- Diagnostic capture `/home/pi/operator-evidence/cloudflare-wan-observability-revision-diagnostic-20260809T235722Z` showed the monitoring `kube-prometheus-stack` release at Helm revision 10 while the drill code still hard-coded observability revision 9, exposing a stale constant. 
- The intent is to avoid embedding any fixed observability revision in the drill and instead require an operator-reviewed, explicit approval coordinate for any live preflight or execution.

### Description

- Introduce a required operator-supplied coordinate `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION` (no default) and validate it as a canonical positive decimal integer, rejecting zero, negative, signed, leading-zero, whitespace, non-numeric, and mixed values. 
- During live preflight the helper now reads `helm -n monitoring history kube-prometheus-stack -o json`, requires exactly one deployed entry, compares the deployed numeric revision to the supplied `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION`, and fails before any node-executor or privileged host actions if missing/invalid/ambiguous/mismatched. 
- The manual plan output and sanitized evidence now record both expected and observed observability revisions; the same approved coordinate is revalidated after cleanup to detect drift. 
- Update docs (`docs/cloudflare_tunnel.md`) to document the separate read-only Helm-history approval step and show how an operator passes the reviewed coordinate, and add focused offline tests that mock Helm/history and assert closed-fail behavior without performing any real cluster, SSH, systemd, or nftables mutations. 
- Files changed: `scripts/cloudflare_wan_dependency_loss_drill.sh`, `docs/cloudflare_tunnel.md`, `tests/test_cloudflare_wan_dependency_loss_drill.py` (local commit `85fd8f39e7b583ab0e86047358c02623b67a881c`).

### Testing

- Ran shell syntax validation: `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` (passed). 
- Ran the focused offline test suite: `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` (passed) and the broader set `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_hardening.py tests/test_docs_guardrails.py` (passed for the exercised tests). 
- Exercised offline plan invocations and recipe wrappers (`bash scripts/cloudflare_wan_dependency_loss_drill.sh`, `bash scripts/cloudflare_wan_dependency_loss_drill.sh --env=staging`, and offline `just` recipe invocations via test fixtures), all confirming the default offline plan remains non-mutating (passed). 
- Ran `linkchecker --no-warnings README.md docs/` (passed); ran `pre-commit` checks for the modified files (`pre-commit run --files docs/cloudflare_tunnel.md scripts/cloudflare_wan_dependency_loss_drill.sh tests/test_cloudflare_wan_dependency_loss_drill.py`) and whitespace/yaml hooks for those files (passed), while a repository-wide `pre-commit run --all-files` revealed many pre-existing unrelated linter/flake8 failures that were not introduced by this change (unrelated, pre-existing). 
- `pyspelling -c .spellcheck.yaml` could not fully run in this environment due to missing `aspell` (environment limitation). 
- No live infrastructure was accessed or changed: no Helm upgrades, no Kubernetes mutations, no SSH/node executor, no systemd watchdog creation on real hosts, and no nftables operations were performed; all live preflight behaviors were exercised with mocks. 

Note: the branch `codex/require-observability-revision` contains the local commit `85fd8f39e7b583ab0e86047358c02623b67a881c` and is ahead of `origin/main` locally, but pushing/opening the GitHub PR was blocked by missing repository credentials in this environment (push failed). The exact documented read-only manual-node-plan command to run after separately reviewing and approving the observability revision is:

```
CF_DRILL_APPROVED_REVISION=<approved-git-sha> \
CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<approved-observability-revision> \
  just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
```

This change deliberately does not set or assume revision 10 as a default; operators must obtain and explicitly approve the single deployed observability revision via a separate read-only gate before any live preflight or execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7914fa038c832f925aba5901080eee)