### PR TITLE
Enable and validate authenticated DSPACE production metrics (values-only contract)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -4,6 +4,33 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 
 ## Production Helm reconciliation for application 3.0.1
 
+### Authenticated production metrics at unchanged coordinates
+
+Production metrics are supported by the deployed DSPACE application **3.0.1** and chart
+**3.0.2**. This is a values-only reconciliation, not an application or chart promotion, and
+merging the repository change does not deploy it.
+
+Run from `sugarkube3` with the externally managed tunnel on `127.0.0.1:16443`, explicit
+`KUBECONFIG=$HOME/.kube/config-sugarkube-prod`, and context `sugar-prod`. Do **not** run
+`just kubeconfig-env env=prod` from `sugarkube3`. Install and check the credential first, using
+only the hidden terminal prompt:
+
+```bash
+export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+kubectl config use-context sugar-prod
+just observability-app-metrics-secret-install app=dspace env=prod
+just observability-app-metrics-secret-check app=dspace env=prod
+```
+
+For reconciliation, operators must supply the genuine existing finalized production evidence as
+immutable provenance, an executable runtime smoke runner, and a fresh, nonexisting evidence
+destination. Discover revisions dynamically rather than hard-coding revision 9. After rollout,
+run the bounded DSPACE runtime and `/chat` checks, production application-metrics verification,
+the dashboard API check, and manual dashboard inspection. DSPACE HTTP, runtime, and feature panels
+should populate; release-integrity, blackbox, token.place, and alerting panels may remain
+`NO DATA` until their separate production integrations are deployed. A post-mutation failure
+requires evidence review and deliberate reconciliation, not an immediate rerun or rollback.
+
 This section **prepares but does not execute** the incident reconciliation tracked by
 Sugarkube issue #2325. Keep the production Helm freeze in place throughout. The reviewed,
 machine-readable input is `docs/apps/dspace.prod-recovery-coordinates.json`: schema 2 keeps the
@@ -354,7 +381,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release is Helm revision 28 from the immutable DSPACE `3.1.0` staging image `main-018687f`, with finalized evidence recorded at `deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json`; operators can use that final record as the promotion and reconciliation proof instead of creating a replacement candidate/evidence path for this deployment. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production remains pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; authenticated metrics and its ServiceMonitor are enabled without changing either coordinate.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -12,3 +12,17 @@ env:
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
     value: llama-3.1-8b-instruct
+
+metrics:
+  enabled: true
+  auth:
+    existingSecret: dspace-prod-metrics-token
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube-prod

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -711,6 +711,13 @@ PagerDuty incident recovers and resolves. Re-run live verification.
 
 ## Declarative application metrics verification
 
+Production DSPACE application 3.0.1/chart 3.0.2 uses this guarded lifecycle with
+`app=dspace env=prod`. Run it only from `sugarkube3` with the externally managed
+`127.0.0.1:16443` tunnel, explicit `$HOME/.kube/config-sugarkube-prod`, and `sugar-prod` context;
+do not use `just kubeconfig-env env=prod` there. Install and check the production credential before
+the guarded values-only reconciliation. No application/chart promotion is involved, and the
+repository change alone deploys nothing.
+
 Sugarkube keeps application-specific Prometheus metrics contracts in the
 strict JSON inventory at `platform/observability/app-metrics.json`. The live
 verifier is generic: application names, metric families, bounded labels, Secret

--- a/justfile
+++ b/justfile
@@ -3528,15 +3528,15 @@ observability-watchdog-secret-check env='':
 observability-watchdog-verify env='':
     @scripts/observability_helm.sh watchdog-verify '{{ env }}'
 
-# Interactively install or rotate a staging application's metrics bearer token (hidden input).
+# Interactively install or rotate a configured application's metrics bearer token (hidden input).
 observability-app-metrics-secret-install app env='staging':
     @python3 scripts/observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'
 
-# Check a staging application's metrics Secret/key contract without reading its value.
+# Check an application's metrics Secret/key contract without reading its value.
 observability-app-metrics-secret-check app env='staging':
     @python3 scripts/observability_app_metrics.py secret-check --app '{{ app }}' --env '{{ env }}'
 
-# Verify a staging application's authenticated Prometheus metrics contract.
+# Verify an application's authenticated Prometheus metrics contract.
 observability-app-metrics-verify app env='staging':
     @python3 scripts/observability_app_metrics.py verify --app '{{ app }}' --env '{{ env }}'
 

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -188,6 +188,158 @@
           }
         }
       }
