### PR TITLE
Support authenticated production DSPACE metrics (values-only reconciliation, verification, and runbook)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,60 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+## Production authenticated metrics at the existing release
+
+DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
+**3.0.2**. This repository change does not deploy application or chart code, and it is not a
+promotion. It supplies the reviewed values contract for an upgrade-only configuration
+reconciliation at the existing immutable coordinates.
+
+Run production operations from `sugarkube3` with the externally managed API tunnel listening on
+`127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
+`just kubeconfig-env env=prod` on that host:
+
+```bash
+export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+test "$(kubectl config current-context)" = sugar-prod
+python3 scripts/cluster_identity.py assert --kubeconfig "$KUBECONFIG" --env prod
+just observability-app-metrics-secret-install app=dspace env=prod
+just observability-app-metrics-secret-check app=dspace env=prod
+```
+
+The hidden-input installer creates or rotates only `dspace/dspace-prod-metrics-token` key `token`;
+the check proves that the key is nonempty without reading it. Install and check it before any
+reconciliation. Never put the credential in an argument, environment variable, transcript, or
+evidence file.
+
+The reconciliation operator must supply the genuine existing finalized production evidence, the
+executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destination. Discover the
+current Helm revision immediately before the operation rather than assuming revision 9. Review the
+digest-qualified chart render and transient live-versus-desired values comparison: the only
+permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
+3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
+`--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
+
+```bash
+just dspace-prod-metrics-reconcile \
+  manifest="$GENUINE_FINALIZED_PROD_EVIDENCE" \
+  evidence="$FRESH_NONEXISTING_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
+  confirm="dspace:prod:<40-character-application-SHA>"
+```
+
+After rollout, run the DSPACE runtime and `/chat` verification, then run:
+
+```bash
+just observability-app-metrics-verify app=dspace env=prod
+just observability-dashboard-verify env=prod
+```
+
+Inspect the production dashboard manually. DSPACE HTTP, runtime, and feature panels should
+populate. Release-integrity, blackbox, token.place, and alerting panels may remain `NO DATA` until
+those separate production integrations are deployed. A failure after mutation is not permission
+to rerun or roll back immediately: preserve and review the reserved failure evidence, discover the
+new live revision, and plan a deliberate reconciliation.
+
 ## Production Helm reconciliation for application 3.0.1
 
 This section **prepares but does not execute** the incident reconciliation tracked by

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -12,3 +12,17 @@ env:
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
     value: llama-3.1-8b-instruct
+
+metrics:
+  enabled: true
+  auth:
+    existingSecret: dspace-prod-metrics-token
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube-prod

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -3,7 +3,10 @@
 This runbook covers the staging and production observability lifecycles. It is intentionally
 non-Flux: operators use guarded Helm commands from this repository, with the chart version and
 full values chain committed in Git. The production core stack has live acceptance evidence; the
-application integrations listed below remain separately deferred.
+application integrations listed below remain separately deferred. Authenticated DSPACE metrics are
+supported separately on the existing application 3.0.1/chart 3.0.2 coordinates; this repository
+change alone does not deploy them or promote a release. Follow the
+[DSPACE production procedure](apps/dspace.md#production-authenticated-metrics-at-the-existing-release).
 
 ## Canonical sources
 

--- a/justfile
+++ b/justfile
@@ -1794,6 +1794,14 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
     fi
     "${rollback_command[@]}"
 
+# Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
+dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --configuration-reconciliation --environment prod \
+      --manifest '{{ manifest }}' --evidence '{{ evidence }}' \
+      --smoke-runner '{{ smoke_runner }}' --kubeconfig '{{ kubeconfig }}' \
+      --verifier '{{ verifier }}' --confirm '{{ confirm }}' --config '{{ config }}'
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash
@@ -3528,15 +3536,15 @@ observability-watchdog-secret-check env='':
 observability-watchdog-verify env='':
     @scripts/observability_helm.sh watchdog-verify '{{ env }}'
 
-# Interactively install or rotate a staging application's metrics bearer token (hidden input).
+# Interactively install or rotate an application's metrics bearer token (hidden input).
 observability-app-metrics-secret-install app env='staging':
     @python3 scripts/observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'
 
-# Check a staging application's metrics Secret/key contract without reading its value.
+# Check an application's metrics Secret/key contract without reading its value.
 observability-app-metrics-secret-check app env='staging':
     @python3 scripts/observability_app_metrics.py secret-check --app '{{ app }}' --env '{{ env }}'
 
-# Verify a staging application's authenticated Prometheus metrics contract.
+# Verify an application's authenticated Prometheus metrics contract.
 observability-app-metrics-verify app env='staging':
     @python3 scripts/observability_app_metrics.py verify --app '{{ app }}' --env '{{ env }}'
 

--- a/justfile
+++ b/justfile
@@ -3538,7 +3538,9 @@ observability-watchdog-verify env='':
 
 # Interactively install or rotate an application's metrics bearer token (hidden input).
 observability-app-metrics-secret-install app env='staging':
-    @python3 scripts/observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'
+    #!/usr/bin/env bash
+    case "$-" in *x*) printf '%s\n' 'error: shell xtrace is refused' >&2; exit 2;; esac
+    python3 scripts/observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'
 
 # Check an application's metrics Secret/key contract without reading its value.
 observability-app-metrics-secret-check app env='staging':

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -188,6 +188,156 @@
           }
         }
       }
+    },
+    "dspace": {
+      "environments": {
+        "prod": {
+          "namespace": "dspace",
+          "serviceMonitorName": "dspace",
+          "expectedTargetCount": 2,
+          "secret": {
+            "name": "dspace-prod-metrics-token",
+            "key": "token"
+          },
+          "serviceMonitor": {
+            "selectorMatchLabels": {
+              "app.kubernetes.io/instance": "dspace",
+              "app.kubernetes.io/name": "dspace"
+            },
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "authorization": {
+              "type": "Bearer",
+              "credentials": {
+                "name": "dspace-prod-metrics-token",
+                "key": "token"
+              }
+            },
+            "relabelings": [
+              {
+                "action": "replace",
+                "targetLabel": "app",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "environment",
+                "replacement": "prod"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "release",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "cluster",
+                "replacement": "sugarkube-prod"
+              }
+            ]
+          },
+          "targetLabels": {
+            "app": "dspace",
+            "environment": "prod",
+            "release": "dspace",
+            "cluster": "sugarkube-prod",
+            "namespace": "dspace"
+          },
+          "publicMetrics": {
+            "url": "https://democratized.space/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "dspace_http_requests_total",
+            "dspace_http_request_duration_seconds_bucket",
+            "dspace_dchat_requests_total",
+            "dspace_dependency_requests_total",
+            "dspace_instrumentation_up",
+            "dspace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "app": [
+              "dspace"
+            ],
+            "environment": [
+              "prod"
+            ],
+            "release": [
+              "dspace"
+            ],
+            "cluster": [
+              "sugarkube-prod"
+            ],
+            "method": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "HEAD",
+              "other"
+            ],
+            "route": [
+              "/",
+              "/metrics",
+              "/health",
+              "/healthz",
+              "/build-info.json",
+              "/chat",
+              "other"
+            ],
+            "status_class": [
+              "1xx",
+              "2xx",
+              "3xx",
+              "4xx",
+              "5xx",
+              "unknown"
+            ],
+            "provider": [
+              "openai",
+              "token-place",
+              "unknown"
+            ],
+            "dependency": [
+              "openai",
+              "token-place",
+              "unknown"
+            ],
+            "outcome": [
+              "success",
+              "error",
+              "timeout",
+              "rate_limited",
+              "unknown"
+            ]
+          },
+          "derivedApplicationLabels": {},
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "bearer",
+            "cookie",
+            "email",
+            "hostname",
+            "jwt",
+            "node",
+            "passwd",
+            "passcode",
+            "remote_addr",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user"
+          ]
+        }
+      }
     }
   }
 }

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -356,15 +356,44 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
         if inputs.env == "prod":
             unsafe = any(
                 isinstance(doc, dict)
-                and release_associated(doc, inputs.release, allow_name=False)
                 and (
                     contains_exact_scalar(doc, production_leaks)
-                    or dspace_production_metrics_token_is_unsafe(
-                        doc, inputs, metrics_enabled=metrics_enabled
+                    or (
+                        contains_exact_scalar(doc, {"METRICS_TOKEN"})
+                        and not release_associated(doc, inputs.release, allow_name=False)
+                    )
+                    or (
+                        release_associated(doc, inputs.release, allow_name=False)
+                        and dspace_production_metrics_token_is_unsafe(
+                            doc, inputs, metrics_enabled=metrics_enabled
+                        )
                     )
                 )
                 for doc in documents
             )
+            if metrics_enabled:
+                token_entries: list[object] = []
+                for document in documents:
+                    if not isinstance(document, dict):
+                        continue
+                    if scalar(document.get("kind")) == "Secret":
+                        unsafe = True
+                    found, containers = nested_value(
+                        document, ("spec", "template", "spec", "containers")
+                    )
+                    if not found or not isinstance(containers, list):
+                        continue
+                    for container in containers:
+                        env = container.get("env") if isinstance(container, dict) else None
+                        token_entries.extend(
+                            entry
+                            for entry in env
+                            if isinstance(env, list)
+                            if isinstance(entry, dict)
+                            and scalar(entry.get("name")) == "METRICS_TOKEN"
+                        )
+                if len(token_entries) != 1:
+                    unsafe = True
             if unsafe or (service_monitors and not metrics_enabled):
                 errors.append("DSPACE production rendered staging-only metrics configuration")
             if metrics_enabled:
@@ -404,7 +433,16 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                         },
                     ]
                     if (
-                        metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        metadata.get("name") != "dspace"
+                        or metadata.get("namespace") != "dspace"
+                        or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        or spec.get("selector")
+                        != {
+                            "matchLabels": {
+                                "app.kubernetes.io/instance": "dspace",
+                                "app.kubernetes.io/name": "dspace",
+                            }
+                        }
                         or auth != {"name": "dspace-prod-metrics-token", "key": "token"}
                         or endpoint.get("path") != "/metrics"
                         or endpoint.get("interval") != "30s"

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -385,18 +385,31 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     )
                     auth = endpoint.get("bearerTokenSecret")
                     relabelings = endpoint.get("relabelings")
-                    cluster_ok = isinstance(relabelings, list) and any(
-                        isinstance(item, dict)
-                        and item.get("targetLabel") == "cluster"
-                        and item.get("replacement") == "sugarkube-prod"
-                        for item in relabelings
-                    )
+                    expected_relabelings = [
+                        {"action": "replace", "targetLabel": "app", "replacement": "dspace"},
+                        {
+                            "action": "replace",
+                            "targetLabel": "environment",
+                            "replacement": "prod",
+                        },
+                        {
+                            "action": "replace",
+                            "targetLabel": "release",
+                            "replacement": "dspace",
+                        },
+                        {
+                            "action": "replace",
+                            "targetLabel": "cluster",
+                            "replacement": "sugarkube-prod",
+                        },
+                    ]
                     if (
                         metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
                         or auth != {"name": "dspace-prod-metrics-token", "key": "token"}
+                        or endpoint.get("path") != "/metrics"
                         or endpoint.get("interval") != "30s"
                         or endpoint.get("scrapeTimeout") != "10s"
-                        or not cluster_ok
+                        or relabelings != expected_relabelings
                     ):
                         errors.append("DSPACE production ServiceMonitor contract mismatch")
     return errors

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -84,7 +84,7 @@ class ReleaseInputs:
 
 def safe_yaml_documents(text: str) -> list[object]:
     """Parse JSON-compatible YAML via Psych's AST, rejecting tags and aliases."""
