### PR TITLE
Require approved observability Helm revision for Cloudflare WAN drill

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -526,6 +526,26 @@ part of this rollout.
    just cf-tunnel-wan-dependency-loss-drill env=staging
    ```
 
+   Before any live preflight, use a **separate, read-only approval gate** to inspect the
+   `monitoring/kube-prometheus-stack` Helm history. Confirm that it has exactly one deployed entry,
+   review that entry's positive-integer revision with the change approver, and record the approved
+   coordinate out of band. The drill deliberately does not query Helm to choose or approve this value,
+   and no revision shown by a prior capture is a permanent default. After that independent review,
+   enter the reviewed coordinate when prompted and run the read-only manual-node plan:
+
+   ```bash
+   read -r -p 'Approved observability Helm revision: ' APPROVED_OBSERVABILITY_REVISION
+   CF_DRILL_EXPECTED_OBSERVABILITY_REVISION="${APPROVED_OBSERVABILITY_REVISION}" \
+     CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
+     just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
+   ```
+
+   Do not use a command substitution from `helm history` in this invocation: that would silently
+   discover rather than explicitly approve the coordinate. The default plan above remains fully
+   offline and needs neither approval variable. The manual-node-plan and execute paths require
+   `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION` to be a canonical positive decimal integer and fail
+   closed unless exactly one deployed observability history entry matches it.
+
    The helper selects the two exact preflight-approved pod sandboxes and installs a uniquely named
    `nftables` output table inside each pod network namespace. Unlike a newly applied Kubernetes policy,
    the namespace-local output hook evaluates every packet in established QUIC and TCP flows. It drops
@@ -534,7 +554,8 @@ part of this rollout.
    rule and never flushes a ruleset.
 
    Execution remains **blocked unless every preflight passes**. In addition to `--execute`, the operator
-   must provide the approved Git revision, a safe executable node-command adapter, and the exact typed
+   must provide the approved Git revision, the separately approved observability Helm revision, a safe
+   executable node-command adapter, and the exact typed
    confirmation printed by `--help`. The adapter boundary is intentional: the repository does not assume
    unattended remote access, weaken host-key checking, create keys, or handle login credentials. If
    authenticated privileged execution on both nodes cannot be guaranteed, stop at the plan and run
@@ -554,7 +575,8 @@ part of this rollout.
    commands. The disruption is limited to three minutes, below the shortest five-minute alert threshold.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
-   Helm histories, Secret metadata, and Deployment state must be unchanged; and
+   Helm histories, including the single deployed observability release at the explicitly approved
+   revision, Secret metadata, and Deployment state must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -28,9 +28,11 @@ Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
        cloudflare_wan_dependency_loss_drill.sh --manual-node-plan [--env staging]
        [--confirm 'DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY']
 
-The default is a non-mutating plan. Execution also requires:
+The default offline plan requires no approval coordinates or cluster/node tools.
+Both --manual-node-plan and --execute require:
   CF_DRILL_APPROVED_REVISION=<full git revision>
   CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<separately reviewed positive integer>
+Execution additionally requires the exact confirmation and:
   CF_DRILL_NODE_EXECUTOR=<executable accepting NODE and COMMAND arguments>
 The executor is deliberately not SSH: authentication and sudo must be established separately.
 It must execute the supplied command verbatim on the named node and must not log credentials.
@@ -81,14 +83,15 @@ render_manual_node_plan() {
 }
 
 validate_observability_history() {
-  local history="$1" phase="$2" deployed_count revision
+  local history="$1" phase="$2" deployed_count revision revision_json
   deployed_count="$(jq '[.[] | select(.status == "deployed")] | length' <<<"${history}")" || \
     die "${phase} observability Helm history is not valid JSON"
   [[ "${deployed_count}" == 1 ]] || \
     die "${phase} observability Helm history must contain exactly one deployed entry (expected revision ${expected_observability_revision}; observed deployed entries ${deployed_count})"
-  revision="$(jq -r '[.[] | select(.status == "deployed")][0].revision' <<<"${history}")"
-  [[ "${revision}" =~ ^[1-9][0-9]*$ ]] || \
-    die "${phase} observability deployed revision is not a canonical positive decimal integer (expected ${expected_observability_revision}; observed ${revision})"
+  revision_json="$(jq -c '[.[] | select(.status == "deployed")][0].revision' <<<"${history}")"
+  jq -e 'type == "number" and . > 0 and floor == .' <<<"${revision_json}" >/dev/null || \
+    die "${phase} observability deployed revision is not a positive integer-valued JSON number (expected ${expected_observability_revision}; observed ${revision_json})"
+  revision="$(jq -r '.' <<<"${revision_json}")"
   [[ "${revision}" == "${expected_observability_revision}" ]] || \
     die "${phase} observability Helm revision mismatch (expected ${expected_observability_revision}; observed ${revision})"
   observed_observability_revision="${revision}"

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -30,6 +30,7 @@ Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
 
 The default is a non-mutating plan. Execution also requires:
   CF_DRILL_APPROVED_REVISION=<full git revision>
+  CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<separately reviewed positive integer>
   CF_DRILL_NODE_EXECUTOR=<executable accepting NODE and COMMAND arguments>
 The executor is deliberately not SSH: authentication and sudo must be established separately.
 It must execute the supplied command verbatim on the named node and must not log credentials.
@@ -49,6 +50,7 @@ render_manual_node_plan() {
   local -a disruptions=() cleanups=()
   table="$(table_for)"
   printf 'MANUAL NODE PLAN -- commands were rendered but NOT EXECUTED.\n'
+  printf 'Observability Helm revision: expected=%s observed=%s\n' "${expected_observability_revision}" "${observed_observability_revision}"
   printf 'Run each record through a separately authenticated, host-key-verified session for its exact node.\n'
   printf 'Complete and verify both watchdog commands successfully before running either DISRUPTION command.\n'
   printf 'After the observation window, run both CLEANUP commands.\n'
@@ -76,6 +78,20 @@ render_manual_node_plan() {
     printf 'CLEANUP node=%q pod=%q uid=%q owner=%q table=%q command=%q\n' "${pod_nodes[$i]}" "${pod_names[$i]}" "${pod_uids[$i]}" "${owner}" "${table}" "${cleanups[$i]}"
   done
   printf 'BLOCKED: manual-node plan only; the drill was not executed and has not passed.\n'
+}
+
+validate_observability_history() {
+  local history="$1" phase="$2" deployed_count revision
+  deployed_count="$(jq '[.[] | select(.status == "deployed")] | length' <<<"${history}")" || \
+    die "${phase} observability Helm history is not valid JSON"
+  [[ "${deployed_count}" == 1 ]] || \
+    die "${phase} observability Helm history must contain exactly one deployed entry (expected revision ${expected_observability_revision}; observed deployed entries ${deployed_count})"
+  revision="$(jq -r '[.[] | select(.status == "deployed")][0].revision' <<<"${history}")"
+  [[ "${revision}" =~ ^[1-9][0-9]*$ ]] || \
+    die "${phase} observability deployed revision is not a canonical positive decimal integer (expected ${expected_observability_revision}; observed ${revision})"
+  [[ "${revision}" == "${expected_observability_revision}" ]] || \
+    die "${phase} observability Helm revision mismatch (expected ${expected_observability_revision}; observed ${revision})"
+  observed_observability_revision="${revision}"
 }
 
 manual_cleanup() {
@@ -137,6 +153,9 @@ owner="cfwandrill-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 if ((execute)); then
   [[ "${confirmation}" == "${CONFIRMATION}" ]] || die "confirmation must exactly equal: ${CONFIRMATION}"
 fi
+expected_observability_revision="${CF_DRILL_EXPECTED_OBSERVABILITY_REVISION:-}"
+[[ "${expected_observability_revision}" =~ ^[1-9][0-9]*$ ]] || \
+  die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required and must be a canonical positive decimal integer (for example, 10; no signs, whitespace, or leading zeros)'
 [[ -n "${CF_DRILL_APPROVED_REVISION:-}" ]] || die 'CF_DRILL_APPROVED_REVISION is required'
 [[ "$(kubectl config current-context)" == "${EXPECTED_CONTEXT}" ]] || die "context must be ${EXPECTED_CONTEXT}"
 [[ -z "$(git status --porcelain)" ]] || die 'repository worktree must be clean'
@@ -150,7 +169,8 @@ releases="$(helm -n cloudflare list -o json)"
 cf_history="$(helm -n cloudflare history cloudflare-tunnel -o json)"
 [[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${cf_history}")" == "${EXPECTED_HELM_REVISION}" ]] || die 'Cloudflare Helm revision must be 2'
 obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
-[[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${obs_history}")" == 9 ]] || die 'observability Helm revision must be 9'
+observed_observability_revision=''
+validate_observability_history "${obs_history}" 'preflight'
 
 deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 jq -e --arg image "${EXPECTED_IMAGE}" '
@@ -230,10 +250,11 @@ done
 evidence_dir="${evidence_dir:-${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-${owner}}"
 umask 077; mkdir -p "${evidence_dir}"
 jq -n --arg owner "${owner}" --arg revision "${head_revision}" --arg secret "${secret_metadata}" \
+  --arg expectedObservabilityRevision "${expected_observability_revision}" --arg observedObservabilityRevision "${observed_observability_revision}" \
   --argjson pods "$(for i in 0 1; do jq -n --arg name "${pod_names[$i]}" --arg uid "${pod_uids[$i]}" --arg node "${pod_nodes[$i]}" --arg sandbox "${pod_sandboxes[$i]}" --arg pid "${pod_pids[$i]}" --arg netns "${pod_netns[$i]}" --argjson restartCount "${pod_restarts[$i]}" --arg image "${EXPECTED_IMAGE}" '{name:$name,uid:$uid,node:$node,sandbox:$sandbox,pid:$pid,netns:$netns,restartCount:$restartCount,image:$image}'; done | jq -s .)" \
   --argjson deployment "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,status:{observedGeneration:.status.observedGeneration}}' <<<"${deployment}")" \
   --argjson metrics "$(jq -n --arg targets "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"0"')" --arg ha "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1]//"0"')" '{targets:$targets,ha:$ha}')" \
-  '{owner:$owner,revision:$revision,secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
+  '{owner:$owner,revision:$revision,observabilityRevision:{expected:$expectedObservabilityRevision,observed:$observedObservabilityRevision},secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
 printf '%s\n' "${preflight_http[@]}" >"${evidence_dir}/endpoints-before.tsv"
 printf '%s\n' "${cf_history}" >"${evidence_dir}/cloudflare-helm-history.json"
 printf '%s\n' "${obs_history}" >"${evidence_dir}/observability-helm-history.json"
@@ -316,8 +337,10 @@ done
 prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' >"${evidence_dir}/recovery-metrics.json"
 [[ "$(kubectl -n cloudflare get secret tunnel-token -o jsonpath='{.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\t"}{.metadata.creationTimestamp}{"\n"}')" == "${secret_metadata}" ]] || die 'Secret metadata changed'
 [[ "$(helm -n cloudflare history cloudflare-tunnel -o json)" == "${cf_history}" ]] || die 'Cloudflare Helm history changed'
-[[ "$(helm -n monitoring history kube-prometheus-stack -o json)" == "${obs_history}" ]] || die 'observability Helm history changed'
+recovery_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
+validate_observability_history "${recovery_obs_history}" 'post-cleanup'
+[[ "${recovery_obs_history}" == "${obs_history}" ]] || die "observability Helm history changed (expected deployed revision ${expected_observability_revision}; observed ${observed_observability_revision})"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 [[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
 just cf-tunnel-verify env=staging
-printf 'PASS: same cloudflared processes recovered; sanitized evidence: %s\n' "${evidence_dir}"
+printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -31,6 +31,7 @@ class StatefulDrillHarness:
         state = {
             "context": "sugar-staging", "revision": "approved", "dirty": False,
             "image_ok": True, "helm_revision": 2, "pod_count": 2,
+            "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
@@ -50,6 +51,7 @@ class StatefulDrillHarness:
             "HARNESS_STATE": str(self.state),
             "HARNESS_LOG": str(self.log),
             "CF_DRILL_APPROVED_REVISION": "approved",
+            "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "10",
             "CF_DRILL_NODE_EXECUTOR": str(node),
         }
 
@@ -127,7 +129,13 @@ if name == "git":
 elif name == "helm":
     if "list" in args: out(json.dumps([{"name":"cloudflare-tunnel","status":"deployed","chart":"cloudflare-tunnel-0.3.2"}]))
     elif "cloudflare-tunnel" in args: out(json.dumps([{"status":"deployed","revision":state["helm_revision"]}]))
-    else: out('[{"status":"deployed","revision":9}]')
+    else:
+        state["obs_history_calls"] = state.get("obs_history_calls", 0) + 1
+        revision = state["obs_revision"]
+        if state["obs_history_calls"] > 1 and state["obs_revision_after_cleanup"] is not None:
+            revision = state["obs_revision_after_cleanup"]
+        entries = [{"status":"deployed","revision":revision} for _ in range(state["obs_deployed_entries"])]
+        out(json.dumps(entries)); save()
 elif name == "just": sys.exit(0)
 elif name == "ruby":
     for i in range(16): out(f"https://endpoint-{i}.test")
@@ -215,7 +223,34 @@ def test_dry_run_performs_no_mutation_or_external_preflight(tmp_path: Path) -> N
     assert not marker.exists(), "dry-run should not even invoke cluster/node stubs"
 
 
-def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -> dict[str, str]:
+@pytest.mark.parametrize("mode", ["manual", "execute"])
+def test_live_modes_require_explicit_observability_revision(
+    tmp_path: Path, mode: str,
+) -> None:
+    env = manual_plan_environment(tmp_path)
+    env.pop("CF_DRILL_EXPECTED_OBSERVABILITY_REVISION")
+    args = ["--manual-node-plan"] if mode == "manual" else ["--execute", f"--confirm={CONFIRM}"]
+    result = run(*args, env=env)
+    assert result.returncode != 0
+    assert "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required" in result.stderr
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "+10", "01", " 10", "10 ", "ten", "10x"])
+def test_live_modes_reject_noncanonical_observability_revision(
+    tmp_path: Path, value: str,
+) -> None:
+    env = manual_plan_environment(tmp_path)
+    env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = value
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "canonical positive decimal integer" in result.stderr
+    assert not (tmp_path / "node-executor-called").exists()
+
+
+def manual_plan_environment(
+    tmp_path: Path, *, context: str = "sugar-staging", obs_revision: int = 10,
+    obs_deployed_entries: int = 1,
+) -> dict[str, str]:
     image = TEXT.split("readonly EXPECTED_IMAGE='", 1)[1].split("'", 1)[0]
     deployment = {
         "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "app.kubernetes.io/name": "cloudflare-tunnel", "app.kubernetes.io/instance": "cloudflare-tunnel"}},
@@ -236,13 +271,20 @@ def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -
         path.chmod(0o755)
 
     stub("git", "case \"$*\" in *status*) exit 0;; *rev-parse*) echo approved;; esac\n")
-    stub("helm", "case \"$*\" in *' list '*) printf '%s\\n' '[{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}]';; *cloudflare-tunnel*) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":2}]';; *) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":9}]';; esac\n")
+    obs_history = json.dumps(
+        [{"status": "deployed", "revision": obs_revision}] * obs_deployed_entries
+    )
+    stub("helm", f"case \"$*\" in *' list '*) printf '%s\\n' '[{{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}}]';; *cloudflare-tunnel*) printf '%s\\n' '[{{\"status\":\"deployed\",\"revision\":2}}]';; *) printf '%s\\n' {json.dumps(obs_history)};; esac\n")
     stub("kubectl", f"case \"$*\" in *current-context*) echo {context};; *'get deployment'*) printf '%s\\n' {json.dumps(json.dumps(deployment))};; *'get pods'*) printf '%s\\n' {json.dumps(json.dumps(pods))};; *'get secret'*) printf 'secret-uid\\t12\\t2026-08-09T00:00:00Z\\n';; *ALERTS*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"0\"]}}]}}}}';; *get\\ --raw*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"2\"]}}]}}}}';; esac\n")
     stub("just", "exit 0\n")
     stub("ruby", "i=1; while [ $i -le 16 ]; do echo https://endpoint-$i.test; i=$((i+1)); done\n")
     stub("curl", "printf 200\n")
     stub("date", "printf 20260809T000000Z\n")
-    return {"PATH": f"{tmp_path}:/usr/bin:/bin", "CF_DRILL_APPROVED_REVISION": "approved"}
+    return {
+        "PATH": f"{tmp_path}:/usr/bin:/bin",
+        "CF_DRILL_APPROVED_REVISION": "approved",
+        "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": str(obs_revision),
+    }
 
 
 def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_commands(tmp_path: Path) -> None:
@@ -266,6 +308,39 @@ def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_co
     assert all("systemctl" in lines[i] and "MainPID" in lines[i] for i in disruptions)
     assert all("delete\\ table\\ inet" in lines[i] and "list\\ ruleset" in lines[i] and "length\\ ==\\ 0" in lines[i] for i in cleanups)
     assert "BLOCKED: manual-node plan only; the drill was not executed and has not passed." in result.stdout
+    assert "Observability Helm revision: expected=10 observed=10" in result.stdout
+
+
+def test_later_matching_observability_revision_needs_no_source_change(tmp_path: Path) -> None:
+    result = run(
+        "--manual-node-plan",
+        env=manual_plan_environment(tmp_path, obs_revision=42),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "expected=42 observed=42" in result.stdout
+
+
+def test_observability_revision_mismatch_fails_before_node_executor(tmp_path: Path) -> None:
+    env = manual_plan_environment(tmp_path, obs_revision=10)
+    env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = "11"
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "expected 11; observed 10" in result.stderr
+    assert "WATCHDOG " not in result.stdout
+
+
+@pytest.mark.parametrize("deployed_entries", [0, 2])
+def test_observability_history_requires_exactly_one_deployed_entry(
+    tmp_path: Path, deployed_entries: int,
+) -> None:
+    env = manual_plan_environment(
+        tmp_path, obs_revision=10, obs_deployed_entries=deployed_entries
+    )
+    env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = "10"
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "exactly one deployed entry" in result.stderr
+    assert "WATCHDOG " not in result.stdout
 
 
 def test_manual_node_plan_preflight_failure_emits_no_actionable_commands(tmp_path: Path) -> None:
@@ -561,10 +636,39 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
+    assert preflight["observabilityRevision"] == {"expected": "10", "observed": "10"}
+    assert "observability revision expected=10 observed=10" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
     assert (harness.evidence / "interruption-metrics.json").exists()
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+@pytest.mark.parametrize("expected", ["", "0", "-1", "+10", "01", " 10", "ten"])
+def test_invalid_coordinate_never_invokes_node_executor(
+    tmp_path: Path, expected: str,
+) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    harness.env["CF_DRILL_EXPECTED_OBSERVABILITY_REVISION"] = expected
+    result = harness.run()
+    assert result.returncode != 0
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+def test_revision_mismatch_never_invokes_node_executor(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, obs_revision=11)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "expected 10; observed 11" in result.stderr
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+def test_post_cleanup_observability_revision_drift_is_rejected(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, obs_revision_after_cleanup=11)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "post-cleanup observability Helm revision mismatch" in result.stderr
+    assert harness.current()["tables"] == [False, False]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -223,6 +223,20 @@ def test_dry_run_performs_no_mutation_or_external_preflight(tmp_path: Path) -> N
     assert not marker.exists(), "dry-run should not even invoke cluster/node stubs"
 
 
+def test_help_distinguishes_offline_manual_and_execution_requirements() -> None:
+    result = run("--help")
+    assert result.returncode == 0
+    assert (
+        "default offline plan requires no approval coordinates or cluster/node tools"
+        in result.stdout
+    )
+    assert "Both --manual-node-plan and --execute require:" in result.stdout
+    assert "CF_DRILL_APPROVED_REVISION" in result.stdout
+    assert "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION" in result.stdout
+    assert "Execution additionally requires the exact confirmation and:" in result.stdout
+    assert "CF_DRILL_NODE_EXECUTOR" in result.stdout
+
+
 @pytest.mark.parametrize("mode", ["manual", "execute"])
 def test_live_modes_require_explicit_observability_revision(
     tmp_path: Path, mode: str,
@@ -661,6 +675,20 @@ def test_revision_mismatch_never_invokes_node_executor(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "expected 10; observed 11" in result.stderr
     assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+
+
+@pytest.mark.parametrize("observed", ["10", 10.5])
+def test_invalid_observed_revision_type_never_reaches_disruption(
+    tmp_path: Path, observed: object,
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, obs_revision=observed)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "positive integer-valued JSON number" in result.stderr
+    assert not any(entry["tool"] == "node-executor" for entry in harness.commands())
+    assert not any(
+        event.get("event") in {"watchdog", "table"} for event in harness.events()
+    )
 
 
 def test_post_cleanup_observability_revision_drift_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

The diagnostic capture at `/home/pi/operator-evidence/cloudflare-wan-observability-revision-diagnostic-20260809T235722Z` showed a healthy observability release at Helm revision 10 while the Cloudflare WAN dependency-loss drill still embedded revision 9.

Revision 10 is evidence of the reviewed current state, not a new constant or default. Live preflight and execution must instead require an explicit operator-approved coordinate.

This PR is based on required ancestor `4e20cfc9c90d9c43fad444aefe133bbf27c66bb4` from PR #2570.

### Changes

- Add the operator-supplied `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION` coordinate without defaulting, inference, or automatic Helm discovery.
- Require a canonical positive decimal integer for live manual-plan and execute modes, rejecting empty, zero, negative, signed, leading-zero, whitespace, non-numeric, and mixed values.
- Preserve the dependency-free, non-mutating default offline plan.
- During live preflight, require exactly one deployed `monitoring/kube-prometheus-stack` Helm-history entry whose integer-valued JSON revision matches the approved coordinate.
- Fail closed before the node executor, watchdogs, pod namespaces, or `nftables` can be reached when validation fails.
- Record expected and observed observability revisions in the rendered manual plan and evidence output.
- Revalidate the approved revision after cleanup and reject history or revision drift.
- Preserve all existing staging, Cloudflare Tunnel revision, image, ownership, executor, exact-owner cleanup, and transient-watchdog checks.
- Document the separate read-only approval gate in `docs/cloudflare_tunnel.md`.

Changed paths are limited to:

- `scripts/cloudflare_wan_dependency_loss_drill.sh`
- `tests/test_cloudflare_wan_dependency_loss_drill.py`
- `docs/cloudflare_tunnel.md`

### Read-only manual plan

Operators must inspect and approve the current observability revision through a separate read-only gate. Do not substitute a command that derives the value automatically from `helm history`.

After approval, run:

~~~bash
read -r -p 'Approved observability Helm revision: ' APPROVED_OBSERVABILITY_REVISION
CF_DRILL_EXPECTED_OBSERVABILITY_REVISION="${APPROVED_OBSERVABILITY_REVISION}" \
  CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
  just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
~~~

### Verification

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh`
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — 96 passed
- `pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_justfile_formatting.py` — 30 passed
- `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION -u CF_DRILL_APPROVED_REVISION bash scripts/cloudflare_wan_dependency_loss_drill.sh`
- `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION -u CF_DRILL_APPROVED_REVISION just cf-tunnel-wan-dependency-loss-drill env=staging`
- `git diff --check`
- `git diff --cached | ./scripts/scan-secrets.py`
- Targeted formatting hooks passed; the repository-wide `run-checks` hook reported lint findings outside the changed paths.

No production access, live drill, Kubernetes or Helm deployment, SSH, namespace entry, systemd operation, or `nftables` mutation was performed. This PR does not close or claim completion of any WAN-linked issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7914f75610832fb3b57c66e87fe9b5)