+    },
+    "dspace": {
+      "environments": {
+        "prod": {
+          "namespace": "dspace",
+          "serviceMonitorName": "dspace",
+          "expectedTargetCount": 2,
+          "secret": {
+            "name": "dspace-prod-metrics-token",
+            "key": "token"
+          },
+          "serviceMonitor": {
+            "selectorMatchLabels": {
+              "app.kubernetes.io/instance": "dspace",
+              "app.kubernetes.io/name": "dspace"
+            },
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "authorization": {
+              "type": "Bearer",
+              "credentials": {
+                "name": "dspace-prod-metrics-token",
+                "key": "token"
+              }
+            },
+            "relabelings": [
+              {
+                "action": "replace",
+                "targetLabel": "app",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "environment",
+                "replacement": "prod"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "release",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "cluster",
+                "replacement": "sugarkube-prod"
+              }
+            ]
+          },
+          "targetLabels": {
+            "app": "dspace",
+            "environment": "prod",
+            "release": "dspace",
+            "cluster": "sugarkube-prod",
+            "namespace": "dspace"
+          },
+          "publicMetrics": {
+            "url": "https://democratized.space/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "dspace_http_requests_total",
+            "dspace_http_request_duration_seconds_bucket",
+            "dspace_dchat_requests_total",
+            "dspace_dependency_requests_total",
+            "dspace_instrumentation_up",
+            "dspace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "app": [
+              "dspace"
+            ],
+            "environment": [
+              "prod"
+            ],
+            "release": [
+              "dspace"
+            ],
+            "cluster": [
+              "sugarkube-prod"
+            ],
+            "method": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "HEAD",
+              "other"
+            ],
+            "route": [
+              "/metrics",
+              "/chat",
+              "/health",
+              "/healthz",
+              "other"
+            ],
+            "status_class": [
+              "1xx",
+              "2xx",
+              "3xx",
+              "4xx",
+              "5xx",
+              "unknown"
+            ],
+            "provider": [
+              "openrouter",
+              "tokenplace",
+              "unknown"
+            ],
+            "feature": [
+              "chat",
+              "dependency",
+              "http",
+              "unknown"
+            ],
+            "dependency": [
+              "tokenplace",
+              "openrouter",
+              "unknown"
+            ],
+            "outcome": [
+              "success",
+              "error",
+              "unknown"
+            ]
+          },
+          "derivedApplicationLabels": {},
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "bearer",
+            "cookie",
+            "email",
+            "hostname",
+            "jwt",
+            "node",
+            "passwd",
+            "passcode",
+            "remote_addr",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user"
+          ]
+        }
+      }
     }
   }
 }

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -84,7 +84,7 @@ class ReleaseInputs:
 
 def safe_yaml_documents(text: str) -> list[object]:
     """Parse JSON-compatible YAML via Psych's AST, rejecting tags and aliases."""