-    ruby = r'''
+    ruby = r"""
 require "psych"
 require "json"
 scanner = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], []))
@@ -103,7 +103,7 @@ def convert(node, scanner)
   end
 end
 puts JSON.generate(convert(Psych.parse_stream(STDIN.read), scanner))
-'''
+"""
     try:
         parsed = subprocess.run(
             ["ruby", "-e", ruby], input=text, capture_output=True, text=True, check=False
@@ -158,7 +158,9 @@ def release_associated(
 ) -> bool:
     metadata = document.get("metadata") if isinstance(document.get("metadata"), dict) else {}
     labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
-    annotations = metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    annotations = (
+        metadata.get("annotations") if isinstance(metadata.get("annotations"), dict) else {}
+    )
     return (
         scalar(labels.get("app.kubernetes.io/instance")) == release
         or scalar(labels.get("release")) == release
@@ -184,9 +186,7 @@ def dspace_production_metrics_token_is_unsafe(
     """Return whether an associated resource has a non-legacy METRICS_TOKEN form."""
     if not contains_exact_scalar(document, {"METRICS_TOKEN"}):
         return False
-    if metrics_enabled or scalar(document.get("kind")) not in {
-        "Deployment", "StatefulSet", "DaemonSet"
-    }:
+    if scalar(document.get("kind")) not in {"Deployment", "StatefulSet", "DaemonSet"}:
         return True
     found, containers = nested_value(document, ("spec", "template", "spec", "containers"))
     if not found or not isinstance(containers, list):
@@ -202,11 +202,25 @@ def dspace_production_metrics_token_is_unsafe(
                 continue
             value_from = entry.get("valueFrom")
             field_ref = value_from.get("fieldRef") if isinstance(value_from, dict) else None
+            secret_ref = value_from.get("secretKeyRef") if isinstance(value_from, dict) else None
+            if (
+                metrics_enabled
+                and set(entry) == {"name", "valueFrom"}
+                and isinstance(value_from, dict)
+                and set(value_from) == {"secretKeyRef"}
+                and isinstance(secret_ref, dict)
+                and set(secret_ref) == {"name", "key"}
+                and secret_ref == {"name": "dspace-prod-metrics-token", "key": "token"}
+            ):
+                safe_entries.add(id(entry))
             # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
             if (
-                set(entry) == {"name", "valueFrom"}
-                and isinstance(value_from, dict) and set(value_from) == {"fieldRef"}
-                and isinstance(field_ref, dict) and set(field_ref) == {"fieldPath"}
+                not metrics_enabled
+                and set(entry) == {"name", "valueFrom"}
+                and isinstance(value_from, dict)
+                and set(value_from) == {"fieldRef"}
+                and isinstance(field_ref, dict)
+                and set(field_ref) == {"fieldPath"}
                 and field_ref.get("fieldPath") == "metadata.uid"
             ):
                 safe_entries.add(id(entry))
@@ -252,8 +266,7 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
             document,
             inputs.release,
             allow_name=(
-                inputs.app != "dspace"
-                and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
+                inputs.app != "dspace" and kind not in {"Deployment", "StatefulSet", "DaemonSet"}
             ),
         )
         if inputs.app == "dspace" and kind == "Secret":
@@ -272,10 +285,15 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 found, containers = nested_value(
                     document, ("spec", "template", "spec", "containers")
                 )
-                intended = [
-                    item
-                    for item in containers if isinstance(item, dict) and scalar(item.get("name")) in candidates
-                ] if found and isinstance(containers, list) else []
+                intended = (
+                    [
+                        item
+                        for item in containers
+                        if isinstance(item, dict) and scalar(item.get("name")) in candidates
+                    ]
+                    if found and isinstance(containers, list)
+                    else []
+                )
                 intended_container_found = intended_container_found or bool(intended)
                 for item in intended:
                     if not scalar(item.get("image")).endswith(expected_suffix):
@@ -327,13 +345,16 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {
+            "dspace-staging-metrics-token",
+            "sugarkube-int",
+            "staging.democratized.space",
+        }
         metrics_enabled = (
             resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
         )
-        if inputs.env == "prod" and (
-            service_monitors
-            or any(
+        if inputs.env == "prod":
+            unsafe = any(
                 isinstance(doc, dict)
                 and release_associated(doc, inputs.release, allow_name=False)
                 and (
@@ -344,15 +365,51 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 )
                 for doc in documents
             )
-        ):
-            errors.append("DSPACE production rendered staging-only metrics configuration")
+            if unsafe or (service_monitors and not metrics_enabled):
+                errors.append("DSPACE production rendered staging-only metrics configuration")
+            if metrics_enabled:
+                if len(service_monitors) != 1:
+                    errors.append("DSPACE production requires exactly one ServiceMonitor")
+                for monitor in service_monitors:
+                    metadata = (
+                        monitor.get("metadata") if isinstance(monitor.get("metadata"), dict) else {}
+                    )
+                    spec = monitor.get("spec") if isinstance(monitor.get("spec"), dict) else {}
+                    endpoints = spec.get("endpoints")
+                    endpoint = (
+                        endpoints[0]
+                        if isinstance(endpoints, list)
+                        and len(endpoints) == 1
+                        and isinstance(endpoints[0], dict)
+                        else {}
+                    )
+                    auth = endpoint.get("bearerTokenSecret")
+                    relabelings = endpoint.get("relabelings")
+                    cluster_ok = isinstance(relabelings, list) and any(
+                        isinstance(item, dict)
+                        and item.get("targetLabel") == "cluster"
+                        and item.get("replacement") == "sugarkube-prod"
+                        for item in relabelings
+                    )
+                    if (
+                        metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        or auth != {"name": "dspace-prod-metrics-token", "key": "token"}
+                        or endpoint.get("interval") != "30s"
+                        or endpoint.get("scrapeTimeout") != "10s"
+                        or not cluster_ok
+                    ):
+                        errors.append("DSPACE production ServiceMonitor contract mismatch")
     return errors
 
 
 def parse_chart_yaml(text: str) -> dict[str, str]:
     documents = safe_yaml_documents(text)
     document = documents[0] if documents else {}
-    return {str(key): scalar(value) for key, value in document.items()} if isinstance(document, dict) else {}
+    return (
+        {str(key): scalar(value) for key, value in document.items()}
+        if isinstance(document, dict)
+        else {}
+    )
 
 
 def semver_key(v: str) -> tuple[int, int, int, int, tuple[object, ...]]:
@@ -422,13 +479,15 @@ def deployment_app_container_env_sets(
             found.append(
                 (
                     container_name,
-                    {
-                        scalar(item.get("name"))
-                        for item in envs
-                        if isinstance(item, dict) and scalar(item.get("name"))
-                    }
-                    if isinstance(envs, list)
-                    else set(),
+                    (
+                        {
+                            scalar(item.get("name"))
+                            for item in envs
+                            if isinstance(item, dict) and scalar(item.get("name"))
+                        }
+                        if isinstance(envs, list)
+                        else set()
+                    ),
                 )
             )
     return found
@@ -488,7 +547,9 @@ def expected_ingress_host(values: tuple[str, ...], explicit: str) -> str:
     host = scalar(resolved_host)
     enabled = scalar(resolved_enabled).lower()
     if enabled == "true" and not host:
-        raise SystemExit("ERROR: ingress.enabled is true but no nonempty ingress.host was resolved.")
+        raise SystemExit(
+            "ERROR: ingress.enabled is true but no nonempty ingress.host was resolved."
+        )
     return host if enabled != "false" else ""
 
 
@@ -513,6 +574,21 @@ def validate_dspace_values(manifest: str, inputs: ReleaseInputs) -> list[str]:
         for document in safe_yaml_documents(manifest)
     )
     errors: list[str] = []
+    if inputs.env == "prod" and metrics_enabled:
+        expected = {
+            ("metrics", "auth", "existingSecret"): "dspace-prod-metrics-token",
+            ("metrics", "auth", "secretKey"): "token",
+            ("serviceMonitor", "interval"): "30s",
+            ("serviceMonitor", "scrapeTimeout"): "10s",
+            ("serviceMonitor", "additionalLabels", "release"): "kube-prometheus-stack",
+            ("serviceMonitor", "cluster"): "sugarkube-prod",
+        }
+        if not monitor_enabled or any(
+            resolved_values_scalar(inputs.values, path) != value for path, value in expected.items()
+        ):
+            errors.append(
+                "DSPACE production values do not match the authenticated metrics contract"
+            )
     if rendered_monitor and not metrics_enabled:
         errors.append("DSPACE ServiceMonitor rendered while metrics.enabled is not true")
     if rendered_monitor and (not secret or not secret_key):
@@ -689,7 +765,9 @@ def cmd_resolve_host(args: argparse.Namespace) -> int:
     try:
         host = expected_ingress_host(values, args.host)
     except (ValueError, json.JSONDecodeError, SystemExit) as error:
-        print(f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr)
+        print(
+            f"ERROR: values parsing failed while resolving ingress host: {error}", file=sys.stderr
+        )
         return 1
     print(host)
     return 0

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -483,6 +483,25 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
     return pod.get("applicationImageID", pod.get("imageIDs", {}).get("dspace"))
 
 
+def assert_production_target(kubeconfig: str, runner: Runner) -> None:
+    context = runner(
+        ["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]
+    ).strip()
+    if context != "sugar-prod":
+        raise RollbackError("metrics configuration reconciliation requires sugar-prod")
+    runner(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "cluster_identity.py"),
+            "assert",
+            "--kubeconfig",
+            kubeconfig,
+            "--env",
+            "prod",
+        ]
+    )
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -494,22 +513,7 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
             )
-        context = runner(
-            ["kubectl", "--kubeconfig", str(kubeconfig), "config", "current-context"]
-        ).strip()
-        if context != "sugar-prod":
-            raise RollbackError("metrics configuration reconciliation requires sugar-prod")
-        runner(
-            [
-                sys.executable,
-                str(REPO_ROOT / "scripts" / "cluster_identity.py"),
-                "assert",
-                "--kubeconfig",
-                str(kubeconfig),
-                "--env",
-                "prod",
-            ]
-        )
+        assert_production_target(str(kubeconfig), runner)
         args.kubeconfig = str(kubeconfig)
     with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
         os.chmod(temporary, 0o700)
@@ -815,10 +819,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     }
     reserve(args.evidence, evidence)
     mutated = False
+    production_target_verified = not configuration_reconciliation
     failed_stage = "pre-mutation-revalidation"
     operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
+        if configuration_reconciliation:
+            production_target_verified = False
+            assert_production_target(args.kubeconfig, runner)
+            production_target_verified = True
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
         if configuration_reconciliation:
@@ -862,6 +871,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                     "prod",
                 ]
             )
+            production_target_verified = False
+            assert_production_target(args.kubeconfig, runner)
+            production_target_verified = True
         command = [
             "helm",
             "--kubeconfig",
@@ -1115,27 +1127,29 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         return result
     except Exception as exc:
         diagnostics: dict[str, Any] = {}
-        try:
-            observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-            observed_info = observed_helm.get("info", {})
-            observed_chart = observed_helm.get("chart", {}).get("metadata", {})
-            diagnostics["helm"] = {
-                "release": observed_helm.get("name"),
-                "namespace": observed_helm.get("namespace"),
-                "revision": revision(observed_helm),
-                "status": observed_info.get("status"),
-                "chartName": observed_chart.get("name"),
-                "chartVersion": chart_version(observed_helm),
-                "invocationDescriptionMatches": observed_info.get("description") == description,
-            }
-        except Exception:
-            diagnostics["helm"] = "unavailable"
-        try:
-            diagnostics["pods"] = pods(
-                runner, args.kubeconfig, "dspace", "dspace", require_any=False
-            )
-        except Exception:
-            diagnostics["pods"] = "unavailable"
+        if production_target_verified:
+            try:
+                observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+                observed_info = observed_helm.get("info", {})
+                observed_chart = observed_helm.get("chart", {}).get("metadata", {})
+                diagnostics["helm"] = {
+                    "release": observed_helm.get("name"),
+                    "namespace": observed_helm.get("namespace"),
+                    "revision": revision(observed_helm),
+                    "status": observed_info.get("status"),
+                    "chartName": observed_chart.get("name"),
+                    "chartVersion": chart_version(observed_helm),
+                    "invocationDescriptionMatches": observed_info.get("description")
+                    == description,
+                }
+            except Exception:
+                diagnostics["helm"] = "unavailable"
+            try:
+                diagnostics["pods"] = pods(
+                    runner, args.kubeconfig, "dspace", "dspace", require_any=False
+                )
+            except Exception:
+                diagnostics["pods"] = "unavailable"
         evidence.update(
             state="failed",
             failedStage=failed_stage,

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import datetime as dt
 import hashlib
 import json
@@ -445,7 +446,12 @@ def replace_reserved(path: Path, value: dict[str, Any]) -> None:
 
 
 def verify_post_pods(
-    after: list[dict[str, Any]], before: list[dict[str, Any]], target: dict[str, Any], changed: bool
+    after: list[dict[str, Any]],
+    before: list[dict[str, Any]],
+    target: dict[str, Any],
+    changed: bool,
+    *,
+    retain_tag: bool = False,
 ) -> None:
     if any(p["terminating"] for p in after):
         raise RollbackError("terminating old DSPACE pods remain")
@@ -455,7 +461,9 @@ def verify_post_pods(
     new = {(p["uid"], p["startTime"]) for p in after}
     if changed and (old & new or old == new):
         raise RollbackError("DSPACE pod replacement was not proved")
-    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
+    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}"
+    if not retain_tag:
+        expected_image += f"@{target['imageDigest']}"
     for pod in after:
         if application_image(pod) != expected_image:
             raise RollbackError("DSPACE container image coordinate does not match target")
@@ -476,6 +484,33 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
 
 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
+    if getattr(args, "configuration_reconciliation", False):
+        if not args.kubeconfig or ":" in args.kubeconfig:
+            raise RollbackError(
+                "metrics configuration reconciliation requires one explicit absolute kubeconfig"
+            )
+        kubeconfig = Path(args.kubeconfig).expanduser()
+        if not kubeconfig.is_absolute():
+            raise RollbackError(
+                "metrics configuration reconciliation requires one explicit absolute kubeconfig"
+            )
+        context = runner(
+            ["kubectl", "--kubeconfig", str(kubeconfig), "config", "current-context"]
+        ).strip()
+        if context != "sugar-prod":
+            raise RollbackError("metrics configuration reconciliation requires sugar-prod")
+        runner(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "cluster_identity.py"),
+                "assert",
+                "--kubeconfig",
+                str(kubeconfig),
+                "--env",
+                "prod",
+            ]
+        )
+        args.kubeconfig = str(kubeconfig)
     with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
         os.chmod(temporary, 0o700)
         return _rollback(args, runner, Path(temporary))
@@ -492,6 +527,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
     if target["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
+    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    image_value = target["imageTag"]
+    if not configuration_reconciliation:
+        image_value += f"@{target['imageDigest']}"
     # The manifest module's OCI and cluster proof functions deliberately accept
     # candidate records. Project the exact candidate portion of the validated
     # final record rather than reimplementing or weakening those validators.
@@ -548,15 +587,16 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--set-string",
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
-            f"image.tag={target['imageTag']}@{target['imageDigest']}",
+            f"image.tag={image_value}",
         ]
     )
     before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
-    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
+        if revision(before_helm) != target["helmRevision"]:
+            raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
                 "env",
@@ -590,45 +630,69 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             ],
             "Helm stored values",
         )
-        desired_values = app_chart.merged_values_document(
-            tuple(config["SUGARKUBE_VALUES"].split(","))
-        )
+        desired_values = app_chart.merged_values_document(tuple(str(path) for path in values))
         if not isinstance(desired_values, dict):
             raise RollbackError("desired values are structurally invalid")
+        desired_values["image"] = {
+            "repository": release.IMAGE_REF,
+            "tag": target["imageTag"],
+            "pullPolicy": "Always",
+        }
+        current_values_path = staged_directory / "live-values.json"
+        current_values_path.write_text(release._canonical(live_values), encoding="utf-8")
+        os.chmod(current_values_path, 0o600)
+        installed_manifest = runner(
+            [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "manifest",
+                "dspace",
+                "--namespace",
+                "dspace",
+            ]
+        )
+        approved_current_render = runner(
+            [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "template",
+                "dspace",
+                coordinate,
+                "--namespace",
+                "dspace",
+                "--values",
+                str(current_values_path),
+            ]
+        )
+        if installed_manifest.strip() != approved_current_render.strip():
+            raise RollbackError("live manifest does not match the approved chart digest")
         try:
             release.verify_helm_stored_values(
                 approved,
-                {
-                    **desired_values,
-                    "image": {
-                        "repository": release.IMAGE_REF,
-                        "tag": target["imageTag"],
-                        "pullPolicy": "Always",
-                    },
-                },
+                desired_values,
                 "prod",
             )
         except release.ManifestError as exc:
             raise RollbackError("desired production metrics contract is invalid") from exc
 
-        def unrelated(value: dict[str, Any]) -> dict[str, Any]:
-            return {
-                key: item
-                for key, item in value.items()
-                if key not in {"image", "metrics", "serviceMonitor"}
-            }
-
-        if unrelated(live_values) != unrelated(desired_values):
-            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
-        live_metrics = live_values.get("metrics", {})
-        live_monitor = live_values.get("serviceMonitor", {})
-        if not isinstance(live_metrics, dict) or not isinstance(live_monitor, dict):
-            raise RollbackError("live metrics values are structurally invalid")
-        if live_metrics.get("enabled") not in {None, False} or live_monitor.get("enabled") not in {
+        live_metrics = live_values.get("metrics")
+        live_monitor = live_values.get("serviceMonitor")
+        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
             None,
-            False,
-        }:
+            {"enabled": False},
+        ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
+        baseline = copy.deepcopy(live_values)
+        baseline.pop("metrics", None)
+        baseline.pop("serviceMonitor", None)
+        desired_baseline = copy.deepcopy(desired_values)
+        desired_baseline.pop("metrics", None)
+        desired_baseline.pop("serviceMonitor", None)
+        if baseline != desired_baseline:
+            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -659,7 +723,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             current_ids.clear()
             break
     if configuration_reconciliation and (
-        current_images != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
+        current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
         or current_ids != {target["imageDigest"]}
     ):
         raise RollbackError("live image coordinate differs from finalized provenance")
@@ -678,7 +742,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
     except RollbackError:
         installed_render = None
-    expected_image = f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
+    expected_image = f"{release.IMAGE_REF}:{image_value}"
     if (
         installed_render is not None
         and installed_render == rendered_target
@@ -686,6 +750,21 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         and current_ids == {target["imageDigest"]}
     ):
         raise RollbackError("current rendered release is already the exact approved target")
+    render_errors = app_chart.validate_rendered_manifest(
+        rendered_target,
+        app_chart.ReleaseInputs(
+            "dspace",
+            args.environment,
+            "dspace",
+            "dspace",
+            coordinate,
+            target["chartVersion"],
+            tuple(str(path) for path in values),
+            target["imageTag"],
+        ),
+    )
+    if render_errors:
+        raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
     confirmation(args.environment, args.confirm, target)
@@ -741,6 +820,47 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     try:
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
+        if configuration_reconciliation:
+            current_status = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+            if (
+                revision(current_status) != revision(before_helm)
+                or chart_version(current_status) != target["chartVersion"]
+            ):
+                raise RollbackError("Helm coordinates changed before mutation")
+            current_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
+            if current_pods != before_pods:
+                raise RollbackError("DSPACE pods changed before mutation")
+            current_values = json_command(
+                runner,
+                [
+                    "helm",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "values",
+                    "dspace",
+                    "--namespace",
+                    "dspace",
+                    "-o",
+                    "json",
+                ],
+                "Helm stored values",
+            )
+            if current_values != live_values:
+                raise RollbackError("Helm values changed before mutation")
+            runner(
+                [
+                    "env",
+                    f"KUBECONFIG={args.kubeconfig}",
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "observability_app_metrics.py"),
+                    "secret-check",
+                    "--app",
+                    "dspace",
+                    "--env",
+                    "prod",
+                ]
+            )
         command = [
             "helm",
             "--kubeconfig",
@@ -756,7 +876,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "--set-string",
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
-            f"image.tag={target['imageTag']}@{target['imageDigest']}",
+            f"image.tag={image_value}",
             "--wait",
             "--timeout",
             args.timeout,
@@ -813,7 +933,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             or current_images
             != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
         )
-        verify_post_pods(after_pods, before_pods, target, changed)
+        verify_post_pods(
+            after_pods,
+            before_pods,
+            target,
+            changed,
+            retain_tag=configuration_reconciliation,
+        )
         if configuration_reconciliation and len(after_pods) != 2:
             raise RollbackError("reconciliation did not produce exactly two Ready DSPACE pods")
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
@@ -890,9 +1016,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             namespace="dspace",
             cluster_environment=args.environment,
             invocation_description=description,
-            expected_image_coordinate=(
-                f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
-            ),
+            expected_image_coordinate=f"{release.IMAGE_REF}:{image_value}",
             helm_stored_values_result=helm_stored_values_result,
         )
         verifier_command = [
@@ -970,6 +1094,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "frontend": {"sourceRevision": verifier["frontendSourceRevision"]},
                 "provider": {"default": verifier["defaultProvider"]},
                 "journeys": verifier["journeys"],
+                **(
+                    {
+                        "helmStoredValues": helm_stored_values_result,
+                        "productionMetrics": {
+                            "secretContract": True,
+                            "serviceMonitor": True,
+                            "healthyTargets": 2,
+                            "requiredFamilies": True,
+                            "unauthenticatedStatus": 401,
+                        },
+                    }
+                    if configuration_reconciliation
+                    else {}
+                ),
             },
         }
         replace_reserved(args.evidence, result)
@@ -1022,11 +1160,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--smoke-runner", type=Path)
     parser.add_argument("--confirm", default="")
     parser.add_argument("--config", default="")
-    parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))
+    parser.add_argument("--kubeconfig")
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
     args = parser.parse_args(argv)
+    if args.kubeconfig is None and not args.configuration_reconciliation:
+        args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:
         rollback(args)
     except (RollbackError, app_config.AppConfigError) as exc:

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import app_config  # noqa: E402
+from scripts import app_chart  # noqa: E402
 from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
@@ -552,6 +553,82 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     )
     before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
+    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    if configuration_reconciliation:
+        if args.environment != "prod":
+            raise RollbackError("metrics configuration reconciliation is production-only")
+        runner(
+            [
+                "env",
+                f"KUBECONFIG={args.kubeconfig}",
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "observability_app_metrics.py"),
+                "secret-check",
+                "--app",
+                "dspace",
+                "--env",
+                "prod",
+            ]
+        )
+        if chart_version(before_helm) != target["chartVersion"]:
+            raise RollbackError("live chart coordinate differs from finalized provenance")
+        if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
+            raise RollbackError("live release must have exactly two Ready DSPACE pods")
+        live_values = json_command(
+            runner,
+            [
+                "helm",
+                "--kubeconfig",
+                args.kubeconfig,
+                "get",
+                "values",
+                "dspace",
+                "--namespace",
+                "dspace",
+                "-o",
+                "json",
+            ],
+            "Helm stored values",
+        )
+        desired_values = app_chart.merged_values_document(
+            tuple(config["SUGARKUBE_VALUES"].split(","))
+        )
+        if not isinstance(desired_values, dict):
+            raise RollbackError("desired values are structurally invalid")
+        try:
+            release.verify_helm_stored_values(
+                approved,
+                {
+                    **desired_values,
+                    "image": {
+                        "repository": release.IMAGE_REF,
+                        "tag": target["imageTag"],
+                        "pullPolicy": "Always",
+                    },
+                },
+                "prod",
+            )
+        except release.ManifestError as exc:
+            raise RollbackError("desired production metrics contract is invalid") from exc
+
+        def unrelated(value: dict[str, Any]) -> dict[str, Any]:
+            return {
+                key: item
+                for key, item in value.items()
+                if key not in {"image", "metrics", "serviceMonitor"}
+            }
+
+        if unrelated(live_values) != unrelated(desired_values):
+            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+        live_metrics = live_values.get("metrics", {})
+        live_monitor = live_values.get("serviceMonitor", {})
+        if not isinstance(live_metrics, dict) or not isinstance(live_monitor, dict):
+            raise RollbackError("live metrics values are structurally invalid")
+        if live_metrics.get("enabled") not in {None, False} or live_monitor.get("enabled") not in {
+            None,
+            False,
+        }:
+            raise RollbackError("live metrics values are not the approved disabled baseline")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -581,6 +658,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             # identities in pod evidence and recover rather than crashing.
             current_ids.clear()
             break
+    if configuration_reconciliation and (
+        current_images != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
+        or current_ids != {target["imageDigest"]}
+    ):
+        raise RollbackError("live image coordinate differs from finalized provenance")
     try:
         installed_render = runner(
             [
@@ -617,7 +699,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     target_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
-        "operation": OPERATION,
+        "operation": (
+            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+        ),
         "state": "reserved",
         "invocationId": invocation,
         "targetManifestFingerprint": target_fingerprint,
@@ -652,7 +736,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     reserve(args.evidence, evidence)
     mutated = False
     failed_stage = "pre-mutation-revalidation"
-    description = f"sugarkube-dspace-manifest-rollback:{invocation}"
+    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
@@ -722,13 +807,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             or chart_version(after_helm) != target["chartVersion"]
         ):
             raise RollbackError("installed chart name/version does not match target")
-        changed = (
+        changed = configuration_reconciliation or (
             chart_version(before_helm) != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
             or current_images
             != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
         )
         verify_post_pods(after_pods, before_pods, target, changed)
+        if configuration_reconciliation and len(after_pods) != 2:
+            raise RollbackError("reconciliation did not produce exactly two Ready DSPACE pods")
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
         failed_stage = "ownership-and-finalization-proof"
         workloads = json_command(
@@ -813,6 +900,21 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
         )
+        if configuration_reconciliation:
+            failed_stage = "production-metrics-verification"
+            runner(
+                [
+                    "env",
+                    f"KUBECONFIG={args.kubeconfig}",
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "observability_app_metrics.py"),
+                    "verify",
+                    "--app",
+                    "dspace",
+                    "--env",
+                    "prod",
+                ]
+            )
         failed_stage = "revision-stability-collection"
         stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
         if revision(stable) != after_revision:
@@ -897,6 +999,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--kubeconfig", default=str(Path.home() / ".kube" / "config-sugarkube"))
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
+    parser.add_argument("--configuration-reconciliation", action="store_true")
     args = parser.parse_args(argv)
     try:
         rollback(args)

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -750,21 +750,22 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         and current_ids == {target["imageDigest"]}
     ):
         raise RollbackError("current rendered release is already the exact approved target")
-    render_errors = app_chart.validate_rendered_manifest(
-        rendered_target,
-        app_chart.ReleaseInputs(
-            "dspace",
-            args.environment,
-            "dspace",
-            "dspace",
-            coordinate,
-            target["chartVersion"],
-            tuple(str(path) for path in values),
-            target["imageTag"],
-        ),
-    )
-    if render_errors:
-        raise RollbackError("strict application chart render validation failed")
+    if configuration_reconciliation:
+        render_errors = app_chart.validate_rendered_manifest(
+            rendered_target,
+            app_chart.ReleaseInputs(
+                "dspace",
+                args.environment,
+                "dspace",
+                "dspace",
+                coordinate,
+                target["chartVersion"],
+                tuple(str(path) for path in values),
+                target["imageTag"],
+            ),
+        )
+        if render_errors:
+            raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
     confirmation(args.environment, args.confirm, target)

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -852,6 +852,31 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             ],
             "DSPACE pods",
         )
+        helm_stored_values_result = None
+        if approved["schemaVersion"] == 2:
+            stored_values = json_command(
+                runner,
+                [
+                    "helm",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "values",
+                    "dspace",
+                    "--namespace",
+                    "dspace",
+                    "--all",
+                    "-o",
+                    "json",
+                ],
+                "Helm stored values",
+            )
+            try:
+                helm_stored_values_result = release.verify_helm_stored_values(
+                    approved, stored_values, args.environment
+                )
+            except release.ManifestError as exc:
+                raise RollbackError("post-upgrade Helm stored values are invalid") from exc
         finalizer_proof = release.finalize(
             approved,
             after_helm,
@@ -868,6 +893,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             expected_image_coordinate=(
                 f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"
             ),
+            helm_stored_values_result=helm_stored_values_result,
         )
         verifier_command = [
             str(args.verifier),

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -922,16 +922,26 @@ def verify_helm_stored_values(
         raise ManifestError("Helm stored image values do not match approved coordinates")
 
     if environment == "prod":
-        metrics = stored_values.get("metrics", {})
-        service_monitor = stored_values.get("serviceMonitor", {})
+        expected_metrics = {
+            "enabled": True,
+            "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+        }
+        expected_monitor = {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        }
         if (
-            not isinstance(metrics, dict)
-            or not isinstance(service_monitor, dict)
-            or metrics.get("enabled") is True
-            or service_monitor.get("enabled") is True
+            stored_values.get("metrics") != expected_metrics
+            or stored_values.get("serviceMonitor") != expected_monitor
             or contains_staging_reference(stored_values)
         ):
-            raise ManifestError("Helm stored production values contain staging-only settings")
+            raise ManifestError(
+                "Helm stored production metrics values do not match the approved contract "
+                "or contain staging-only settings"
+            )
     return {
         "check": "helmStoredValues",
         "passed": True,
@@ -941,7 +951,12 @@ def verify_helm_stored_values(
 
 def contains_staging_reference(value: object) -> bool:
     """Detect known staging-only scalar values without reflecting them in diagnostics."""
-    forbidden = {"METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"}
+    forbidden = {
+        "METRICS_TOKEN",
+        "dspace-staging-metrics-token",
+        "sugarkube-int",
+        "staging.democratized.space",
+    }
     if isinstance(value, dict):
         return any(
             contains_staging_reference(key) or contains_staging_reference(item)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -937,6 +937,13 @@ def verify_helm_stored_values(
             stored_values.get("metrics") != expected_metrics
             or stored_values.get("serviceMonitor") != expected_monitor
             or contains_staging_reference(stored_values)
+            or contains_inline_credential(
+                {
+                    key: item
+                    for key, item in stored_values.items()
+                    if key not in {"metrics", "serviceMonitor"}
+                }
+            )
         ):
             raise ManifestError(
                 "Helm stored production metrics values do not match the approved contract "
@@ -965,6 +972,23 @@ def contains_staging_reference(value: object) -> bool:
     if isinstance(value, list):
         return any(contains_staging_reference(item) for item in value)
     return isinstance(value, str) and value in forbidden
+
+
+def contains_inline_credential(value: object) -> bool:
+    """Reject credential-shaped values without reflecting their contents."""
+    sensitive = re.compile(
+        r"(?:authorization|bearer|credential|pass" r"word|passwd|secret|token)", re.I
+    )
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(key, str) and sensitive.search(key):
+                return True
+            if contains_inline_credential(item):
+                return True
+        return False
+    if isinstance(value, list):
+        return any(contains_inline_credential(item) for item in value)
+    return False
 
 
 def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]) -> int:

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -977,7 +977,9 @@ def contains_staging_reference(value: object) -> bool:
 def contains_inline_credential(value: object) -> bool:
     """Detect inline credential material while allowing references and empty defaults."""
     sensitive = re.compile(
-        r"(?:authorization|bearer|credential|pass" r"word|passwd|secret|token)", re.I
+        r"(?:authorization|bearer|credential|pass"
+        r"word|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key)",
+        re.I,
     )
     reference_keys = {
         "automountserviceaccounttoken",
@@ -1000,16 +1002,26 @@ def contains_inline_credential(value: object) -> bool:
         ):
             return True
         for key, item in value.items():
+            if isinstance(key, str) and key.lower() == "secret" and isinstance(item, dict):
+                if item.get("enabled") is True:
+                    return True
+                if not is_empty(item.get("data")) or not is_empty(item.get("stringData")):
+                    return True
+                if contains_inline_credential(
+                    {
+                        child_key: child_value
+                        for child_key, child_value in item.items()
+                        if child_key not in {"enabled", "data", "stringData"}
+                    }
+                ):
+                    return True
+                continue
             if isinstance(key, str) and sensitive.search(key):
                 if key.lower() in reference_keys:
                     if isinstance(item, (dict, list)) and contains_inline_credential(item):
                         return True
                     continue
                 if is_empty(item):
-                    continue
-                if key.lower() == "secret" and isinstance(item, dict):
-                    if contains_inline_credential(item):
-                        return True
                     continue
                 return True
             if contains_inline_credential(item):

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -924,6 +924,7 @@ def verify_helm_stored_values(
     if environment == "prod":
         expected_metrics = {
             "enabled": True,
+            "path": "/metrics",
             "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
         }
         expected_monitor = {
@@ -959,7 +960,6 @@ def verify_helm_stored_values(
 def contains_staging_reference(value: object) -> bool:
     """Detect known staging-only scalar values without reflecting them in diagnostics."""
     forbidden = {
-        "METRICS_TOKEN",
         "dspace-staging-metrics-token",
         "sugarkube-int",
         "staging.democratized.space",
@@ -975,13 +975,42 @@ def contains_staging_reference(value: object) -> bool:
 
 
 def contains_inline_credential(value: object) -> bool:
-    """Reject credential-shaped values without reflecting their contents."""
+    """Detect inline credential material while allowing references and empty defaults."""
     sensitive = re.compile(
         r"(?:authorization|bearer|credential|pass" r"word|passwd|secret|token)", re.I
     )
+    reference_keys = {
+        "automountserviceaccounttoken",
+        "existingsecret",
+        "secretkey",
+        "secretkeyref",
+        "secretname",
+    }
+
+    def is_empty(item: object) -> bool:
+        return item is None or item is False or item == "" or item == {} or item == []
+
     if isinstance(value, dict):
+        name = value.get("name")
+        if (
+            isinstance(name, str)
+            and sensitive.search(name)
+            and "value" in value
+            and not is_empty(value["value"])
+        ):
+            return True
         for key, item in value.items():
             if isinstance(key, str) and sensitive.search(key):
+                if key.lower() in reference_keys:
+                    if isinstance(item, (dict, list)) and contains_inline_credential(item):
+                        return True
+                    continue
+                if is_empty(item):
+                    continue
+                if key.lower() == "secret" and isinstance(item, dict):
+                    if contains_inline_credential(item):
+                        return True
+                    continue
                 return True
             if contains_inline_credential(item):
                 return True

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -452,7 +452,17 @@ def assert_production_context():
     ctx = run(["kubectl", "config", "current-context"]).strip()
     if ctx != "sugar-prod":
         fail(f"context mismatch: expected sugar-prod, got {ctx or '<none>'}", 3)
-    run([sys.executable, str(ROOT / "scripts" / "cluster_identity.py"), "assert", "--env", "prod"])
+    run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "cluster_identity.py"),
+            "assert",
+            "--kubeconfig",
+            kubeconfig,
+            "--env",
+            "prod",
+        ]
+    )
 
 
 def appcfg(app, env):
@@ -918,13 +928,31 @@ def load_rendered_docs(input_path: str) -> list[dict[str, Any]]:
         raw = (
             sys.stdin.read() if input_path == "-" else Path(input_path).read_text(encoding="utf-8")
         )
+        ruby = r"""
+require "psych"
+require "json"
+scanner = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], []))
+def convert(node, scanner)
+  case node
+  when Psych::Nodes::Stream then node.children.map { |child| convert(child, scanner) }
+  when Psych::Nodes::Document then convert(node.root, scanner)
+  when Psych::Nodes::Mapping
+    Hash[*node.children.map { |child| convert(child, scanner) }]
+  when Psych::Nodes::Sequence then node.children.map { |child| convert(child, scanner) }
+  when Psych::Nodes::Scalar
+    raise "unsafe YAML tag #{node.tag}" if node.tag && !node.tag.start_with?("tag:yaml.org,2002:")
+    node.quoted ? node.value : scanner.tokenize(node.value)
+  when Psych::Nodes::Alias then raise "YAML aliases are not allowed"
+  else raise "unsupported YAML node #{node.class}"
+  end
+end
+puts JSON.generate(convert(Psych.parse_stream(STDIN.read), scanner))
+"""
         converted = subprocess.run(
             [
                 "ruby",
-                "-ryaml",
-                "-rjson",
                 "-e",
-                "puts JSON.generate(YAML.load_stream(STDIN.read).compact)",
+                ruby,
             ],
             input=raw,
             text=True,

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -507,6 +507,9 @@ def install_secret(cfg):
         "TOKEN",
         "METRICS_TOKEN",
         "TOKENPLACE_METRICS_TOKEN",
+        "DSPACE_METRICS_TOKEN",
+        "DSPACE_PROD_METRICS_TOKEN",
+        "DSPACE_METRICS_CREDENTIAL",
         "SUGARKUBE_APP_METRICS_TOKEN",
     ):
         if bad in __import__("os").environ:
@@ -791,7 +794,10 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                 )
                 if not isinstance(series_name, str) or not PROM_METRIC.fullmatch(series_name):
                     fail("Prometheus query sample is structurally invalid (details redacted)", 1)
-                if metric_family_from_series(series_name) == metric:
+                # A required family may itself include a Prometheus suffix (for
+                # example the histogram family explicitly named ``*_bucket``).
+                # Prefer exact identity before normalizing conventional suffixes.
+                if series_name == metric or metric_family_from_series(series_name) == metric:
                     found.add(metric)
     return found
 
@@ -820,10 +826,15 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     metadata = sm.get("metadata")
     labels = metadata.get("labels") if isinstance(metadata, dict) else None
-    if env == "prod" and (
-        not isinstance(labels, dict) or labels.get("release") != "kube-prometheus-stack"
-    ):
-        fail("ServiceMonitor discovery label mismatch", 1)
+    if env == "prod":
+        if (
+            not isinstance(metadata, dict)
+            or metadata.get("name") != cfg["serviceMonitorName"]
+            or metadata.get("namespace") != cfg["namespace"]
+        ):
+            fail("ServiceMonitor identity mismatch", 1)
+        if not isinstance(labels, dict) or labels.get("release") != "kube-prometheus-stack":
+            fail("ServiceMonitor discovery label mismatch", 1)
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("ServiceMonitor must expose exactly one endpoint", 1)

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -19,7 +19,6 @@ import warnings
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "platform/observability/app-metrics.json"
 PROM = "/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy"
@@ -32,9 +31,7 @@ SAFE_VALUE = re.compile(r"[-A-Za-z0-9_./:*]+")
 PROM_LABEL = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 PROM_METRIC = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 K8S_LABEL_NAME = re.compile(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?")
-K8S_LABEL_PREFIX = re.compile(
-    r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-)
+K8S_LABEL_PREFIX = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 STANDARD_LABELS = {
     "__name__",
     "job",
@@ -212,11 +209,11 @@ def validate_inventory(doc):
         environments = appdoc["environments"]
         if not isinstance(environments, dict) or not environments:
             fail(f"application {app}.environments must be a nonempty object")
-        if set(environments) != {"staging"}:
-            fail("only staging app metrics verification is supported")
         for env, cfg in environments.items():
-            if env != "staging":
-                fail("only staging app metrics verification is supported")
+            if env not in {"staging", "prod"}:
+                fail("application metrics environment is unsupported")
+            if env == "prod" and app != "dspace":
+                fail("only staging app metrics verification is supported for this application")
             expect_keys(
                 cfg,
                 {
@@ -249,7 +246,14 @@ def validate_inventory(doc):
             sm = cfg["serviceMonitor"]
             expect_keys(
                 sm,
-                {"selectorMatchLabels", "path", "interval", "scrapeTimeout", "authorization", "relabelings"},
+                {
+                    "selectorMatchLabels",
+                    "path",
+                    "interval",
+                    "scrapeTimeout",
+                    "authorization",
+                    "relabelings",
+                },
                 "serviceMonitor",
             )
             if sm["path"] != "/metrics":
@@ -260,7 +264,9 @@ def validate_inventory(doc):
             expect_keys(sm["authorization"], {"type", "credentials"}, "authorization")
             if sm["authorization"]["type"] != "Bearer":
                 fail("authorization.type must be Bearer")
-            expect_keys(sm["authorization"].get("credentials"), {"name", "key"}, "authorization.credentials")
+            expect_keys(
+                sm["authorization"].get("credentials"), {"name", "key"}, "authorization.credentials"
+            )
             name(sm["authorization"]["credentials"]["name"], "authorization.credentials.name")
             name(sm["authorization"]["credentials"]["key"], "authorization.credentials.key")
             if sm["authorization"]["credentials"] != cfg["secret"]:
@@ -275,7 +281,11 @@ def validate_inventory(doc):
             if not isinstance(relabelings, list) or len(relabelings) != 4:
                 fail("serviceMonitor.relabelings must contain exactly four entries")
             for idx, relabeling in enumerate(relabelings):
-                expect_keys(relabeling, {"action", "targetLabel", "replacement"}, f"serviceMonitor.relabelings[{idx}]")
+                expect_keys(
+                    relabeling,
+                    {"action", "targetLabel", "replacement"},
+                    f"serviceMonitor.relabelings[{idx}]",
+                )
                 if relabeling["action"] != "replace":
                     fail("serviceMonitor.relabelings action must be replace")
                 prometheus_label(relabeling["targetLabel"], "relabeling targetLabel")
@@ -284,13 +294,18 @@ def validate_inventory(doc):
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
             if set(labels) != {"app", "environment", "release", "cluster", "namespace"}:
-                fail("targetLabels must contain exactly app, environment, release, cluster, and namespace")
+                fail(
+                    "targetLabels must contain exactly app, environment, release, cluster, and namespace"
+                )
             for k, v in labels.items():
                 prometheus_label(k, "target label name")
                 nonempty(v, "target label value")
             if labels["app"] != app or labels["environment"] != env:
                 fail("targetLabels must match application and environment")
-            if labels["release"] != cfg["serviceMonitorName"] or labels["namespace"] != cfg["namespace"]:
+            if (
+                labels["release"] != cfg["serviceMonitorName"]
+                or labels["namespace"] != cfg["namespace"]
+            ):
                 fail("targetLabels must match ServiceMonitor and namespace")
             mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
             if len(mapping) != len(relabelings):
@@ -302,20 +317,28 @@ def validate_inventory(doc):
                 "cluster": labels.get("cluster"),
             }
             if mapping != required_mapping:
-                fail("serviceMonitor.relabelings must map app, environment, release, and cluster exactly")
+                fail(
+                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
+                )
             if "namespace" in mapping:
                 fail("namespace must be supplied by discovery, not relabel replacement")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
-            if isinstance(pm["expectedUnauthenticatedStatus"], bool) or not isinstance(pm["expectedUnauthenticatedStatus"], int) or not STATUS.fullmatch(
-                str(pm["expectedUnauthenticatedStatus"])
+            if (
+                isinstance(pm["expectedUnauthenticatedStatus"], bool)
+                or not isinstance(pm["expectedUnauthenticatedStatus"], int)
+                or not STATUS.fullmatch(str(pm["expectedUnauthenticatedStatus"]))
             ):
                 fail("public status is malformed")
             rt = cfg["retries"]
             expect_keys(rt, {"attempts", "delaySeconds"}, "retries")
             for key in ("attempts", "delaySeconds"):
-                if isinstance(rt[key], bool) or not isinstance(rt[key], int) or not 1 <= rt[key] <= 60:
+                if (
+                    isinstance(rt[key], bool)
+                    or not isinstance(rt[key], int)
+                    or not 1 <= rt[key] <= 60
+                ):
                     fail("retry settings must be bounded integers")
             metrics = cfg["requiredMetricFamilies"]
             unique_string_list(metrics, "requiredMetricFamilies", prometheus_metric)
@@ -341,13 +364,23 @@ def validate_inventory(doc):
                 fail("static and derived application labels conflict")
             for label, source in derived.items():
                 prometheus_label(label, "derived label name")
-                expect_keys(source, {"workload", "container", "env", "normalizer"}, f"derivedApplicationLabels.{label}")
-                expect_keys(source["workload"], {"kind", "name"}, f"derivedApplicationLabels.{label}.workload")
+                expect_keys(
+                    source,
+                    {"workload", "container", "env", "normalizer"},
+                    f"derivedApplicationLabels.{label}",
+                )
+                expect_keys(
+                    source["workload"],
+                    {"kind", "name"},
+                    f"derivedApplicationLabels.{label}.workload",
+                )
                 if source["workload"]["kind"] != "Deployment":
                     fail("derived workload kind is unsupported")
                 name(source["workload"]["name"], "derived workload name")
                 name(source["container"], "derived container")
-                if not isinstance(source["env"], str) or not re.fullmatch(r"[A-Z_][A-Z0-9_]{0,62}", source["env"]):
+                if not isinstance(source["env"], str) or not re.fullmatch(
+                    r"[A-Z_][A-Z0-9_]{0,62}", source["env"]
+                ):
                     fail("derived environment variable name is unsafe")
                 if source["normalizer"] != "identity":
                     fail("derived normalizer is unsupported")
@@ -366,8 +399,8 @@ def normalize_live_env(env: str) -> str:
         value = value[4:].strip()
     if value == "int":
         value = "staging"
-    if value != "staging":
-        fail("application metrics live operations support staging only")
+    if value not in {"staging", "prod"}:
+        fail("application metrics environment is unsupported")
     return value
 
 
@@ -412,6 +445,16 @@ def assert_context():
         fail(f"context mismatch: expected sugar-staging, got {ctx or '<none>'}", 3)
 
 
+def assert_production_context():
+    kubeconfig = os.environ.get("KUBECONFIG", "")
+    if not kubeconfig or ":" in kubeconfig or not Path(kubeconfig).is_absolute():
+        fail("production requires one explicit absolute KUBECONFIG", 3)
+    ctx = run(["kubectl", "config", "current-context"]).strip()
+    if ctx != "sugar-prod":
+        fail(f"context mismatch: expected sugar-prod, got {ctx or '<none>'}", 3)
+    run([sys.executable, str(ROOT / "scripts" / "cluster_identity.py"), "assert", "--env", "prod"])
+
+
 def appcfg(app, env):
     app = normalize_application_argument(app)
     env = normalize_live_env(env)
@@ -448,6 +491,8 @@ def check_secret(cfg):
 
 
 def install_secret(cfg):
+    if "xtrace" in os.environ.get("SHELLOPTS", "").split(":"):
+        fail("shell xtrace is refused")
     for bad in (
         "TOKEN",
         "METRICS_TOKEN",
@@ -470,8 +515,10 @@ def install_secret(cfg):
         use_stdin_fallback = True
     try:
         with tty_context:
-            if not tty.isatty() or not tty.readable() or (
-                not use_stdin_fallback and not tty.writable()
+            if (
+                not tty.isatty()
+                or not tty.readable()
+                or (not use_stdin_fallback and not tty.writable())
             ):
                 fail("an interactive controlling terminal is required")
             prompt = "Enter application metrics bearer token (input hidden): "
@@ -545,7 +592,9 @@ def find_env_value(workload: dict[str, Any], source: dict[str, Any]) -> str:
     containers = pod_spec.get("containers") if isinstance(pod_spec, dict) else None
     if not isinstance(containers, list):
         fail("workload source contract is malformed (details redacted)", 1)
-    matches = [c for c in containers if isinstance(c, dict) and c.get("name") == source["container"]]
+    matches = [
+        c for c in containers if isinstance(c, dict) and c.get("name") == source["container"]
+    ]
     if len(matches) != 1:
         fail("workload container source is absent or ambiguous (details redacted)", 1)
     env_entries = matches[0].get("env")
@@ -596,7 +645,20 @@ def derive_build_labels_live(cfg):
         if key in seen:
             continue
         seen.add(key)
-        docs.append(kjson(["kubectl", "-n", cfg["namespace"], "get", workload["kind"].lower(), workload["name"], "-o", "json"]))
+        docs.append(
+            kjson(
+                [
+                    "kubectl",
+                    "-n",
+                    cfg["namespace"],
+                    "get",
+                    workload["kind"].lower(),
+                    workload["name"],
+                    "-o",
+                    "json",
+                ]
+            )
+        )
     return derive_build_labels_from_docs(cfg, docs)
 
 
@@ -605,25 +667,36 @@ def validate_metric_labels(cfg, labels, derived_values=None):
     if not isinstance(labels, dict):
         fail("metric labels were malformed (details redacted)", 1)
     for label, value in labels.items():
-        if not isinstance(label, str) or not PROM_LABEL.fullmatch(label) or not isinstance(value, str):
+        if (
+            not isinstance(label, str)
+            or not PROM_LABEL.fullmatch(label)
+            or not isinstance(value, str)
+        ):
             fail("metric labels were malformed (details redacted)", 1)
         low = label.lower()
         is_standard = label in STANDARD_LABELS
-        if not is_standard and label not in cfg["allowedApplicationLabels"] and label not in cfg.get("derivedApplicationLabels", {}):
+        if (
+            not is_standard
+            and label not in cfg["allowedApplicationLabels"]
+            and label not in cfg.get("derivedApplicationLabels", {})
+        ):
             fail("unbounded application metric label observed (details redacted)", 1)
         if not is_standard and (
             any(w in low for w in cfg["forbiddenApplicationLabels"])
             or any(w in low for w in FORBIDDEN_WORDS)
         ):
             fail("forbidden application metric label observed (details redacted)", 1)
-        if label in cfg["allowedApplicationLabels"] and value not in cfg["allowedApplicationLabels"][label]:
+        if (
+            label in cfg["allowedApplicationLabels"]
+            and value not in cfg["allowedApplicationLabels"][label]
+        ):
             fail("application metric label enum mismatch (details redacted)", 1)
         if label in cfg.get("derivedApplicationLabels", {}) and value != derived_values.get(label):
             fail("derived application metric label mismatch (details redacted)", 1)
 
 
 def prometheus_label_escape(value: str) -> str:
-    return value.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 def promql_selector(labels: dict[str, str]) -> str:
@@ -654,12 +727,18 @@ def is_relevant_target(cfg: dict[str, Any], target: dict[str, Any]) -> bool:
     if not isinstance(labels, dict) or not isinstance(discovered, dict):
         fail("Prometheus target response is structurally invalid (details redacted)", 1)
     identities = target_discovery_identities(cfg)
-    for field in (target.get("scrapePool"), target.get("scrapeConfig"), labels.get("job"), discovered.get("job")):
+    for field in (
+        target.get("scrapePool"),
+        target.get("scrapeConfig"),
+        labels.get("job"),
+        discovered.get("job"),
+    ):
         if isinstance(field, str) and field in identities:
             return True
     if (
         discovered.get("__meta_kubernetes_namespace") == cfg["namespace"]
-        and discovered.get("__meta_prometheus_operator_service_monitor_name") == cfg["serviceMonitorName"]
+        and discovered.get("__meta_prometheus_operator_service_monitor_name")
+        == cfg["serviceMonitorName"]
     ):
         return True
     return False
@@ -697,18 +776,21 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                     fail("Prometheus query response is structurally invalid (details redacted)", 1)
                 sample_labels = sample.get("metric")
                 validate_metric_labels(cfg, sample_labels, derived_values)
-                series_name = sample_labels.get("__name__") if isinstance(sample_labels, dict) else None
+                series_name = (
+                    sample_labels.get("__name__") if isinstance(sample_labels, dict) else None
+                )
                 if not isinstance(series_name, str) or not PROM_METRIC.fullmatch(series_name):
                     fail("Prometheus query sample is structurally invalid (details redacted)", 1)
                 if metric_family_from_series(series_name) == metric:
                     found.add(metric)
     return found
 
+
 def verify(app, env):
     app = normalize_application_argument(app)
     env = normalize_live_env(env)
     cfg = appcfg(app, env)
-    assert_context()
+    assert_production_context() if env == "prod" else assert_context()
     check_secret(cfg)
     derived_values = derive_build_labels_live(cfg)
     sm = kjson(
@@ -726,6 +808,12 @@ def verify(app, env):
     spec = sm.get("spec")
     if not isinstance(spec, dict):
         fail("ServiceMonitor response is structurally invalid", 1)
+    metadata = sm.get("metadata")
+    labels = metadata.get("labels") if isinstance(metadata, dict) else None
+    if env == "prod" and (
+        not isinstance(labels, dict) or labels.get("release") != "kube-prometheus-stack"
+    ):
+        fail("ServiceMonitor discovery label mismatch", 1)
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("ServiceMonitor must expose exactly one endpoint", 1)
@@ -734,8 +822,15 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     authorization = ep.get("authorization")
     auth = authorization.get("credentials") if isinstance(authorization, dict) else None
+    if app == "dspace" and env == "prod":
+        auth = ep.get("bearerTokenSecret")
+        authorization = {"type": "Bearer"} if isinstance(auth, dict) else authorization
     selector = spec.get("selector")
-    if not isinstance(authorization, dict) or not isinstance(auth, dict) or not isinstance(selector, dict):
+    if (
+        not isinstance(authorization, dict)
+        or not isinstance(auth, dict)
+        or not isinstance(selector, dict)
+    ):
         fail("ServiceMonitor response is structurally invalid", 1)
     if (
         ep.get("path") != "/metrics"
@@ -747,10 +842,7 @@ def verify(app, env):
         or auth.get("key") != cfg["secret"]["key"]
     ):
         fail("ServiceMonitor endpoint/auth contract mismatch", 1)
-    if (
-        selector.get("matchLabels")
-        != cfg["serviceMonitor"]["selectorMatchLabels"]
-    ):
+    if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("ServiceMonitor selector mismatch", 1)
     targets = []
     attempts = cfg["retries"]["attempts"]
@@ -767,7 +859,10 @@ def verify(app, env):
         if i + 1 < attempts:
             time.sleep(cfg["retries"]["delaySeconds"])
     if not target_state_converged(cfg, targets):
-        fail("Prometheus targets are absent, down, mislabeled, or have unexpected count (details redacted)", 1)
+        fail(
+            "Prometheus targets are absent, down, mislabeled, or have unexpected count (details redacted)",
+            1,
+        )
 
     required = set(cfg["requiredMetricFamilies"])
     found: set[str] = set()
@@ -780,6 +875,7 @@ def verify(app, env):
     missing = required - found
     if missing:
         fail(f"required metric family missing: {sorted(missing)[0]}", 1)
+
     class NoRedirect(urllib.request.HTTPRedirectHandler):
         def redirect_request(self, req, fp, code, msg, headers, newurl):
             return None
@@ -819,9 +915,17 @@ def verify(app, env):
 
 def load_rendered_docs(input_path: str) -> list[dict[str, Any]]:
     try:
-        raw = sys.stdin.read() if input_path == "-" else Path(input_path).read_text(encoding="utf-8")
+        raw = (
+            sys.stdin.read() if input_path == "-" else Path(input_path).read_text(encoding="utf-8")
+        )
         converted = subprocess.run(
-            ["ruby", "-ryaml", "-rjson", "-e", "puts JSON.generate(YAML.load_stream(STDIN.read).compact)"],
+            [
+                "ruby",
+                "-ryaml",
+                "-rjson",
+                "-e",
+                "puts JSON.generate(YAML.load_stream(STDIN.read).compact)",
+            ],
             input=raw,
             text=True,
             capture_output=True,
@@ -832,7 +936,9 @@ def load_rendered_docs(input_path: str) -> list[dict[str, Any]]:
         fail("rendered manifests are malformed (details redacted)")
 
 
-def validate_render(app: str, env: str, input_path: str, release_namespace: str = "", release_name: str = "") -> None:
+def validate_render(
+    app: str, env: str, input_path: str, release_namespace: str = "", release_name: str = ""
+) -> None:
     inv = load_config()
     cfg = inv.get("applications", {}).get(app, {}).get("environments", {}).get(env)
     if cfg is None:
@@ -857,7 +963,9 @@ def validate_render(app: str, env: str, input_path: str, release_namespace: str 
     sms = []
     for candidate in named_sms:
         rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (rendered_ns is None and release_namespace == cfg["namespace"]):
+        if rendered_ns == cfg["namespace"] or (
+            rendered_ns is None and release_namespace == cfg["namespace"]
+        ):
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -891,15 +999,35 @@ def validate_render(app: str, env: str, input_path: str, release_namespace: str 
         fail("rendered ServiceMonitor endpoint is structurally invalid")
     auth = ep.get("authorization")
     creds = auth.get("credentials") if isinstance(auth, dict) else None
+    if app == "dspace" and env == "prod":
+        creds = ep.get("bearerTokenSecret")
+        auth = {"type": "Bearer"} if isinstance(creds, dict) else auth
     if not isinstance(auth, dict) or not isinstance(creds, dict):
         fail("rendered ServiceMonitor authorization is structurally invalid")
-    if (ep.get("path") != cfg["serviceMonitor"]["path"] or ep.get("interval") != cfg["serviceMonitor"]["interval"] or ep.get("scrapeTimeout") != cfg["serviceMonitor"]["scrapeTimeout"] or auth.get("type") != cfg["serviceMonitor"]["authorization"]["type"] or creds.get("name") != cfg["secret"]["name"] or creds.get("key") != cfg["secret"]["key"] or ep.get("relabelings") != cfg["serviceMonitor"]["relabelings"]):
+    if (
+        ep.get("path") != cfg["serviceMonitor"]["path"]
+        or ep.get("interval") != cfg["serviceMonitor"]["interval"]
+        or ep.get("scrapeTimeout") != cfg["serviceMonitor"]["scrapeTimeout"]
+        or auth.get("type") != cfg["serviceMonitor"]["authorization"]["type"]
+        or creds.get("name") != cfg["secret"]["name"]
+        or creds.get("key") != cfg["secret"]["key"]
+        or ep.get("relabelings") != cfg["serviceMonitor"]["relabelings"]
+    ):
         fail("rendered ServiceMonitor endpoint/auth/relabeling contract mismatch")
+
 
 def main(argv=None):
     p = argparse.ArgumentParser()
     p.add_argument(
-        "mode", choices=["validate", "validate-render", "secret-check", "secret-install", "verify", "verify-all"]
+        "mode",
+        choices=[
+            "validate",
+            "validate-render",
+            "secret-check",
+            "secret-install",
+            "verify",
+            "verify-all",
+        ],
     )
     p.add_argument("--app")
     p.add_argument("--env", default="staging")
@@ -925,15 +1053,16 @@ def main(argv=None):
         if a.mode == "verify-all":
             env = normalize_live_env(a.env)
             inv = load_config()
-            for app in inv["applications"]:
-                verify(app, env)
+            for app, appdoc in inv["applications"].items():
+                if "environments" not in appdoc or env in appdoc["environments"]:
+                    verify(app, env)
             return 0
         if not a.app:
             fail("--app is required")
         app = normalize_application_argument(a.app)
         env = normalize_live_env(a.env)
         cfg = appcfg(app, env)
-        assert_context()
+        assert_production_context() if env == "prod" else assert_context()
         if a.mode == "secret-check":
             check_secret(cfg)
         elif a.mode == "secret-install":

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -168,12 +168,21 @@ def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> 
     assert "cluster: sugarkube-int" in text
 
 
-def test_dspace_prod_values_do_not_enable_metrics_or_servicemonitor() -> None:
+def test_dspace_prod_values_enable_authenticated_metrics_without_a_credential() -> None:
     text = OVERLAYS["prod"].read_text(encoding="utf-8")
 
-    assert "metrics:" not in text
-    assert "serviceMonitor:" not in text
-    assert "dspace-staging-metrics-token" not in text
+    values = merged_values_document((str(OVERLAYS["prod"]),))
+    assert values["metrics"] == {
+        "enabled": True,
+        "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+    }
+    assert values["serviceMonitor"] == {
+        "enabled": True,
+        "interval": "30s",
+        "scrapeTimeout": "10s",
+        "additionalLabels": {"release": "kube-prometheus-stack"},
+        "cluster": "sugarkube-prod",
+    }
 
 
 def test_dspace_fixtures_do_not_contain_real_credentials() -> None:
@@ -182,4 +191,7 @@ def test_dspace_fixtures_do_not_contain_real_credentials() -> None:
         assert (
             "dspace-staging-metrics-token" not in text or path.name == "dspace.values.staging.yaml"
         )
-        assert "secretKey: token" not in text or path.name == "dspace.values.staging.yaml"
+        assert "secretKey: token" not in text or path.name in {
+            "dspace.values.staging.yaml",
+            "dspace.values.prod.yaml",
+        }

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -330,6 +330,11 @@ spec:
         - name: ${{container}}
           image: ghcr.io/example/${{app}}:${{tag}}
           env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dspace-prod-metrics-token
+                  key: token
             - name: TOKENPLACE_IMAGE_TAG
               value: ${{tag}}
             - name: TOKENPLACE_RELEASE_VERSION
@@ -428,6 +433,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
+  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -1612,7 +1618,7 @@ spec:
 @pytest.mark.parametrize(
     "leak", ["METRICS_TOKEN", "dspace-staging-metrics-token", "sugarkube-int"]
 )
-def test_dspace_production_checks_only_release_associated_structure(leak: str) -> None:
+def test_dspace_production_rejects_staging_scalars_anywhere(leak: str) -> None:
     inputs = app_chart.ReleaseInputs(
         "dspace", "prod", "dspace", "dspace", "chart", "3.1.0", (),
         "main-deadbee", "democratized.space",
@@ -1646,7 +1652,7 @@ data:
   value: {leak}
 """
 
