### PR TITLE
Require operator-approved observability Helm revision for Cloudflare WAN drill

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -526,6 +526,21 @@ part of this rollout.
    just cf-tunnel-wan-dependency-loss-drill env=staging
    ```
 
+   Before any live read-only preflight, obtain the current
+   `monitoring/kube-prometheus-stack` revision through a **separate read-only review gate** and have
+   the operator approve that coordinate. The helper deliberately does not discover, infer, or default
+   it. Pass the reviewed positive decimal revision explicitly when rendering the read-only manual node
+   plan (replace `<approved-observability-revision>` with the separately approved value):
+
+   ```bash
+   CF_DRILL_EXPECTED_OBSERVABILITY_REVISION='<approved-observability-revision>' \
+     CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
+     just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
+   ```
+
+   This command performs cluster preflight and renders commands, but does not invoke a node executor.
+   A later healthy Helm revision can be reviewed and supplied without changing this repository.
+
    The helper selects the two exact preflight-approved pod sandboxes and installs a uniquely named
    `nftables` output table inside each pod network namespace. Unlike a newly applied Kubernetes policy,
    the namespace-local output hook evaluates every packet in established QUIC and TCP flows. It drops
@@ -534,7 +549,8 @@ part of this rollout.
    rule and never flushes a ruleset.
 
    Execution remains **blocked unless every preflight passes**. In addition to `--execute`, the operator
-   must provide the approved Git revision, a safe executable node-command adapter, and the exact typed
+   must provide the approved Git revision, the separately approved observability Helm revision, a safe
+   executable node-command adapter, and the exact typed
    confirmation printed by `--help`. The adapter boundary is intentional: the repository does not assume
    unattended remote access, weaken host-key checking, create keys, or handle login credentials. If
    authenticated privileged execution on both nodes cannot be guaranteed, stop at the plan and run

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -30,6 +30,7 @@ Usage: cloudflare_wan_dependency_loss_drill.sh [--execute] [--env staging]
 
 The default is a non-mutating plan. Execution also requires:
   CF_DRILL_APPROVED_REVISION=<full git revision>
+  CF_DRILL_EXPECTED_OBSERVABILITY_REVISION=<separately reviewed positive Helm revision>
   CF_DRILL_NODE_EXECUTOR=<executable accepting NODE and COMMAND arguments>
 The executor is deliberately not SSH: authentication and sudo must be established separately.
 It must execute the supplied command verbatim on the named node and must not log credentials.
@@ -49,6 +50,8 @@ render_manual_node_plan() {
   local -a disruptions=() cleanups=()
   table="$(table_for)"
   printf 'MANUAL NODE PLAN -- commands were rendered but NOT EXECUTED.\n'
+  printf 'Observability Helm revision: expected=%s observed=%s\n' \
+    "${expected_observability_revision}" "${observed_observability_revision}"
   printf 'Run each record through a separately authenticated, host-key-verified session for its exact node.\n'
   printf 'Complete and verify both watchdog commands successfully before running either DISRUPTION command.\n'
   printf 'After the observation window, run both CLEANUP commands.\n'
@@ -133,10 +136,16 @@ EOF
   exit 0
 fi
 
-owner="cfwandrill-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 if ((execute)); then
   [[ "${confirmation}" == "${CONFIRMATION}" ]] || die "confirmation must exactly equal: ${CONFIRMATION}"
 fi
+expected_observability_revision="${CF_DRILL_EXPECTED_OBSERVABILITY_REVISION:-}"
+[[ -n "${expected_observability_revision}" ]] || \
+  die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required for live preflight and execution'
+[[ "${expected_observability_revision}" =~ ^[1-9][0-9]*$ ]] || \
+  die 'CF_DRILL_EXPECTED_OBSERVABILITY_REVISION must be a canonical positive decimal integer (for example, 10; no sign, whitespace, or leading zero)'
+
+owner="cfwandrill-$(date -u +%Y%m%dT%H%M%SZ)-$$"
 [[ -n "${CF_DRILL_APPROVED_REVISION:-}" ]] || die 'CF_DRILL_APPROVED_REVISION is required'
 [[ "$(kubectl config current-context)" == "${EXPECTED_CONTEXT}" ]] || die "context must be ${EXPECTED_CONTEXT}"
 [[ -z "$(git status --porcelain)" ]] || die 'repository worktree must be clean'
@@ -150,7 +159,14 @@ releases="$(helm -n cloudflare list -o json)"
 cf_history="$(helm -n cloudflare history cloudflare-tunnel -o json)"
 [[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${cf_history}")" == "${EXPECTED_HELM_REVISION}" ]] || die 'Cloudflare Helm revision must be 2'
 obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
-[[ "$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${obs_history}")" == 9 ]] || die 'observability Helm revision must be 9'
+observability_deployed_count="$(jq '[.[]|select(.status=="deployed")]|length' <<<"${obs_history}")"
+[[ "${observability_deployed_count}" == 1 ]] || \
+  die "observability Helm history must contain exactly one deployed entry; expected revision=${expected_observability_revision}, deployed entries=${observability_deployed_count}"
+observed_observability_revision="$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${obs_history}")"
+[[ "${observed_observability_revision}" =~ ^[1-9][0-9]*$ ]] || \
+  die "observability deployed revision is not a canonical positive decimal integer; expected=${expected_observability_revision}, observed=${observed_observability_revision}"
+[[ "${observed_observability_revision}" == "${expected_observability_revision}" ]] || \
+  die "observability Helm revision mismatch; expected=${expected_observability_revision}, observed=${observed_observability_revision}"
 
 deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 jq -e --arg image "${EXPECTED_IMAGE}" '
@@ -230,10 +246,12 @@ done
 evidence_dir="${evidence_dir:-${HOME}/operator-evidence/cloudflare-wan-dependency-loss-drill-${owner}}"
 umask 077; mkdir -p "${evidence_dir}"
 jq -n --arg owner "${owner}" --arg revision "${head_revision}" --arg secret "${secret_metadata}" \
+  --arg expectedObservabilityRevision "${expected_observability_revision}" \
+  --arg observedObservabilityRevision "${observed_observability_revision}" \
   --argjson pods "$(for i in 0 1; do jq -n --arg name "${pod_names[$i]}" --arg uid "${pod_uids[$i]}" --arg node "${pod_nodes[$i]}" --arg sandbox "${pod_sandboxes[$i]}" --arg pid "${pod_pids[$i]}" --arg netns "${pod_netns[$i]}" --argjson restartCount "${pod_restarts[$i]}" --arg image "${EXPECTED_IMAGE}" '{name:$name,uid:$uid,node:$node,sandbox:$sandbox,pid:$pid,netns:$netns,restartCount:$restartCount,image:$image}'; done | jq -s .)" \
   --argjson deployment "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,status:{observedGeneration:.status.observedGeneration}}' <<<"${deployment}")" \
   --argjson metrics "$(jq -n --arg targets "$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"0"')" --arg ha "$(prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' | jq -r '.data.result[0].value[1]//"0"')" '{targets:$targets,ha:$ha}')" \
-  '{owner:$owner,revision:$revision,secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
+  '{owner:$owner,revision:$revision,observability:{expectedRevision:$expectedObservabilityRevision,observedRevision:$observedObservabilityRevision},secretMetadata:$secret,pods:$pods,deployment:$deployment,preflightMetrics:$metrics}' >"${evidence_dir}/preflight.json"
 printf '%s\n' "${preflight_http[@]}" >"${evidence_dir}/endpoints-before.tsv"
 printf '%s\n' "${cf_history}" >"${evidence_dir}/cloudflare-helm-history.json"
 printf '%s\n' "${obs_history}" >"${evidence_dir}/observability-helm-history.json"
@@ -316,8 +334,16 @@ done
 prom_query 'count(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"} >= 4)' >"${evidence_dir}/recovery-metrics.json"
 [[ "$(kubectl -n cloudflare get secret tunnel-token -o jsonpath='{.metadata.uid}{"\t"}{.metadata.resourceVersion}{"\t"}{.metadata.creationTimestamp}{"\n"}')" == "${secret_metadata}" ]] || die 'Secret metadata changed'
 [[ "$(helm -n cloudflare history cloudflare-tunnel -o json)" == "${cf_history}" ]] || die 'Cloudflare Helm history changed'
-[[ "$(helm -n monitoring history kube-prometheus-stack -o json)" == "${obs_history}" ]] || die 'observability Helm history changed'
+final_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json)"
+final_observability_deployed_count="$(jq '[.[]|select(.status=="deployed")]|length' <<<"${final_obs_history}")"
+[[ "${final_observability_deployed_count}" == 1 ]] || \
+  die "post-cleanup observability Helm history must contain exactly one deployed entry; expected revision=${expected_observability_revision}, deployed entries=${final_observability_deployed_count}"
+final_observed_observability_revision="$(jq -r '[.[]|select(.status=="deployed")][0].revision' <<<"${final_obs_history}")"
+[[ "${final_observed_observability_revision}" == "${expected_observability_revision}" ]] || \
+  die "post-cleanup observability Helm revision drift; expected=${expected_observability_revision}, observed=${final_observed_observability_revision}"
+[[ "${final_obs_history}" == "${obs_history}" ]] || die 'observability Helm history changed'
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
 [[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
 just cf-tunnel-verify env=staging
-printf 'PASS: same cloudflared processes recovered; sanitized evidence: %s\n' "${evidence_dir}"
+printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' \
+  "${expected_observability_revision}" "${final_observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -30,7 +30,9 @@ class StatefulDrillHarness:
         self.evidence = tmp_path / "evidence"
         state = {
             "context": "sugar-staging", "revision": "approved", "dirty": False,
-            "image_ok": True, "helm_revision": 2, "pod_count": 2,
+            "image_ok": True, "helm_revision": 2, "observability_revisions": [9],
+            "observability_revision_after_cleanup": None, "observability_history_calls": 0,
+            "pod_count": 2,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
@@ -50,6 +52,7 @@ class StatefulDrillHarness:
             "HARNESS_STATE": str(self.state),
             "HARNESS_LOG": str(self.log),
             "CF_DRILL_APPROVED_REVISION": "approved",
+            "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "9",
             "CF_DRILL_NODE_EXECUTOR": str(node),
         }
 
@@ -127,7 +130,12 @@ if name == "git":
 elif name == "helm":
     if "list" in args: out(json.dumps([{"name":"cloudflare-tunnel","status":"deployed","chart":"cloudflare-tunnel-0.3.2"}]))
     elif "cloudflare-tunnel" in args: out(json.dumps([{"status":"deployed","revision":state["helm_revision"]}]))
-    else: out('[{"status":"deployed","revision":9}]')
+    else:
+        state["observability_history_calls"] += 1
+        revisions = state["observability_revisions"]
+        if state["observability_history_calls"] > 1 and state["observability_revision_after_cleanup"] is not None:
+            revisions = [state["observability_revision_after_cleanup"]]
+        save(); out(json.dumps([{"status":"deployed","revision":revision} for revision in revisions]))
 elif name == "just": sys.exit(0)
 elif name == "ruby":
     for i in range(16): out(f"https://endpoint-{i}.test")
@@ -215,7 +223,41 @@ def test_dry_run_performs_no_mutation_or_external_preflight(tmp_path: Path) -> N
     assert not marker.exists(), "dry-run should not even invoke cluster/node stubs"
 
 
-def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -> dict[str, str]:
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--manual-node-plan"],
+        ["--execute", f"--confirm={CONFIRM}"],
+    ],
+)
+def test_live_modes_require_explicit_observability_revision(arguments: list[str]) -> None:
+    result = run(*arguments, env={"CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": ""})
+    assert result.returncode != 0
+    assert "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION is required" in result.stderr
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "+1", "01", " 1", "1 ", "1 2", "abc", "9x"])
+def test_live_modes_reject_noncanonical_observability_revision(value: str, tmp_path: Path) -> None:
+    marker = tmp_path / "node-called"
+    executor = tmp_path / "node-executor"
+    executor.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    executor.chmod(0o755)
+    result = run(
+        "--manual-node-plan",
+        env={
+            "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": value,
+            "CF_DRILL_NODE_EXECUTOR": str(executor),
+        },
+    )
+    assert result.returncode != 0
+    assert "required" in result.stderr or "canonical positive decimal integer" in result.stderr
+    assert not marker.exists()
+
+
+def manual_plan_environment(
+    tmp_path: Path, *, context: str = "sugar-staging", observed_revision: int = 9,
+    expected_revision: str = "9", deployed_entries: int = 1,
+) -> dict[str, str]:
     image = TEXT.split("readonly EXPECTED_IMAGE='", 1)[1].split("'", 1)[0]
     deployment = {
         "metadata": {"labels": {"app.kubernetes.io/managed-by": "Helm", "app.kubernetes.io/name": "cloudflare-tunnel", "app.kubernetes.io/instance": "cloudflare-tunnel"}},
@@ -236,13 +278,21 @@ def manual_plan_environment(tmp_path: Path, *, context: str = "sugar-staging") -
         path.chmod(0o755)
 
     stub("git", "case \"$*\" in *status*) exit 0;; *rev-parse*) echo approved;; esac\n")
-    stub("helm", "case \"$*\" in *' list '*) printf '%s\\n' '[{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}]';; *cloudflare-tunnel*) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":2}]';; *) printf '%s\\n' '[{\"status\":\"deployed\",\"revision\":9}]';; esac\n")
+    obs_history = json.dumps([
+        {"status": "deployed", "revision": observed_revision}
+        for _ in range(deployed_entries)
+    ])
+    stub("helm", f"case \"$*\" in *' list '*) printf '%s\\n' '[{{\"name\":\"cloudflare-tunnel\",\"status\":\"deployed\",\"chart\":\"cloudflare-tunnel-0.3.2\"}}]';; *cloudflare-tunnel*) printf '%s\\n' '[{{\"status\":\"deployed\",\"revision\":2}}]';; *) printf '%s\\n' {json.dumps(obs_history)};; esac\n")
     stub("kubectl", f"case \"$*\" in *current-context*) echo {context};; *'get deployment'*) printf '%s\\n' {json.dumps(json.dumps(deployment))};; *'get pods'*) printf '%s\\n' {json.dumps(json.dumps(pods))};; *'get secret'*) printf 'secret-uid\\t12\\t2026-08-09T00:00:00Z\\n';; *ALERTS*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"0\"]}}]}}}}';; *get\\ --raw*) printf '%s\\n' '{{\"data\":{{\"result\":[{{\"value\":[0,\"2\"]}}]}}}}';; esac\n")
     stub("just", "exit 0\n")
     stub("ruby", "i=1; while [ $i -le 16 ]; do echo https://endpoint-$i.test; i=$((i+1)); done\n")
     stub("curl", "printf 200\n")
     stub("date", "printf 20260809T000000Z\n")
-    return {"PATH": f"{tmp_path}:/usr/bin:/bin", "CF_DRILL_APPROVED_REVISION": "approved"}
+    return {
+        "PATH": f"{tmp_path}:/usr/bin:/bin",
+        "CF_DRILL_APPROVED_REVISION": "approved",
+        "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": expected_revision,
+    }
 
 
 def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_commands(tmp_path: Path) -> None:
@@ -266,6 +316,41 @@ def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_co
     assert all("systemctl" in lines[i] and "MainPID" in lines[i] for i in disruptions)
     assert all("delete\\ table\\ inet" in lines[i] and "list\\ ruleset" in lines[i] and "length\\ ==\\ 0" in lines[i] for i in cleanups)
     assert "BLOCKED: manual-node plan only; the drill was not executed and has not passed." in result.stdout
+    assert "Observability Helm revision: expected=9 observed=9" in result.stdout
+
+
+def test_manual_plan_accepts_a_later_reviewed_revision_without_source_change(tmp_path: Path) -> None:
+    result = run(
+        "--manual-node-plan",
+        env=manual_plan_environment(tmp_path, observed_revision=42, expected_revision="42"),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "expected=42 observed=42" in result.stdout
+
+
+def test_observability_revision_mismatch_fails_before_node_executor(tmp_path: Path) -> None:
+    env = manual_plan_environment(tmp_path, observed_revision=11, expected_revision="12")
+    marker = tmp_path / "node-called"
+    executor = tmp_path / "node-executor"
+    executor.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    executor.chmod(0o755)
+    env["CF_DRILL_NODE_EXECUTOR"] = str(executor)
+    result = run("--manual-node-plan", env=env)
+    assert result.returncode != 0
+    assert "expected=12, observed=11" in result.stderr
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("deployed_entries", [0, 2])
+def test_observability_history_requires_exactly_one_deployed_entry(
+    tmp_path: Path, deployed_entries: int,
+) -> None:
+    result = run(
+        "--manual-node-plan",
+        env=manual_plan_environment(tmp_path, deployed_entries=deployed_entries),
+    )
+    assert result.returncode != 0
+    assert "exactly one deployed entry" in result.stderr
 
 
 def test_manual_node_plan_preflight_failure_emits_no_actionable_commands(tmp_path: Path) -> None:
@@ -561,10 +646,20 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
+    assert preflight["observability"] == {"expectedRevision": "9", "observedRevision": "9"}
+    assert "observability revision expected=9 observed=9" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
     assert (harness.evidence / "interruption-metrics.json").exists()
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+def test_post_cleanup_observability_revision_drift_fails_closed(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, observability_revision_after_cleanup=10)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "post-cleanup observability Helm revision drift; expected=9, observed=10" in result.stderr
+    assert harness.current()["tables"] == [False, False]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- The WAN dependency-loss drill embedded a stale hard-coded observability Helm revision (9), but live evidence showed revision 10; embedding a new constant is unacceptable.  
- The drill must require an explicit, operator-supplied coordinate for the monitoring release so live preflights and execution cannot silently accept or infer the value.  
- Offline plan behavior must remain non-mutating and must not require the coordinate or node executor.  

### Description

- Replaced the hard-coded observability revision check with an operator-supplied environment coordinate `CF_DRILL_EXPECTED_OBSERVABILITY_REVISION` and added strict validation for canonical positive decimal integers.  
- Implemented fail-closed Helm-history checks that require exactly one deployed `monitoring/kube-prometheus-stack` entry and that its numeric revision equals the supplied coordinate; the observed and expected revisions are recorded.  
- Surface the expected/observed observability revision in the rendered manual-node plan, include them in `evidence/preflight.json`, and revalidate post-cleanup that the deployed observability revision did not drift.  
- Updated `docs/cloudflare_tunnel.md` to document the separate read-only approval step and show how an operator passes the reviewed coordinate (example command with placeholder); documentation does not establish revision 10 as a default.  
- Expanded the mocked, offline-focused test suite to cover missing/empty variables, malformed values, mismatch handling, multiple/absent deployed entries, executor isolation on validation failures, later reviewed revisions, evidence output, and post-cleanup drift.  
- Files changed: `scripts/cloudflare_wan_dependency_loss_drill.sh`, `tests/test_cloudflare_wan_dependency_loss_drill.py`, `docs/cloudflare_tunnel.md` (see diff in the PR).  
- Diagnostic capture referenced in the change: `/home/pi/operator-evidence/cloudflare-wan-observability-revision-diagnostic-20260809T235722Z`.

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — syntax check passed.  
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — the focused test file was run locally after the changes and all tests in that file passed (mocked/offline harness).  
- Targeted runs of important scenarios passed, including the stateful interruption/recovery and post-cleanup drift checks.  
- Docs checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed for the updated docs.  
- `pre-commit run --all-files` could not be completed repository-wide due to unrelated, pre-existing lint/yaml issues outside the scope of this focused change; pre-commit hooks were run and passed for the modified files.  
- No live cluster, Helm, SSH, systemd, namespace, or nftables mutation was performed; all test behavior used mocked or local shims.  

Notes and next steps: a local branch with the change has been committed; pushing / opening the upstream pull request in GitHub failed in this environment because credentials are not available, so no PR URL was created here. The intended command to render the read-only manual-node-plan after a separate review/approval of the current monitoring revision is shown in the docs and is:  

```bash
CF_DRILL_EXPECTED_OBSERVABILITY_REVISION='<approved-observability-revision>' \
  CF_DRILL_APPROVED_REVISION="$(git rev-parse HEAD)" \
  just cf-tunnel-wan-dependency-loss-drill env=staging --manual-node-plan
```

This change requires an explicit operator approval step for the observability Helm revision and preserves all existing safety and cleanup guarantees.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7914fd6958832f9dcfd04b899d367c)