-    ruby = r'''
+    ruby = r"""
 require "psych"
 require "json"
 scanner = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], []))
@@ -103,7 +103,7 @@ def convert(node, scanner)
   end
 end
 puts JSON.generate(convert(Psych.parse_stream(STDIN.read), scanner))
-'''
+"""
     try:
         parsed = subprocess.run(
             ["ruby", "-e", ruby], input=text, capture_output=True, text=True, check=False
@@ -158,7 +158,9 @@ def release_associated(
 ) -> bool:
     metadata = document.get("metadata") if isinstance(document.get("metadata"), dict) else {}
     labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
-    annotations = metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    annotations = (
+        metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    )
     return (
         scalar(labels.get("app.kubernetes.io/instance")) == release
         or scalar(labels.get("release")) == release
@@ -184,9 +186,42 @@ def dspace_production_metrics_token_is_unsafe(
     """Return whether an associated resource has a non-legacy METRICS_TOKEN form."""
     if not contains_exact_scalar(document, {"METRICS_TOKEN"}):
         return False
-    if metrics_enabled or scalar(document.get("kind")) not in {
-        "Deployment", "StatefulSet", "DaemonSet"
-    }:
+    if metrics_enabled:
+        found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
+        if not found or not isinstance(containers, list):
+            return True
+        candidates = {inputs.app, inputs.release, *APP_CONTAINER_NAMES.get(inputs.app, set())}
+        safe_entries: set[int] = set()
+        for container in containers:
+            if not isinstance(container, dict) or scalar(container.get("name")) not in candidates:
+                continue
+            env = container.get("env")
+            for entry in env if isinstance(env, list) else []:
+                ref = entry.get("valueFrom") if isinstance(entry, dict) else None
+                secret_ref = ref.get("secretKeyRef") if isinstance(ref, dict) else None
+                if (
+                    scalar(entry.get("name")) == "METRICS_TOKEN"
+                    and set(entry) == {"name", "valueFrom"}
+                    and isinstance(ref, dict)
+                    and set(ref) == {"secretKeyRef"}
+                    and isinstance(secret_ref, dict)
+                    and set(secret_ref) == {"name", "key"}
+                    and secret_ref == {"name": "dspace-prod-metrics-token", "key": "token"}
+                ):
+                    safe_entries.add(id(entry))
+
+        def has_unsafe_enabled_token(value: object) -> bool:
+            if isinstance(value, dict):
+                return id(value) not in safe_entries and any(
+                    has_unsafe_enabled_token(key) or has_unsafe_enabled_token(item)
+                    for key, item in value.items()
+                )
+            if isinstance(value, list):
+                return any(has_unsafe_enabled_token(item) for item in value)
+            return value == "METRICS_TOKEN"
+
+        return has_unsafe_enabled_token(document)
+    if scalar(document.get("kind")) not in {"Deployment", "StatefulSet", "DaemonSet"}:
         return True
     found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
     if not found or not isinstance(containers, list):
@@ -205,8 +240,10 @@ def dspace_production_metrics_token_is_unsafe(
             # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
             if (
                 set(entry) == {"name", "valueFrom"}
-                and isinstance(value_from, dict) and set(value_from) == {"fieldRef"}
-                and isinstance(field_ref, dict) and set(field_ref) == {"fieldPath"}
+                and isinstance(value_from, dict)
+                and set(value_from) == {"fieldRef"}
+                and isinstance(field_ref, dict)
+                and set(field_ref) == {"fieldPath"}
                 and field_ref.get("fieldPath") == "metadata.uid"
             ):
                 safe_entries.add(id(entry))
@@ -252,8 +289,7 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
             document,
             inputs.release,
             allow_name=(
-                inputs.app != "dspace"
-                and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
+                inputs.app != "dspace" and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
             ),
         )
         if inputs.app == "dspace" and kind == "Secret":
@@ -272,10 +308,15 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 found, containers = nested_value(
                     document, ("spec", "template", "spec", "containers")
                 )
-                intended = [
-                    item
-                    for item in containers if isinstance(item, dict) and scalar(item.get("name")) in candidates
-                ] if found and isinstance(containers, list) else []
+                intended = (
+                    [
+                        item
+                        for item in containers
+                        if isinstance(item, dict) and scalar(item.get("name")) in candidates
+                    ]
+                    if found and isinstance(containers, list)
+                    else []
+                )
                 intended_container_found = intended_container_found or bool(intended)
                 for item in intended:
                     if not scalar(item.get("image")).endswith(expected_suffix):
@@ -327,13 +368,18 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {
+            "dspace-staging-metrics-token",
+            "sugarkube-int",
+            "staging.democratized.space",
+        }
         metrics_enabled = (
             resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
         )
-        if inputs.env == "prod" and (
-            service_monitors
-            or any(
+        if inputs.env == "prod":
+            if service_monitors and not metrics_enabled:
+                errors.append("DSPACE production rendered staging-only metrics configuration")
+            if any(
                 isinstance(doc, dict)
                 and release_associated(doc, inputs.release, allow_name=False)
                 and (
@@ -343,16 +389,56 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     )
                 )
                 for doc in documents
-            )
-        ):
-            errors.append("DSPACE production rendered staging-only metrics configuration")
+            ):
+                errors.append("DSPACE production rendered staging-only metrics configuration")
+            if metrics_enabled:
+                if len(service_monitors) != 1:
+                    errors.append("DSPACE production must render exactly one ServiceMonitor")
+                else:
+                    monitor = service_monitors[0]
+                    labels = monitor.get("metadata", {}).get("labels", {})
+                    spec = monitor.get("spec", {})
+                    endpoints = spec.get("endpoints") if isinstance(spec, dict) else None
+                    endpoint = (
+                        endpoints[0]
+                        if isinstance(endpoints, list) and len(endpoints) == 1
+                        else None
+                    )
+                    auth = endpoint.get("bearerTokenSecret") if isinstance(endpoint, dict) else None
+                    relabelings = (
+                        endpoint.get("relabelings", []) if isinstance(endpoint, dict) else []
+                    )
+                    cluster = [
+                        r
+                        for r in relabelings
+                        if isinstance(r, dict) and r.get("targetLabel") == "cluster"
+                    ]
+                    if (
+                        not isinstance(labels, dict)
+                        or labels.get("release") != "kube-prometheus-stack"
+                    ):
+                        errors.append(
+                            "DSPACE production ServiceMonitor discovery label is incorrect"
+                        )
+                    if auth != {"name": "dspace-prod-metrics-token", "key": "token"}:
+                        errors.append(
+                            "DSPACE production ServiceMonitor authentication is incorrect"
+                        )
+                    if len(cluster) != 1 or cluster[0].get("replacement") != "sugarkube-prod":
+                        errors.append(
+                            "DSPACE production ServiceMonitor cluster relabeling is incorrect"
+                        )
     return errors
 
 
 def parse_chart_yaml(text: str) -> dict[str, str]:
     documents = safe_yaml_documents(text)
     document = documents[0] if documents else {}
-    return {str(key): scalar(value) for key, value in document.items()} if isinstance(document, dict) else {}
+    return (
+        {str(key): scalar(value) for key, value in document.items()}
+        if isinstance(document, dict)
+        else {}
+    )
 
 
 def semver_key(v: str) -> tuple[int, int, int, int, tuple[object, ...]]:
@@ -422,13 +508,15 @@ def deployment_app_container_env_sets(
             found.append(
                 (
                     container_name,
-                    {
-                        scalar(item.get("name"))
-                        for item in envs
-                        if isinstance(item, dict) and scalar(item.get("name"))
-                    }
-                    if isinstance(envs, list)
-                    else set(),
+                    (
+                        {
+                            scalar(item.get("name"))
+                            for item in envs
+                            if isinstance(item, dict) and scalar(item.get("name"))
+                        }
+                        if isinstance(envs, list)
+                        else set()
+                    ),
                 )
             )
     return found
@@ -488,7 +576,9 @@ def expected_ingress_host(values: tuple[str, ...], explicit: str) -> str:
     host = scalar(resolved_host)
     enabled = scalar(resolved_enabled).lower()
     if enabled == "true" and not host:
-        raise SystemExit("ERROR: ingress.enabled is true but no nonempty ingress.host was resolved.")
+        raise SystemExit(
+            "ERROR: ingress.enabled is true but no nonempty ingress.host was resolved."
+        )
     return host if enabled != "false" else ""
 
 
@@ -689,7 +779,9 @@ def cmd_resolve_host(args: argparse.Namespace) -> int:
     try:
         host = expected_ingress_host(values, args.host)
     except (ValueError, json.JSONDecodeError, SystemExit) as error:
-        print(f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr)
+        print(
+            f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr
+        )
         return 1
     print(host)
     return 0

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -922,16 +922,28 @@ def verify_helm_stored_values(
         raise ManifestError("Helm stored image values do not match approved coordinates")
 
     if environment == "prod":
-        metrics = stored_values.get("metrics", {})
-        service_monitor = stored_values.get("serviceMonitor", {})
+        metrics = stored_values.get("metrics")
+        service_monitor = stored_values.get("serviceMonitor")
+        expected_metrics = {
+            "enabled": True,
+            "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+        }
+        expected_monitor = {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        }
         if (
-            not isinstance(metrics, dict)
-            or not isinstance(service_monitor, dict)
-            or metrics.get("enabled") is True
-            or service_monitor.get("enabled") is True
+            metrics != expected_metrics
+            or service_monitor != expected_monitor
             or contains_staging_reference(stored_values)
         ):
-            raise ManifestError("Helm stored production values contain staging-only settings")
+            raise ManifestError(
+                "Helm stored production values contain staging-only settings or do not match "
+                "the exact metrics contract"
+            )
     return {
         "check": "helmStoredValues",
         "passed": True,

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -19,7 +19,6 @@ import warnings
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "platform/observability/app-metrics.json"
 PROM = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
@@ -32,9 +31,7 @@ SAFE_VALUE = re.compile(r"[-A-Za-z0-9_./:*]+")
 PROM_LABEL = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 PROM_METRIC = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 K8S_LABEL_NAME = re.compile(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?")
-K8S_LABEL_PREFIX = re.compile(
-    r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-)
+K8S_LABEL_PREFIX = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 STANDARD_LABELS = {
     "__name__",
     "job",
@@ -212,11 +209,9 @@ def validate_inventory(doc):
         environments = appdoc["environments"]
         if not isinstance(environments, dict) or not environments:
             fail(f"application {app}.environments must be a nonempty object")
-        if set(environments) != {"staging"}:
-            fail("only staging app metrics verification is supported")
         for env, cfg in environments.items():
-            if env != "staging":
-                fail("only staging app metrics verification is supported")
+            if env not in {"staging", "prod"}:
+                fail("application metrics environment is unsupported")
             expect_keys(
                 cfg,
                 {
@@ -249,7 +244,14 @@ def validate_inventory(doc):
             sm = cfg["serviceMonitor"]
             expect_keys(
                 sm,
-                {"selectorMatchLabels", "path", "interval", "scrapeTimeout", "authorization", "relabelings"},
+                {
+                    "selectorMatchLabels",
+                    "path",
+                    "interval",
+                    "scrapeTimeout",
+                    "authorization",
+                    "relabelings",
+                },
                 "serviceMonitor",
             )
             if sm["path"] != "/metrics":
@@ -260,7 +262,9 @@ def validate_inventory(doc):
             expect_keys(sm["authorization"], {"type", "credentials"}, "authorization")
             if sm["authorization"]["type"] != "Bearer":
                 fail("authorization.type must be Bearer")
-            expect_keys(sm["authorization"].get("credentials"), {"name", "key"}, "authorization.credentials")
+            expect_keys(
+                sm["authorization"].get("credentials"), {"name", "key"}, "authorization.credentials"
+            )
             name(sm["authorization"]["credentials"]["name"], "authorization.credentials.name")
             name(sm["authorization"]["credentials"]["key"], "authorization.credentials.key")
             if sm["authorization"]["credentials"] != cfg["secret"]:
@@ -275,7 +279,11 @@ def validate_inventory(doc):
             if not isinstance(relabelings, list) or len(relabelings) != 4:
                 fail("serviceMonitor.relabelings must contain exactly four entries")
             for idx, relabeling in enumerate(relabelings):
-                expect_keys(relabeling, {"action", "targetLabel", "replacement"}, f"serviceMonitor.relabelings[{idx}]")
+                expect_keys(
+                    relabeling,
+                    {"action", "targetLabel", "replacement"},
+                    f"serviceMonitor.relabelings[{idx}]",
+                )
                 if relabeling["action"] != "replace":
                     fail("serviceMonitor.relabelings action must be replace")
                 prometheus_label(relabeling["targetLabel"], "relabeling targetLabel")
@@ -284,13 +292,18 @@ def validate_inventory(doc):
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
             if set(labels) != {"app", "environment", "release", "cluster", "namespace"}:
-                fail("targetLabels must contain exactly app, environment, release, cluster, and namespace")
+                fail(
+                    "targetLabels must contain exactly app, environment, release, cluster, and namespace"
+                )
             for k, v in labels.items():
                 prometheus_label(k, "target label name")
                 nonempty(v, "target label value")
             if labels["app"] != app or labels["environment"] != env:
                 fail("targetLabels must match application and environment")
-            if labels["release"] != cfg["serviceMonitorName"] or labels["namespace"] != cfg["namespace"]:
+            if (
+                labels["release"] != cfg["serviceMonitorName"]
+                or labels["namespace"] != cfg["namespace"]
+            ):
                 fail("targetLabels must match ServiceMonitor and namespace")
             mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
             if len(mapping) != len(relabelings):
@@ -302,20 +315,28 @@ def validate_inventory(doc):
                 "cluster": labels.get("cluster"),
             }
             if mapping != required_mapping:
-                fail("serviceMonitor.relabelings must map app, environment, release, and cluster exactly")
+                fail(
+                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
+                )
             if "namespace" in mapping:
                 fail("namespace must be supplied by discovery, not relabel replacement")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
-            if isinstance(pm["expectedUnauthenticatedStatus"], bool) or not isinstance(pm["expectedUnauthenticatedStatus"], int) or not STATUS.fullmatch(
-                str(pm["expectedUnauthenticatedStatus"])
+            if (
+                isinstance(pm["expectedUnauthenticatedStatus"], bool)
+                or not isinstance(pm["expectedUnauthenticatedStatus"], int)
+                or not STATUS.fullmatch(str(pm["expectedUnauthenticatedStatus"]))
             ):
                 fail("public status is malformed")
             rt = cfg["retries"]
             expect_keys(rt, {"attempts", "delaySeconds"}, "retries")
             for key in ("attempts", "delaySeconds"):
-                if isinstance(rt[key], bool) or not isinstance(rt[key], int) or not 1 <= rt[key] <= 60:
+                if (
+                    isinstance(rt[key], bool)
+                    or not isinstance(rt[key], int)
+                    or not 1 <= rt[key] <= 60
+                ):
                     fail("retry settings must be bounded integers")
             metrics = cfg["requiredMetricFamilies"]
             unique_string_list(metrics, "requiredMetricFamilies", prometheus_metric)
@@ -341,13 +362,23 @@ def validate_inventory(doc):
                 fail("static and derived application labels conflict")
             for label, source in derived.items():
                 prometheus_label(label, "derived label name")
-                expect_keys(source, {"workload", "container", "env", "normalizer"}, f"derivedApplicationLabels.{label}")
-                expect_keys(source["workload"], {"kind", "name"}, f"derivedApplicationLabels.{label}.workload")
+                expect_keys(
+                    source,
+                    {"workload", "container", "env", "normalizer"},
+                    f"derivedApplicationLabels.{label}",
+                )
+                expect_keys(
+                    source["workload"],
+                    {"kind", "name"},
+                    f"derivedApplicationLabels.{label}.workload",
+                )
                 if source["workload"]["kind"] != "Deployment":
                     fail("derived workload kind is unsupported")
                 name(source["workload"]["name"], "derived workload name")
                 name(source["container"], "derived container")
-                if not isinstance(source["env"], str) or not re.fullmatch(r"[A-Z_][A-Z0-9_]{0,62}", source["env"]):
+                if not isinstance(source["env"], str) or not re.fullmatch(
+                    r"[A-Z_][A-Z0-9_]{0,62}", source["env"]
+                ):
                     fail("derived environment variable name is unsafe")
                 if source["normalizer"] != "identity":
                     fail("derived normalizer is unsupported")
@@ -366,8 +397,8 @@ def normalize_live_env(env: str) -> str:
         value = value[4:].strip()
     if value == "int":
         value = "staging"
-    if value != "staging":
-        fail("application metrics live operations support staging only")
+    if value not in {"staging", "prod"}:
+        fail("application metrics environment is unsupported")
     return value
 
 
@@ -406,10 +437,30 @@ def kjson(args):
     return doc
 
 
-def assert_context():
+def assert_context(env="staging"):
+    if env == "prod" and not os.environ.get("KUBECONFIG", "").strip():
+        fail("production requires an explicit KUBECONFIG", 3)
     ctx = run(["kubectl", "config", "current-context"]).strip()
-    if ctx != "sugar-staging":
-        fail(f"context mismatch: expected sugar-staging, got {ctx or '<none>'}", 3)
+    expected = "sugar-prod" if env == "prod" else "sugar-staging"
+    if ctx != expected:
+        fail(f"context mismatch: expected {expected}, got {ctx or '<none>'}", 3)
+    if env == "prod":
+        identity = kjson(["kubectl", "config", "view", "--minify", "-o", "json"])
+        clusters = identity.get("clusters")
+        if (
+            not isinstance(clusters, list)
+            or len(clusters) != 1
+            or not isinstance(clusters[0], dict)
+        ):
+            fail("production cluster identity is malformed", 3)
+        cluster = clusters[0]
+        server = (
+            cluster.get("cluster", {}).get("server")
+            if isinstance(cluster.get("cluster"), dict)
+            else None
+        )
+        if cluster.get("name") != "sugar-prod" or server != "https://127.0.0.1:16443":
+            fail("production cluster identity mismatch", 3)
 
 
 def appcfg(app, env):
@@ -448,6 +499,8 @@ def check_secret(cfg):
 
 
 def install_secret(cfg):
+    if "xtrace" in os.environ.get("SHELLOPTS", "").split(":"):
+        fail("shell xtrace is refused")
     for bad in (
         "TOKEN",
         "METRICS_TOKEN",
@@ -470,8 +523,10 @@ def install_secret(cfg):
         use_stdin_fallback = True
     try:
         with tty_context:
-            if not tty.isatty() or not tty.readable() or (
-                not use_stdin_fallback and not tty.writable()
+            if (
+                not tty.isatty()
+                or not tty.readable()
+                or (not use_stdin_fallback and not tty.writable())
             ):
                 fail("an interactive controlling terminal is required")
             prompt = "Enter application metrics bearer token (input hidden): "
@@ -545,7 +600,9 @@ def find_env_value(workload: dict[str, Any], source: dict[str, Any]) -> str:
     containers = pod_spec.get("containers") if isinstance(pod_spec, dict) else None
     if not isinstance(containers, list):
         fail("workload source contract is malformed (details redacted)", 1)
-    matches = [c for c in containers if isinstance(c, dict) and c.get("name") == source["container"]]
+    matches = [
+        c for c in containers if isinstance(c, dict) and c.get("name") == source["container"]
+    ]
     if len(matches) != 1:
         fail("workload container source is absent or ambiguous (details redacted)", 1)
     env_entries = matches[0].get("env")
@@ -596,7 +653,20 @@ def derive_build_labels_live(cfg):
         if key in seen:
             continue
         seen.add(key)
-        docs.append(kjson(["kubectl", "-n", cfg["namespace"], "get", workload["kind"].lower(), workload["name"], "-o", "json"]))
+        docs.append(
+            kjson(
+                [
+                    "kubectl",
+                    "-n",
+                    cfg["namespace"],
+                    "get",
+                    workload["kind"].lower(),
+                    workload["name"],
+                    "-o",
+                    "json",
+                ]
+            )
+        )
     return derive_build_labels_from_docs(cfg, docs)
 
 
@@ -605,25 +675,36 @@ def validate_metric_labels(cfg, labels, derived_values=None):
     if not isinstance(labels, dict):
         fail("metric labels were malformed (details redacted)", 1)
     for label, value in labels.items():
-        if not isinstance(label, str) or not PROM_LABEL.fullmatch(label) or not isinstance(value, str):
+        if (
+            not isinstance(label, str)
+            or not PROM_LABEL.fullmatch(label)
+            or not isinstance(value, str)
+        ):
             fail("metric labels were malformed (details redacted)", 1)
         low = label.lower()
         is_standard = label in STANDARD_LABELS
-        if not is_standard and label not in cfg["allowedApplicationLabels"] and label not in cfg.get("derivedApplicationLabels", {}):
+        if (
+            not is_standard
+            and label not in cfg["allowedApplicationLabels"]
+            and label not in cfg.get("derivedApplicationLabels", {})
+        ):
             fail("unbounded application metric label observed (details redacted)", 1)
         if not is_standard and (
             any(w in low for w in cfg["forbiddenApplicationLabels"])
             or any(w in low for w in FORBIDDEN_WORDS)
         ):
             fail("forbidden application metric label observed (details redacted)", 1)
-        if label in cfg["allowedApplicationLabels"] and value not in cfg["allowedApplicationLabels"][label]:
+        if (
+            label in cfg["allowedApplicationLabels"]
+            and value not in cfg["allowedApplicationLabels"][label]
+        ):
             fail("application metric label enum mismatch (details redacted)", 1)
         if label in cfg.get("derivedApplicationLabels", {}) and value != derived_values.get(label):
             fail("derived application metric label mismatch (details redacted)", 1)
 
 
 def prometheus_label_escape(value: str) -> str:
-    return value.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 def promql_selector(labels: dict[str, str]) -> str:
@@ -654,12 +735,18 @@ def is_relevant_target(cfg: dict[str, Any], target: dict[str, Any]) -> bool:
     if not isinstance(labels, dict) or not isinstance(discovered, dict):
         fail("Prometheus target response is structurally invalid (details redacted)", 1)
     identities = target_discovery_identities(cfg)
-    for field in (target.get("scrapePool"), target.get("scrapeConfig"), labels.get("job"), discovered.get("job")):
+    for field in (
+        target.get("scrapePool"),
+        target.get("scrapeConfig"),
+        labels.get("job"),
+        discovered.get("job"),
+    ):
         if isinstance(field, str) and field in identities:
             return True
     if (
         discovered.get("__meta_kubernetes_namespace") == cfg["namespace"]
-        and discovered.get("__meta_prometheus_operator_service_monitor_name") == cfg["serviceMonitorName"]
+        and discovered.get("__meta_prometheus_operator_service_monitor_name")
+        == cfg["serviceMonitorName"]
     ):
         return True
     return False
@@ -697,18 +784,21 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                     fail("Prometheus query response is structurally invalid (details redacted)", 1)
                 sample_labels = sample.get("metric")
                 validate_metric_labels(cfg, sample_labels, derived_values)
-                series_name = sample_labels.get("__name__") if isinstance(sample_labels, dict) else None
+                series_name = (
+                    sample_labels.get("__name__") if isinstance(sample_labels, dict) else None
+                )
                 if not isinstance(series_name, str) or not PROM_METRIC.fullmatch(series_name):
                     fail("Prometheus query sample is structurally invalid (details redacted)", 1)
                 if metric_family_from_series(series_name) == metric:
                     found.add(metric)
     return found
 
+
 def verify(app, env):
     app = normalize_application_argument(app)
     env = normalize_live_env(env)
     cfg = appcfg(app, env)
-    assert_context()
+    assert_context() if env == "staging" else assert_context("prod")
     check_secret(cfg)
     derived_values = derive_build_labels_live(cfg)
     sm = kjson(
@@ -723,6 +813,13 @@ def verify(app, env):
             "json",
         ]
     )
+    if app == "dspace":
+        metadata = sm.get("metadata")
+        if not isinstance(metadata, dict) or metadata.get("name") != cfg["serviceMonitorName"]:
+            fail("ServiceMonitor identity mismatch", 1)
+        labels = metadata.get("labels")
+        if not isinstance(labels, dict) or labels.get("release") != "kube-prometheus-stack":
+            fail("ServiceMonitor discovery label mismatch", 1)
     spec = sm.get("spec")
     if not isinstance(spec, dict):
         fail("ServiceMonitor response is structurally invalid", 1)
@@ -734,8 +831,15 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     authorization = ep.get("authorization")
     auth = authorization.get("credentials") if isinstance(authorization, dict) else None
+    if app == "dspace":
+        auth = ep.get("bearerTokenSecret")
+        authorization = {"type": "Bearer"} if isinstance(auth, dict) else None
     selector = spec.get("selector")
-    if not isinstance(authorization, dict) or not isinstance(auth, dict) or not isinstance(selector, dict):
+    if (
+        not isinstance(authorization, dict)
+        or not isinstance(auth, dict)
+        or not isinstance(selector, dict)
+    ):
         fail("ServiceMonitor response is structurally invalid", 1)
     if (
         ep.get("path") != "/metrics"
@@ -747,10 +851,7 @@ def verify(app, env):
         or auth.get("key") != cfg["secret"]["key"]
     ):
         fail("ServiceMonitor endpoint/auth contract mismatch", 1)
-    if (
-        selector.get("matchLabels")
-        != cfg["serviceMonitor"]["selectorMatchLabels"]
-    ):
+    if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("ServiceMonitor selector mismatch", 1)
     targets = []
     attempts = cfg["retries"]["attempts"]
@@ -767,7 +868,10 @@ def verify(app, env):
         if i + 1 < attempts:
             time.sleep(cfg["retries"]["delaySeconds"])
     if not target_state_converged(cfg, targets):
-        fail("Prometheus targets are absent, down, mislabeled, or have unexpected count (details redacted)", 1)
+        fail(
+            "Prometheus targets are absent, down, mislabeled, or have unexpected count (details redacted)",
+            1,
+        )
 
     required = set(cfg["requiredMetricFamilies"])
     found: set[str] = set()
@@ -780,6 +884,7 @@ def verify(app, env):
     missing = required - found
     if missing:
         fail(f"required metric family missing: {sorted(missing)[0]}", 1)
+
     class NoRedirect(urllib.request.HTTPRedirectHandler):
         def redirect_request(self, req, fp, code, msg, headers, newurl):
             return None
@@ -819,9 +924,17 @@ def verify(app, env):
 
 def load_rendered_docs(input_path: str) -> list[dict[str, Any]]:
     try:
-        raw = sys.stdin.read() if input_path == "-" else Path(input_path).read_text(encoding="utf-8")
+        raw = (
+            sys.stdin.read() if input_path == "-" else Path(input_path).read_text(encoding="utf-8")
+        )
         converted = subprocess.run(
-            ["ruby", "-ryaml", "-rjson", "-e", "puts JSON.generate(YAML.load_stream(STDIN.read).compact)"],
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.load_stream(STDIN.read).compact)",
+            ],
             input=raw,
             text=True,
             capture_output=True,
@@ -832,7 +945,9 @@ def load_rendered_docs(input_path: str) -> list[dict[str, Any]]:
         fail("rendered manifests are malformed (details redacted)")
 
 
-def validate_render(app: str, env: str, input_path: str, release_namespace: str = "", release_name: str = "") -> None:
+def validate_render(
+    app: str, env: str, input_path: str, release_namespace: str = "", release_name: str = ""
+) -> None:
     inv = load_config()
     cfg = inv.get("applications", {}).get(app, {}).get("environments", {}).get(env)
     if cfg is None:
@@ -857,7 +972,9 @@ def validate_render(app: str, env: str, input_path: str, release_namespace: str 
     sms = []
     for candidate in named_sms:
         rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (rendered_ns is None and release_namespace == cfg["namespace"]):
+        if rendered_ns == cfg["namespace"] or (
+            rendered_ns is None and release_namespace == cfg["namespace"]
+        ):
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -891,15 +1008,35 @@ def validate_render(app: str, env: str, input_path: str, release_namespace: str 
         fail("rendered ServiceMonitor endpoint is structurally invalid")
     auth = ep.get("authorization")
     creds = auth.get("credentials") if isinstance(auth, dict) else None
+    if app == "dspace":
+        creds = ep.get("bearerTokenSecret")
+        auth = {"type": "Bearer"} if isinstance(creds, dict) else None
     if not isinstance(auth, dict) or not isinstance(creds, dict):
         fail("rendered ServiceMonitor authorization is structurally invalid")
-    if (ep.get("path") != cfg["serviceMonitor"]["path"] or ep.get("interval") != cfg["serviceMonitor"]["interval"] or ep.get("scrapeTimeout") != cfg["serviceMonitor"]["scrapeTimeout"] or auth.get("type") != cfg["serviceMonitor"]["authorization"]["type"] or creds.get("name") != cfg["secret"]["name"] or creds.get("key") != cfg["secret"]["key"] or ep.get("relabelings") != cfg["serviceMonitor"]["relabelings"]):
+    if (
+        ep.get("path") != cfg["serviceMonitor"]["path"]
+        or ep.get("interval") != cfg["serviceMonitor"]["interval"]
+        or ep.get("scrapeTimeout") != cfg["serviceMonitor"]["scrapeTimeout"]
+        or auth.get("type") != cfg["serviceMonitor"]["authorization"]["type"]
+        or creds.get("name") != cfg["secret"]["name"]
+        or creds.get("key") != cfg["secret"]["key"]
+        or ep.get("relabelings") != cfg["serviceMonitor"]["relabelings"]
+    ):
         fail("rendered ServiceMonitor endpoint/auth/relabeling contract mismatch")
+
 
 def main(argv=None):
     p = argparse.ArgumentParser()
     p.add_argument(
-        "mode", choices=["validate", "validate-render", "secret-check", "secret-install", "verify", "verify-all"]
+        "mode",
+        choices=[
+            "validate",
+            "validate-render",
+            "secret-check",
+            "secret-install",
+            "verify",
+            "verify-all",
+        ],
     )
     p.add_argument("--app")
     p.add_argument("--env", default="staging")
@@ -933,7 +1070,7 @@ def main(argv=None):
         app = normalize_application_argument(a.app)
         env = normalize_live_env(a.env)
         cfg = appcfg(app, env)
-        assert_context()
+        assert_context() if env == "staging" else assert_context("prod")
         if a.mode == "secret-check":
             check_secret(cfg)
         elif a.mode == "secret-install":

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -168,12 +168,20 @@ def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> 
     assert "cluster: sugarkube-int" in text
 
 
-def test_dspace_prod_values_do_not_enable_metrics_or_servicemonitor() -> None:
+def test_dspace_prod_values_enable_exact_authenticated_metrics_contract() -> None:
     text = OVERLAYS["prod"].read_text(encoding="utf-8")
 
-    assert "metrics:" not in text
-    assert "serviceMonitor:" not in text
+    assert "metrics:\n  enabled: true" in text
+    assert "existingSecret: dspace-prod-metrics-token" in text
+    assert "secretKey: token" in text
+    assert text.count("serviceMonitor:") == 1
+    assert "serviceMonitor:\n  enabled: true" in text
+    assert "interval: 30s" in text
+    assert "scrapeTimeout: 10s" in text
+    assert "release: kube-prometheus-stack" in text
+    assert "cluster: sugarkube-prod" in text
     assert "dspace-staging-metrics-token" not in text
+    assert "sugarkube-int" not in text
 
 
 def test_dspace_fixtures_do_not_contain_real_credentials() -> None:
@@ -182,4 +190,6 @@ def test_dspace_fixtures_do_not_contain_real_credentials() -> None:
         assert (
             "dspace-staging-metrics-token" not in text or path.name == "dspace.values.staging.yaml"
         )
-        assert "secretKey: token" not in text or path.name == "dspace.values.staging.yaml"
+        assert "secretKey: token" not in text or path.name in {
+            "dspace.values.staging.yaml", "dspace.values.prod.yaml"
+        }

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6281,7 +6281,7 @@ def test_observability_app_metrics_verify_all_uses_every_configured_app(monkeypa
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):
-    forbidden = ["prod", "production", "", "dev", "qa"]
+    forbidden = ["production", "", "dev", "qa"]
     for env in forbidden:
         def fail_load_config(env=env):
             raise AssertionError(f"loaded config for {env!r}")
@@ -6289,11 +6289,12 @@ def test_observability_app_metrics_live_environment_normalization_and_rejection(
         monkeypatch.setattr(app_metrics, "load_config", fail_load_config)
         with pytest.raises(SystemExit) as excinfo:
             app_metrics.appcfg("tokenplace", env)
-        assert "staging only" in str(excinfo.value)
+        assert "unsupported" in str(excinfo.value)
         assert app_metrics.main(["verify-all", "--env", env]) == 2
 
     assert app_metrics.normalize_live_env("env=env=int") == "staging"
     assert app_metrics.normalize_live_env("env=staging") == "staging"
+    assert app_metrics.normalize_live_env("env=prod") == "prod"
 
 
 @pytest.mark.parametrize("app", ["app=", "app=foo=bar", "app=Bad_Name", "-bad"])
@@ -7038,12 +7039,12 @@ def test_observability_app_metrics_install_secret_subprocess_failures_are_redact
     [
         (lambda d: d.update({"schemaVersion": 2}), "schemaVersion"),
         (lambda d: d.update({"applications": []}), "applications"),
-        (
-            lambda d: d["applications"]["tokenplace"]["environments"].update(
-                {"prod": {}}
+            (
+                lambda d: d["applications"]["tokenplace"]["environments"].update(
+                    {"qa": {}}
+                ),
+                "unsupported",
             ),
-            "only staging",
-        ),
         (
             lambda d: d["applications"]["tokenplace"]["environments"][
                 "staging"


### PR DESCRIPTION
### Motivation
- Support fail-closed, authenticated Prometheus metrics for production DSPACE using the existing immutable application/chart coordinates without promoting or changing the app or chart.
- Replace the previous blanket rejection of any production ServiceMonitor with strict, environment-aware structural validation and stored-values checks so only the exact safe production metrics contract is accepted.
- Provide operator-facing documentation and guarded secret lifecycle hooks so credentials can be installed/checked safely (credential values are never stored in the repo).

### Description
- Added the exact production values contract to `docs/examples/dspace.values.prod.yaml` enabling metrics and ServiceMonitor references to `dspace-prod-metrics-token/token` and `serviceMonitor` metadata including `release: kube-prometheus-stack` and `cluster: sugarkube-prod`.
- Replaced the blanket production rejection in `scripts/app_chart.py` with targeted checks that:
  - forbid literal Secret resources and staging leaks, permit the chart-3.0.2 pod-UID fallback when metrics are disabled, and allow `METRICS_TOKEN` only when rendered via `valueFrom.secretKeyRef` referencing `dspace-prod-metrics-token/token` when metrics are enabled;
  - validate exactly one ServiceMonitor when metrics are enabled and assert its discovery label, bearer-token reference, and cluster relabeling are exactly as required.
- Updated `scripts/dspace_release_manifest.py::verify_helm_stored_values` to require the exact production metrics and ServiceMonitor values contract (image coordinates unchanged) and to reject staging leaks or incorrect variants without recording Secret contents.
- Extended `scripts/observability_app_metrics.py` to support production verification paths: inventory addition for `dspace/prod` was added to `platform/observability/app-metrics.json`, `assert_context` now verifies explicit prod kubeconfig/context identity, live verifier enforces ServiceMonitor identity, discovery label and bearer-token Secret/key existence (without exposing values), and `install_secret` is guarded (TTY, no env-credentials, xtrace detection).
- Small test & docs updates: `docs/apps/dspace.md` and `docs/observability-operations.md` document the guarded values-only reconciliation and operator workflow; tests were adjusted/added to reflect the new production contract (`tests/test_dspace_runtime_values.py`, `tests/test_generic_app_just_recipes.py`).
- No Secrets or credential values were committed and no application or chart coordinates were changed; the values-only reconciliation command itself was not added in this change (guarded reconciliation remains out-of-band and deferred to follow-ups).

### Testing
- Ran the repository verifier and focused test suite locally (commands shown); all modified-focused tests passed:
  - `python3 scripts/observability_app_metrics.py validate` — passed.
  - `pytest -q tests/test_dspace_runtime_values.py` — passed.
  - `pytest -q tests/test_release_manifest.py` — passed.
  - `pytest -q tests/test_generic_app_just_recipes.py -k 'dspace_production or dspace_servicemonitor or observability_app_metrics'` — passed after adjustments.
  - `pytest -q tests/test_observability_helm.py` — passed for the affected checks.
  - Full focused selection and combinations reported: 214 tests passing in the local runs used to validate the change.
- Static checks and repository gates run where available:
  - `git diff --check` — no issues.
  - `python3 -m json.tool platform/observability/app-metrics.json` — valid JSON.
  - `git diff --cached | ./scripts/scan-secrets.py` — no secrets detected.
- Environment/tooling limitations (not run here): `helm` (required for a digest-qualified live preflight), `pre-commit`, `pyspelling`, and `linkchecker` were not available in this execution environment and therefore were not run; these should be executed in CI or by maintainers before merging.

If you want, I can open a follow-up PR that implements the guarded values-only reconciliation command (reservation + upgrade-only flow) or split the changes into smaller reviewable patches; otherwise this PR keeps the scope focused to values, validation, credential lifecycle hooks, tests, and runbook updates as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7913111f60832f919b9e433e0f6cdd)