-    assert "DSPACE production rendered staging-only metrics configuration" not in (
+    assert "DSPACE production rendered staging-only metrics configuration" in (
         app_chart.validate_rendered_manifest(unrelated, inputs)
     )
     assert "DSPACE production rendered staging-only metrics configuration" in (
@@ -6180,6 +6186,19 @@ def test_observability_app_metrics_malformed_samples_fail_immediately(monkeypatc
     with pytest.raises(app_metrics.Error):
         app_metrics.query_required_families(cfg, {"version": "main-deadbee", "revision": "main-deadbee"})
     assert slept == []
+
+
+def test_observability_app_metrics_accepts_exact_bucket_family(monkeypatch):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"]["environments"]["prod"]
+    cfg = {**cfg, "requiredMetricFamilies": ["dspace_http_request_duration_seconds_bucket"]}
+    monkeypatch.setattr(app_metrics, "prom", lambda path: {
+        "resultType": "vector",
+        "result": [{"metric": {"__name__": "dspace_http_request_duration_seconds_bucket", **cfg["targetLabels"]}}],
+    })
+
+    assert app_metrics.query_required_families(cfg, {}) == {
+        "dspace_http_request_duration_seconds_bucket"
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -208,11 +208,19 @@ if [[ "$*" == *"get values"* ]]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
     exit 1
   fi
-  printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":{{"enabled":false}},"serviceMonitor":{{"enabled":false}},"ingress":{{"host":"%s"}}}}\n' \
-    "${{SUGARKUBE_STUB_HELM_REPOSITORY:-ghcr.io/democratizedspace/dspace}}" \
-    "${{SUGARKUBE_STUB_HELM_TAG:-main-abcdef0}}" \
-    "${{SUGARKUBE_STUB_HELM_PULL_POLICY:-Always}}" \
-    "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
+  if [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then
+    printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":{{"enabled":true,"auth":{{"existingSecret":"dspace-prod-metrics-token","secretKey":"token"}}}},"serviceMonitor":{{"enabled":true,"interval":"30s","scrapeTimeout":"10s","additionalLabels":{{"release":"kube-prometheus-stack"}},"cluster":"sugarkube-prod"}},"ingress":{{"host":"%s"}}}}\n' \
+      "${{SUGARKUBE_STUB_HELM_REPOSITORY:-ghcr.io/democratizedspace/dspace}}" \
+      "${{SUGARKUBE_STUB_HELM_TAG:-main-abcdef0}}" \
+      "${{SUGARKUBE_STUB_HELM_PULL_POLICY:-Always}}" \
+      "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
+  else
+    printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":{{"enabled":false}},"serviceMonitor":{{"enabled":false}},"ingress":{{"host":"%s"}}}}\n' \
+      "${{SUGARKUBE_STUB_HELM_REPOSITORY:-ghcr.io/democratizedspace/dspace}}" \
+      "${{SUGARKUBE_STUB_HELM_TAG:-main-abcdef0}}" \
+      "${{SUGARKUBE_STUB_HELM_PULL_POLICY:-Always}}" \
+      "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
+  fi
   exit 0
 fi
 if [[ "$*" == show\ chart* ]]; then
@@ -399,11 +407,59 @@ metadata:
   labels:
     app.kubernetes.io/instance: dspace
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
   endpoints:
     - port: http
       bearerTokenSecret:
         name: dspace-staging-metrics-token
         key: token
+YAML
+    fi
+    if [ "${{app}}" = dspace ] && [[ "$*" == *dspace.values.prod.yaml* ]]; then
+      cat <<'YAML'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: prod
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-prod
 YAML
     fi
   fi
@@ -6281,7 +6337,7 @@ def test_observability_app_metrics_verify_all_uses_every_configured_app(monkeypa
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):
-    forbidden = ["prod", "production", "", "dev", "qa"]
+    forbidden = ["production", "", "dev", "qa"]
     for env in forbidden:
         def fail_load_config(env=env):
             raise AssertionError(f"loaded config for {env!r}")
@@ -6289,11 +6345,18 @@ def test_observability_app_metrics_live_environment_normalization_and_rejection(
         monkeypatch.setattr(app_metrics, "load_config", fail_load_config)
         with pytest.raises(SystemExit) as excinfo:
             app_metrics.appcfg("tokenplace", env)
-        assert "staging only" in str(excinfo.value)
+        assert "unsupported" in str(excinfo.value)
         assert app_metrics.main(["verify-all", "--env", env]) == 2
 
     assert app_metrics.normalize_live_env("env=env=int") == "staging"
     assert app_metrics.normalize_live_env("env=staging") == "staging"
+    assert app_metrics.normalize_live_env("env=prod") == "prod"
+    monkeypatch.setattr(
+        app_metrics,
+        "load_config",
+        lambda: {"applications": {"dspace": {"environments": {"prod": "prod-cfg"}}}},
+    )
+    assert app_metrics.appcfg("dspace", "prod") == "prod-cfg"
 
 
 @pytest.mark.parametrize("app", ["app=", "app=foo=bar", "app=Bad_Name", "-bad"])

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1388,6 +1388,70 @@ data:
     )
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
+        lambda manifest: manifest.replace(
+            "replacement: dspace\n        - action: replace\n          targetLabel: environment",
+            "replacement: other\n        - action: replace\n          targetLabel: environment",
+            1,
+        ),
+        lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
+        lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
+    ],
+)
+def test_dspace_production_requires_exact_metrics_path_and_relabelings(
+    tmp_path: Path, mutation
+) -> None:
+    values = tmp_path / "prod.yaml"
+    values.write_text(
+        (REPO_ROOT / "docs/examples/dspace.values.prod.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    inputs = app_chart.ReleaseInputs(
+        "dspace",
+        "prod",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.0.2",
+        (str(values),),
+        "main-deadbee",
+    )
+    monitor = """kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    - path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: prod
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-prod
+"""
+
+    assert "DSPACE production ServiceMonitor contract mismatch" in (
+        app_chart.validate_rendered_manifest(mutation(monitor), inputs)
+    )
+
+
 def test_dspace_production_allows_legacy_pod_uid_metrics_token() -> None:
     inputs = app_chart.ReleaseInputs(
         "dspace", "prod", "dspace", "dspace", "chart", "3.0.2", (), "main-deadbee"
@@ -6743,6 +6807,41 @@ def test_observability_app_metrics_load_rendered_docs_malformed_is_redacted(
         app_metrics.load_rendered_docs(str(candidate))
     assert "rendered manifests are malformed" in str(excinfo.value)
     assert "credential-looking-render" not in str(excinfo.value)
+
+
+def test_observability_app_metrics_load_rendered_docs_rejects_aliases(tmp_path):
+    candidate = tmp_path / "candidate.yaml"
+    candidate.write_text("first: &value secret\nsecond: *value\n", encoding="utf-8")
+
+    with pytest.raises(app_metrics.Error, match="rendered manifests are malformed"):
+        app_metrics.load_rendered_docs(str(candidate))
+
+
+def test_observability_app_metrics_production_identity_uses_selected_kubeconfig(
+    monkeypatch, tmp_path
+):
+    kubeconfig = str((tmp_path / "prod-kubeconfig").resolve())
+    calls = []
+    monkeypatch.setenv("KUBECONFIG", kubeconfig)
+    monkeypatch.setattr(
+        app_metrics,
+        "run",
+        lambda command: calls.append(command) or (
+            "sugar-prod\n" if command[:3] == ["kubectl", "config", "current-context"] else ""
+        ),
+    )
+
+    app_metrics.assert_production_context()
+
+    assert calls[-1] == [
+        app_metrics.sys.executable,
+        str(app_metrics.ROOT / "scripts" / "cluster_identity.py"),
+        "assert",
+        "--kubeconfig",
+        kubeconfig,
+        "--env",
+        "prod",
+    ]
 
 
 class _AppMetricsFakeTty:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -1425,12 +1425,52 @@ def test_dspace_production_requires_exact_metrics_path_and_relabelings(
         (str(values),),
         "main-deadbee",
     )
-    monitor = """kind: ServiceMonitor
+    monitor = """kind: Deployment
 metadata:
+  name: dspace
+  namespace: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: dspace
+        app.kubernetes.io/name: dspace
+    spec:
+      containers:
+        - name: dspace
+          image: ghcr.io/democratizedspace/dspace:main-deadbee
+          env:
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dspace-prod-metrics-token
+                  key: token
+---
+kind: Service
+metadata:
+  name: dspace
+  namespace: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+spec:
+  selector:
+    app.kubernetes.io/instance: dspace
+    app.kubernetes.io/name: dspace
+---
+kind: ServiceMonitor
+metadata:
+  name: dspace
+  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
 spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
   endpoints:
     - path: /metrics
       interval: 30s
@@ -1453,8 +1493,11 @@ spec:
           replacement: sugarkube-prod
 """
 
+    assert app_chart.validate_rendered_manifest(monitor, inputs) == []
+    mutated = mutation(monitor)
+    assert mutated != monitor
     assert "DSPACE production ServiceMonitor contract mismatch" in (
-        app_chart.validate_rendered_manifest(mutation(monitor), inputs)
+        app_chart.validate_rendered_manifest(mutated, inputs)
     )
 
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -827,7 +827,9 @@ def test_configuration_reconciliation_completes_all_production_gates(
 
     before_pods = [ready("1"), ready("2")]
     after_pods = [ready("3"), ready("4")]
-    state = {"upgraded": False, "description": ""}
+    terminating_pods = [{**ready("2"), "terminating": True}, *after_pods]
+    state = {"upgraded": False, "description": "", "post_upgrade_pod_reads": 0}
+    monkeypatch.setattr(rollback.time, "sleep", lambda _seconds: None)
 
     def status(*_args: object) -> dict[str, object]:
         return {
@@ -842,13 +844,16 @@ def test_configuration_reconciliation_completes_all_production_gates(
         }
 
     monkeypatch.setattr(rollback, "helm_status", status)
-    monkeypatch.setattr(
-        rollback,
-        "pods",
-        lambda *_args, **_kwargs: json.loads(
-            json.dumps(after_pods if state["upgraded"] else before_pods)
-        ),
-    )
+
+    def observed_pods(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        if not state["upgraded"]:
+            observed = before_pods
+        else:
+            state["post_upgrade_pod_reads"] += 1
+            observed = terminating_pods if state["post_upgrade_pod_reads"] == 1 else after_pods
+        return json.loads(json.dumps(observed))
+
+    monkeypatch.setattr(rollback, "pods", observed_pods)
 
     def runner(command: list[str]) -> str:
         commands.append(command)
@@ -913,6 +918,7 @@ def test_configuration_reconciliation_completes_all_production_gates(
         if "observability_app_metrics.py" in " ".join(command) and "verify" in command
     ]
     assert len(metrics_verifications) == 1
+    assert state["post_upgrade_pod_reads"] == 2
 
 
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -763,6 +763,158 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
     assert written["clusterMayHaveChanged"] is True
 
 
+def test_configuration_reconciliation_completes_all_production_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    selected = target("prod", schema_version=2)
+    args.manifest.write_text(manifest._canonical(selected), encoding="utf-8")
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    args.configuration_reconciliation = True
+    args.kubeconfig = str(kubeconfig)
+    args.confirm = f"dspace:prod:{SHA}"
+    image = {
+        "repository": manifest.IMAGE_REF,
+        "tag": selected["imageTag"],
+        "pullPolicy": "Always",
+    }
+    desired = {
+        "replicaCount": 2,
+        "image": image,
+        "metrics": {
+            "enabled": True,
+            "path": "/metrics",
+            "auth": {
+                "existingSecret": "dspace-prod-metrics-token",
+                "secretKey": "token",
+            },
+        },
+        "serviceMonitor": {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        },
+    }
+    live = {"replicaCount": 2, "image": image}
+    stored_proof = [{"check": "helmStoredValues", "passed": True, "details": "safe"}]
+    finalized: dict[str, object] = {}
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+
+    def verify_stored(_approved: object, values: object, _environment: str) -> object:
+        assert values == desired
+        return stored_proof
+
+    def finalize(*_args: object, **kwargs: object) -> dict[str, object]:
+        finalized.update(kwargs)
+        return {"verificationResults": [{"check": "finalized", "passed": True}]}
+
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", verify_stored)
+    monkeypatch.setattr(rollback.release, "finalize", finalize)
+    monkeypatch.setattr(rollback, "verifier_accepts_runtime_arguments", lambda *_args: True)
+
+    def ready(uid: str) -> dict[str, object]:
+        return {
+            **pod(uid),
+            "applicationImage": f"{manifest.IMAGE_REF}:{selected['imageTag']}",
+            "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+        }
+
+    before_pods = [ready("1"), ready("2")]
+    after_pods = [ready("3"), ready("4")]
+    state = {"upgraded": False, "description": ""}
+
+    def status(*_args: object) -> dict[str, object]:
+        return {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 8 if state["upgraded"] else 7,
+            "info": {
+                "status": "deployed",
+                "description": state["description"] if state["upgraded"] else "previous",
+            },
+            "chart": {"metadata": {"name": "dspace", "version": selected["chartVersion"]}},
+        }
+
+    monkeypatch.setattr(rollback, "helm_status", status)
+    monkeypatch.setattr(
+        rollback,
+        "pods",
+        lambda *_args, **_kwargs: json.loads(
+            json.dumps(after_pods if state["upgraded"] else before_pods)
+        ),
+    )
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        if "current-context" in command:
+            return "sugar-prod"
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "f" * 40
+        if command[0] == "helm" and "upgrade" in command:
+            state["description"] = command[command.index("--description") + 1]
+            state["upgraded"] = True
+        elif command[0] == "helm" and "values" in command and "get" in command:
+            return json.dumps(desired if "--all" in command else live)
+        elif command[0] == "helm" and "template" in command:
+            return "live render" if "live-values.json" in " ".join(command) else "target render"
+        elif command[0] == "helm" and "manifest" in command:
+            return "live render"
+        elif command[:2] == [str(verifier), "verify"]:
+            return json.dumps(verifier_result(environment="prod"))
+        elif command[0] == "kubectl" and (
+            "replicasets,deployments" in command or "pods" in command
+        ):
+            return '{"items": []}'
+        return ""
+
+    result = rollback.rollback(args, runner)
+
+    upgrade = next(command for command in commands if "upgrade" in command)
+    assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
+    assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
+    assert f"image.tag={selected['imageTag']}" in upgrade
+    forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
+    assert not any(item in upgrade for item in forbidden)
+    assert DIGEST not in next(item for item in upgrade if item.startswith("image.tag="))
+    assert finalized["helm_stored_values_result"] is stored_proof
+    assert finalized["expected_image_coordinate"] == (
+        f"{manifest.IMAGE_REF}:{selected['imageTag']}"
+    )
+    assert result["state"] == "succeeded"
+    assert result["helm"]["beforeRevision"] == 7
+    assert result["helm"]["afterRevision"] == 8
+    assert result["verification"]["helmStoredValues"] == stored_proof
+    assert result["verification"]["runtime"]["sourceRevision"] == SHA
+    journeys = {item["name"] for item in result["verification"]["journeys"]}
+    assert journeys == {"/", "/chat"}
+    assert result["verification"]["productionMetrics"] == {
+        "secretContract": True,
+        "serviceMonitor": True,
+        "healthyTargets": 2,
+        "requiredFamilies": True,
+        "unauthenticatedStatus": 401,
+    }
+    assert json.loads(evidence.read_text(encoding="utf-8")) == result
+    assert "dspace-prod-metrics-token" not in evidence.read_text(encoding="utf-8")
+    original = evidence.read_bytes()
+    with pytest.raises(rollback.RollbackError, match="overwrite"):
+        rollback.reserve(evidence, {"state": "reserved"})
+    assert evidence.read_bytes() == original
+    assert sum("secret-check" in command for command in commands) == 2
+    metrics_verifications = [
+        command
+        for command in commands
+        if "observability_app_metrics.py" in " ".join(command) and "verify" in command
+    ]
+    assert len(metrics_verifications) == 1
+
+
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -574,6 +574,122 @@ def test_configuration_reconciliation_invalid_render_fails_before_reservation_an
     assert_no_mutation(commands)
 
 
+@pytest.mark.parametrize("kubeconfig", ("", "relative/kubeconfig", "/tmp/one:/tmp/two"))
+def test_configuration_reconciliation_requires_one_absolute_kubeconfig(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kubeconfig: str
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.configuration_reconciliation = True
+    args.kubeconfig = kubeconfig
+
+    with pytest.raises(rollback.RollbackError, match="one explicit absolute kubeconfig"):
+        rollback.rollback(args, lambda command: commands.append(command) or "")
+    assert commands == []
+    assert not evidence.exists()
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    (
+        ("revision", "live Helm revision differs"),
+        ("chart", "live chart coordinate differs"),
+        ("pods", "exactly two Ready"),
+        ("desired", "desired values are structurally invalid"),
+        ("manifest", "live manifest does not match"),
+        ("contract", "desired production metrics contract is invalid"),
+        ("baseline", "approved disabled baseline"),
+        ("drift", "unrelated Helm values drift"),
+        ("image", "live image coordinate differs"),
+    ),
+)
+def test_configuration_reconciliation_preconditions_fail_before_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    message: str,
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.configuration_reconciliation = True
+    args.confirm = f"dspace:prod:{SHA}"
+    image = {
+        "repository": manifest.IMAGE_REF,
+        "tag": "main-abcdef0",
+        "pullPolicy": "Always",
+    }
+    desired: object = {
+        "image": image,
+        "metrics": {"enabled": True},
+        "serviceMonitor": {"enabled": True},
+    }
+    live = {"image": image}
+    if failure == "desired":
+        desired = []
+    elif failure == "baseline":
+        live["metrics"] = {"enabled": True}
+    elif failure == "drift":
+        live["unrelated"] = True
+
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+
+    def verify_stored(*_args: object) -> None:
+        if failure == "contract":
+            raise manifest.ManifestError("sensitive details must be redacted")
+
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", verify_stored)
+    ready = {
+        "ready": True,
+        "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
+        "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+    }
+    observed = [ready, ready]
+    if failure == "pods":
+        observed = [ready]
+    elif failure == "image":
+        observed = [{**ready, "applicationImageID": f"{manifest.IMAGE_REF}@sha256:{'9' * 64}"}] * 2
+    monkeypatch.setattr(rollback, "pods", lambda *_args, **_kwargs: observed)
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "version": 8 if failure == "revision" else 7,
+            "info": {"status": "deployed"},
+            "chart": {
+                "metadata": {
+                    "name": "dspace",
+                    "version": "0.0.0" if failure == "chart" else "3.2.0",
+                }
+            },
+        },
+    )
+    template_calls = 0
+
+    def runner(command: list[str]) -> str:
+        nonlocal template_calls
+        commands.append(command)
+        if "values" in command and "get" in command:
+            return json.dumps(live)
+        if "template" in command:
+            template_calls += 1
+            if template_calls == 1:
+                return "target render"
+            return "different render" if failure == "manifest" else "live render"
+        if "get" in command and "manifest" in command:
+            return "live render"
+        return ""
+
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    with pytest.raises(rollback.RollbackError, match=message):
+        rollback._rollback(args, runner, staged)
+    assert not evidence.exists()
+    assert_no_mutation(commands)
+
+
 @pytest.mark.parametrize("drift", ("context", "identity"))
 def test_configuration_reconciliation_reasserts_trusted_target_after_reservation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
@@ -679,8 +795,22 @@ def test_configuration_reconciliation_reasserts_trusted_target_after_reservation
     assert evidence.read_bytes() == original
 
 
+@pytest.mark.parametrize(
+    ("diagnostic_failure", "state_drift"),
+    (
+        (None, None),
+        ("helm", None),
+        ("pods", None),
+        (None, "helm"),
+        (None, "pods"),
+        (None, "values"),
+    ),
+)
 def test_configuration_reconciliation_reasserts_target_immediately_before_upgrade(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    diagnostic_failure: str | None,
+    state_drift: str | None,
 ) -> None:
     args, commands, evidence, _verifier = pre_reservation_case(
         tmp_path, monkeypatch, environment="prod"
@@ -700,46 +830,56 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
     monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
     monkeypatch.setattr(rollback.release, "verify_helm_stored_values", lambda *_args: None)
-    monkeypatch.setattr(
-        rollback,
-        "helm_status",
-        lambda *_args: {
+    upgrade_attempted = False
+
+    def status(*_args: object) -> dict[str, object]:
+        if upgrade_attempted and diagnostic_failure == "helm":
+            raise RuntimeError("bounded diagnostic failure")
+        return {
             "name": "dspace",
             "namespace": "dspace",
-            "version": 7,
+            "version": 8 if state_drift == "helm" and evidence.exists() else 7,
             "info": {"status": "deployed"},
             "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
-        },
-    )
-    monkeypatch.setattr(
-        rollback,
-        "pods",
-        lambda *_args, **_kwargs: [
+        }
+
+    def observed_pods(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        if upgrade_attempted and diagnostic_failure == "pods":
+            raise RuntimeError("bounded diagnostic failure")
+        result = [
             {
                 "ready": True,
                 "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
                 "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
             }
-        ]
-        * 2,
-    )
+        ] * 2
+        if state_drift == "pods" and evidence.exists():
+            result[0] = {**result[0], "ready": False}
+        return result
+
+    monkeypatch.setattr(rollback, "helm_status", status)
+    monkeypatch.setattr(rollback, "pods", observed_pods)
     template_calls = 0
 
     def runner(command: list[str]) -> str:
-        nonlocal template_calls
+        nonlocal template_calls, upgrade_attempted
         commands.append(command)
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return "f" * 40
         if "current-context" in command:
             return "sugar-prod"
         if "get" in command and "values" in command:
-            return json.dumps({"image": image})
+            values = {"image": image}
+            if state_drift == "values" and evidence.exists():
+                values["unexpected"] = True
+            return json.dumps(values)
         if "template" in command:
             template_calls += 1
             return "target render" if template_calls == 1 else "live render"
         if "get" in command and "manifest" in command:
             return "live render"
         if "upgrade" in command:
+            upgrade_attempted = True
             raise rollback.RollbackError("bounded failure")
         return ""
 
@@ -747,6 +887,13 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
     staged.mkdir()
     with pytest.raises(rollback.RollbackError, match="preserved evidence"):
         rollback._rollback(args, runner, staged)
+
+    written = json.loads(evidence.read_text(encoding="utf-8"))
+    if state_drift:
+        assert_no_mutation(commands)
+        assert written["failedStage"] == "pre-mutation-revalidation"
+        assert written["clusterMayHaveChanged"] is False
+        return
 
     upgrade_index = next(i for i, command in enumerate(commands) if "upgrade" in command)
     secret_index = max(i for i, command in enumerate(commands) if "secret-check" in command)
@@ -758,9 +905,10 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
     )
     assert secret_index < final_context < final_identity < upgrade_index
     assert not any("rollout" in command for command in commands)
-    written = json.loads(evidence.read_text(encoding="utf-8"))
     assert written["failedStage"] == "helm-upgrade"
     assert written["clusterMayHaveChanged"] is True
+    if diagnostic_failure:
+        assert written["diagnostics"][diagnostic_failure] == "unavailable"
 
 
 def test_configuration_reconciliation_completes_all_production_gates(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -503,6 +503,77 @@ def test_confirmation_and_verifier_gates_precede_reservation_and_mutation(
         assert not any("template" in command for command in commands)
 
 
+def test_configuration_reconciliation_invalid_render_fails_before_reservation_and_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.configuration_reconciliation = True
+    args.kubeconfig = str(tmp_path / "kubeconfig")
+    args.confirm = f"dspace:prod:{SHA}"
+    desired = {
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        },
+        "metrics": {"enabled": True},
+        "serviceMonitor": {"enabled": True},
+    }
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: ["bad"])
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", lambda *_args: None)
+    monkeypatch.setattr(
+        rollback,
+        "pods",
+        lambda *_args, **_kwargs: [
+            {
+                "ready": True,
+                "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
+                "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+            },
+            {
+                "ready": True,
+                "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
+                "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "version": 7,
+            "info": {"status": "deployed"},
+            "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+        },
+    )
+
+    template_calls = 0
+
+    def runner(command: list[str]) -> str:
+        nonlocal template_calls
+        commands.append(command)
+        if "values" in command and "get" in command:
+            return json.dumps({"image": desired["image"]})
+        if "template" in command:
+            template_calls += 1
+            return "invalid target render" if template_calls == 1 else "live render"
+        if "get" in command and "manifest" in command:
+            return "live render"
+        return ""
+
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    with pytest.raises(
+        rollback.RollbackError, match="strict application chart render validation failed"
+    ):
+        rollback._rollback(args, runner, staged)
+    assert not evidence.exists()
+    assert_no_mutation(commands)
+
+
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -574,6 +574,195 @@ def test_configuration_reconciliation_invalid_render_fails_before_reservation_an
     assert_no_mutation(commands)
 
 
+@pytest.mark.parametrize("drift", ("context", "identity"))
+def test_configuration_reconciliation_reasserts_trusted_target_after_reservation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drift: str
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.configuration_reconciliation = True
+    args.confirm = f"dspace:prod:{SHA}"
+    desired = {
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        },
+        "metrics": {"enabled": True},
+        "serviceMonitor": {"enabled": True},
+    }
+    live = {"image": desired["image"]}
+    ready_pods = [
+        {
+            "ready": True,
+            "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
+            "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+        }
+    ] * 2
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", lambda *_args: None)
+    helm_reads = []
+    pod_reads = []
+
+    def status(*args: object) -> dict[str, object]:
+        helm_reads.append(args)
+        return {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 7,
+            "info": {"status": "deployed"},
+            "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+        }
+
+    def pod_read(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        pod_reads.append((args, kwargs))
+        return ready_pods
+
+    monkeypatch.setattr(rollback, "helm_status", status)
+    monkeypatch.setattr(rollback, "pods", pod_read)
+    reserved_at = []
+    real_reserve = rollback.reserve
+
+    def reserve(path: Path, record: dict[str, object]) -> None:
+        real_reserve(path, record)
+        reserved_at.append((len(commands), len(helm_reads), len(pod_reads)))
+
+    monkeypatch.setattr(rollback, "reserve", reserve)
+    sentinel = "TOP-SECRET-drift-diagnostic"
+    template_calls = 0
+
+    def runner(command: list[str]) -> str:
+        nonlocal template_calls
+        commands.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "f" * 40
+        if "current-context" in command:
+            if drift == "context" and reserved_at:
+                return "sugar-staging"
+            return "sugar-prod"
+        if any("cluster_identity.py" in part for part in command):
+            if drift == "identity" and reserved_at:
+                raise rollback.RollbackError(sentinel)
+            return ""
+        if "get" in command and "values" in command:
+            return json.dumps(live)
+        if "template" in command:
+            template_calls += 1
+            return "target render" if template_calls == 1 else "live render"
+        if "get" in command and "manifest" in command:
+            return "live render"
+        return ""
+
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+        rollback._rollback(args, runner, staged)
+
+    command_count, helm_count, pod_count = reserved_at[0]
+    after_reservation = commands[command_count:]
+    assert "current-context" in after_reservation[0]
+    assert not any("secret-check" in command for command in after_reservation)
+    assert_no_mutation(after_reservation)
+    assert len(helm_reads) == helm_count
+    assert len(pod_reads) == pod_count
+    written = json.loads(evidence.read_text(encoding="utf-8"))
+    assert written["state"] == "failed"
+    assert written["failedStage"] == "pre-mutation-revalidation"
+    assert written["clusterMayHaveChanged"] is False
+    assert written["diagnostics"] == {}
+    assert sentinel not in evidence.read_text(encoding="utf-8")
+    original = evidence.read_bytes()
+    with pytest.raises(rollback.RollbackError, match="overwrite"):
+        rollback.reserve(evidence, {"state": "reserved"})
+    assert evidence.read_bytes() == original
+
+
+def test_configuration_reconciliation_reasserts_target_immediately_before_upgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.configuration_reconciliation = True
+    args.confirm = f"dspace:prod:{SHA}"
+    image = {
+        "repository": manifest.IMAGE_REF,
+        "tag": "main-abcdef0",
+        "pullPolicy": "Always",
+    }
+    desired = {
+        "image": image,
+        "metrics": {"enabled": True},
+        "serviceMonitor": {"enabled": True},
+    }
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", lambda *_args: None)
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 7,
+            "info": {"status": "deployed"},
+            "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
+        },
+    )
+    monkeypatch.setattr(
+        rollback,
+        "pods",
+        lambda *_args, **_kwargs: [
+            {
+                "ready": True,
+                "applicationImage": f"{manifest.IMAGE_REF}:main-abcdef0",
+                "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+            }
+        ]
+        * 2,
+    )
+    template_calls = 0
+
+    def runner(command: list[str]) -> str:
+        nonlocal template_calls
+        commands.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "f" * 40
+        if "current-context" in command:
+            return "sugar-prod"
+        if "get" in command and "values" in command:
+            return json.dumps({"image": image})
+        if "template" in command:
+            template_calls += 1
+            return "target render" if template_calls == 1 else "live render"
+        if "get" in command and "manifest" in command:
+            return "live render"
+        if "upgrade" in command:
+            raise rollback.RollbackError("bounded failure")
+        return ""
+
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+        rollback._rollback(args, runner, staged)
+
+    upgrade_index = next(i for i, command in enumerate(commands) if "upgrade" in command)
+    secret_index = max(i for i, command in enumerate(commands) if "secret-check" in command)
+    final_context = max(i for i, command in enumerate(commands) if "current-context" in command)
+    final_identity = max(
+        i
+        for i, command in enumerate(commands)
+        if any("cluster_identity.py" in part for part in command)
+    )
+    assert secret_index < final_context < final_identity < upgrade_index
+    assert not any("rollout" in command for command in commands)
+    written = json.loads(evidence.read_text(encoding="utf-8"))
+    assert written["failedStage"] == "helm-upgrade"
+    assert written["clusterMayHaveChanged"] is True
+
+
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -683,7 +683,7 @@ def production_stored_values() -> dict[str, object]:
         },
         "ingress": {"tls": {"enabled": False, "secretName": ""}},
         "serviceAccount": {"automountServiceAccountToken": False},
-        "secret": {"enabled": False, "name": "", "data": {}},
+        "secret": {"enabled": False, "stringData": {}},
     }
 
 
@@ -750,6 +750,38 @@ def test_helm_stored_values_reject_inline_credential_redacted(
         inline = {shape: sentinel}
     stored = production_stored_values()
     stored.update(inline)
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+    assert sentinel not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        {"enabled": True, "stringData": {}},
+        {
+            "enabled": False,
+            "stringData": {"opaque": "".join(("credential", "-sentinel"))},
+        },
+        {"enabled": False, "data": {"opaque": "".join(("credential", "-sentinel"))}},
+    ],
+)
+def test_helm_stored_values_reject_enabled_or_populated_secret_redacted(
+    secret: dict[str, object],
+) -> None:
+    sentinel = "".join(("credential", "-sentinel"))
+    stored = production_stored_values()
+    stored["secret"] = secret
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+    assert sentinel not in str(raised.value)
+
+
+@pytest.mark.parametrize("name", ["METRICS_TOKEN", "DSPACE_API_KEY"])
+def test_helm_stored_values_reject_credential_environment_plain_value(name: str) -> None:
+    sentinel = "".join(("credential", "-sentinel"))
+    stored = production_stored_values()
+    stored["env"] = [{"name": name, "value": sentinel}]
     with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
         manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
     assert sentinel not in str(raised.value)

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -661,6 +661,100 @@ def test_helm_stored_values_reject_image_mismatch(field: str, wrong: str) -> Non
         manifest.verify_helm_stored_values(value, {"image": image}, "prod")
 
 
+def production_stored_values() -> dict[str, object]:
+    value = split_candidate("prod")
+    return {
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": value["imageTag"],
+            "pullPolicy": "Always",
+        },
+        "metrics": {
+            "enabled": True,
+            "path": "/metrics",
+            "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+        },
+        "serviceMonitor": {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        },
+        "ingress": {"tls": {"enabled": False, "secretName": ""}},
+        "serviceAccount": {"automountServiceAccountToken": False},
+        "secret": {"enabled": False, "name": "", "data": {}},
+    }
+
+
+def test_helm_stored_values_accept_chart_defaults_and_safe_references() -> None:
+    value = split_candidate("prod")
+    stored = production_stored_values()
+    stored["env"] = [
+        {
+            "name": "METRICS_TOKEN",
+            "valueFrom": {
+                "secretKeyRef": {"name": "dspace-prod-metrics-token", "key": "token"}
+            },
+        }
+    ]
+    assert manifest.verify_helm_stored_values(value, stored, "prod")["passed"] is True
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "wrong"),
+    [
+        ("metrics", "path", None),
+        ("metrics", "path", "/wrong"),
+        ("metrics", "auth", {"existingSecret": "wrong", "secretKey": "token"}),
+        (
+            "metrics",
+            "auth",
+            {"existingSecret": "dspace-prod-metrics-token", "secretKey": "wrong"},
+        ),
+        ("serviceMonitor", "enabled", False),
+        ("serviceMonitor", "interval", "60s"),
+        ("serviceMonitor", "scrapeTimeout", "30s"),
+        ("serviceMonitor", "additionalLabels", {}),
+        ("serviceMonitor", "cluster", "wrong"),
+    ],
+)
+def test_helm_stored_values_reject_weakened_production_contract(
+    section: str, field: str, wrong: object
+) -> None:
+    stored = production_stored_values()
+    mapping = stored[section]
+    assert isinstance(mapping, dict)
+    if wrong is None:
+        mapping.pop(field)
+    else:
+        mapping[field] = wrong
+    with pytest.raises(manifest.ManifestError, match="approved contract"):
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+
+
+@pytest.mark.parametrize(
+    "shape",
+    ["".join(("pass", "word")), "secret", "environment"],
+)
+def test_helm_stored_values_reject_inline_credential_redacted(
+    shape: str,
+) -> None:
+    sentinel = "".join(("credential", "-sentinel"))
+    inline: dict[str, object]
+    if shape == "environment":
+        environment_entry = {"name": "METRICS_TOKEN"}
+        environment_entry["".join(("val", "ue"))] = sentinel
+        inline = {"env": [environment_entry]}
+    else:
+        inline = {shape: sentinel}
+    stored = production_stored_values()
+    stored.update(inline)
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+    assert sentinel not in str(raised.value)
+
+
 @pytest.mark.parametrize(
     "leak",
     [


### PR DESCRIPTION
### Motivation
- Allow the repository to represent and verify authenticated DSPACE /metrics in production using the currently deployed immutable coordinates while failing closed on any unsafe or staging-only leakage. 
- Replace the prior blanket rejection of any production ServiceMonitor render with strict, environment-aware validation that enforces the exact production metrics contract. 
- Provide a guarded operator flow for credential lifecycle and a values-only, upgrade-only reconciliation path that preserves immutable provenance and performs bounded post-rollout verification.

### Description
- Added the exact production values example `docs/examples/dspace.values.prod.yaml` that declares `metrics.enabled: true`, `metrics.auth.existingSecret: dspace-prod-metrics-token`, `metrics.auth.secretKey: token`, `serviceMonitor.enabled: true`, `serviceMonitor.interval: 30s`, `serviceMonitor.scrapeTimeout: 10s`, `serviceMonitor.additionalLabels.release: kube-prometheus-stack`, and `serviceMonitor.cluster: sugarkube-prod` (no Secret/credential value committed). 
- Replaced the blanket production rejection with strict rendered-manifest checks in `scripts/app_chart.py` to require the authenticated ServiceMonitor, the exact secret/key reference, `release: kube-prometheus-stack`, `sugarkube-prod` relabeling, no staging-only scalars/leaks, and to permit the chart-3.0.2 pod-UID fallback only when metrics are disabled. 
- Reworked stored-values verification in `scripts/dspace_release_manifest.py` to require the exact production metrics + ServiceMonitor contract (image coordinates still verified unchanged) and to continue forbidding staging references or inline credentials without recording secret material. 
- Extended `scripts/observability_app_metrics.py` and `platform/observability/app-metrics.json` to support production DSPACE verification (explicit `sugar-prod`/kubeconfig checks, hidden-TTY secret install, secret-check that never returns values, ServiceMonitor discovery label enforcement, two healthy Prometheus targets, required metric families, and public unauthenticated 401 check); added defensive context/assertions and refused credential-bearing env/xtrace. 
- Implemented a guarded values-only production reconciliation path by extending `scripts/dspace_manifest_rollback.py` and the `justfile` with `dspace-prod-metrics-reconcile`; the path: verify finalized evidence provenance, check live chart/image/pods match, reserve fresh evidence, validate only the approved `metrics`/`serviceMonitor` delta, perform an upgrade-only Helm invocation, and run full runtime + observability verification without `--reuse-values`, auto-rollback, or promotions. 
- Updated documentation (`docs/apps/dspace.md`, `docs/observability-operations.md`) and tests to reflect the new production contract and guarded lifecycle, and added focused test fixtures and stubs to exercise the new behavior. 
- No image/chart coordinates, pinned version files, or secret values were changed or committed; commit message `Support authenticated production DSPACE metrics` records the repo change.

### Testing
- `python3 scripts/observability_app_metrics.py validate` — passed and reported `Application metrics inventory is valid.`. 
- `pytest -q tests/test_dspace_runtime_values.py tests/test_release_manifest.py` — passed (updated runtime/values tests exercised the new production contract). 
- `pytest -q tests/test_generic_app_just_recipes.py` (focused and full runs during development) — focused dspace/observability cases exercised and fixed; full run completed successfully (tests passed after iterative fixes; final targeted runs passed). 
- `pytest -q tests/test_observability_helm.py` — passed for the observability Helm checks used by the verifier. 
- Values-only preflight dry-run: `python3 scripts/app_chart.py preflight ... --values docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml` — structural render preflight was exercised against local stubs and the repository-side checks; an exact live `helm` digest-qualified render could not be executed in this environment because `helm` is not installed (the code guards this). 
- Lint/docs checks: `git diff --check`, `pyspelling -c .spellcheck.yaml`, and `linkchecker --no-warnings README.md docs/` were run and passed; `pre-commit run --all-files` initially flagged repo-wide baseline hooks outside the scope and produced auto-fixes which were normalized during iteration (repository-wide style findings were preserved as baseline noise and not weakened). 

All changes were kept narrowly scoped to values-only production metrics support, verification, credential lifecycle, reconciliation helper, tests, and operator documentation as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7912e1b07c832f9925c08548c1eb85)