### PR TITLE
Add fail-closed support for authenticated DSPACE production metrics (values-only contract)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -354,7 +354,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release is Helm revision 28 from the immutable DSPACE `3.1.0` staging image `main-018687f`, with finalized evidence recorded at `deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json`; operators can use that final record as the promotion and reconciliation proof instead of creating a replacement candidate/evidence path for this deployment. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production application `3.0.1` remains pinned to chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; the overlay enables authenticated metrics using the externally managed `dspace-prod-metrics-token` Secret. No application or chart promotion is involved, and merging these repository values deploys nothing.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
@@ -626,12 +626,32 @@ just dspace-oci-promote-prod tag="$APP_TAG" \
 
 ## Verify production
 
+Run production operations from `sugarkube3` with the externally managed tunnel already listening on
+`127.0.0.1:16443`. Export the explicit production kubeconfig; do **not** run
+`just kubeconfig-env env=prod` on `sugarkube3`:
+
+```bash
+export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+kubectl config use-context sugar-prod
+just observability-app-metrics-secret-install app=dspace env=prod
+just observability-app-metrics-secret-check app=dspace env=prod
+```
+
+Install or rotate the credential before the guarded values-only reconciliation. Supply the genuine
+existing finalized production evidence as immutable provenance, an executable runtime smoke runner,
+and a fresh, nonexisting evidence destination. Discover the current and resulting Helm revisions at
+run time; never hard-code revision 9, use `--reuse-values`, or substitute a raw `helm upgrade` or
+`helm rollback`. A post-mutation failure requires review of the reserved evidence and a deliberate
+reconciliation decision, not an immediate retry or automatic rollback.
+
 ```bash
 just app-status app=dspace env=prod
 ```
 
 ```bash
 just app-verify app=dspace env=prod
+just observability-app-metrics-verify app=dspace env=prod
+just observability-dashboard-verify env=prod
 ```
 
 Print the generated curl commands without executing them when you need a manual fallback:
@@ -641,6 +661,11 @@ just app-verify app=dspace env=prod print_only=1
 ```
 
 The runtime config check is a required production routing gate before opening `/chat`; browser Network should show production DSPACE calling production token.place. The immutable DSPACE image remains environment-neutral, and this production overlay selects the production token.place origin without rebuilding the image. If `/chat` fails after `/config.json` is correct, capture the browser CORS error plus the token.place response headers and escalate to the token.place operator; do not change DSPACE values to work around token.place CORS policy.
+
+After reconciliation, repeat the bounded DSPACE runtime and `/chat` checks, the production
+observability verification, the dashboard API verification, and a manual dashboard inspection.
+DSPACE HTTP, runtime, and feature panels should populate. Production release-integrity, blackbox,
+token.place, and alerting panels may remain `NO DATA` until those separate integrations are deployed.
 
 ```bash
 curl -fsS https://democratized.space/config.json \

--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -12,3 +12,17 @@ env:
     value: https://token.place
   - name: DSPACE_TOKEN_PLACE_CHAT_MODEL
     value: llama-3.1-8b-instruct
+
+metrics:
+  enabled: true
+  auth:
+    existingSecret: dspace-prod-metrics-token
+    secretKey: token
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  cluster: sugarkube-prod

--- a/docs/observability-operations.md
+++ b/docs/observability-operations.md
@@ -739,9 +739,22 @@ expected unauthenticated public `401` response:
 just observability-app-metrics-verify app=tokenplace env=staging
 ```
 
-`just observability-verify env=staging` also runs every configured application
-metrics verifier after the existing DSPACE checks. Production application metrics
-verification is intentionally rejected until production observability is codified.
-Merging this repository support does not deploy any application, create any
+`just observability-verify env=staging` also runs every configured staging application
+metrics verifier after the existing DSPACE checks. DSPACE production application `3.0.1` and chart
+`3.0.2` use the production inventory contract with exactly two healthy targets and can be checked
+with explicit production access:
+
+```bash
+export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+kubectl config use-context sugar-prod
+just observability-app-metrics-secret-install app=dspace env=prod
+just observability-app-metrics-secret-check app=dspace env=prod
+just observability-app-metrics-verify app=dspace env=prod
+```
+
+Run those commands from `sugarkube3` through the externally managed `127.0.0.1:16443` tunnel; do not
+use `just kubeconfig-env env=prod` there. Credential setup precedes the guarded values-only
+reconciliation and does not promote the application or chart. Merging this repository support does
+not deploy any application, create any
 Secret, dashboard, alert rule, schedulability check, shared-state check, or live
 drill.

--- a/justfile
+++ b/justfile
@@ -3528,15 +3528,15 @@ observability-watchdog-secret-check env='':
 observability-watchdog-verify env='':
     @scripts/observability_helm.sh watchdog-verify '{{ env }}'
 
-# Interactively install or rotate a staging application's metrics bearer token (hidden input).
+# Interactively install or rotate a configured application's metrics bearer token (hidden input).
 observability-app-metrics-secret-install app env='staging':
     @python3 scripts/observability_app_metrics.py secret-install --app '{{ app }}' --env '{{ env }}'
 
-# Check a staging application's metrics Secret/key contract without reading its value.
+# Check an application's metrics Secret/key contract without reading its value.
 observability-app-metrics-secret-check app env='staging':
     @python3 scripts/observability_app_metrics.py secret-check --app '{{ app }}' --env '{{ env }}'
 
-# Verify a staging application's authenticated Prometheus metrics contract.
+# Verify an application's authenticated Prometheus metrics contract.
 observability-app-metrics-verify app env='staging':
     @python3 scripts/observability_app_metrics.py verify --app '{{ app }}' --env '{{ env }}'
 

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -188,6 +188,112 @@
           }
         }
       }
+    },
+    "dspace": {
+      "environments": {
+        "prod": {
+          "namespace": "dspace",
+          "serviceMonitorName": "dspace",
+          "expectedTargetCount": 2,
+          "secret": {
+            "name": "dspace-prod-metrics-token",
+            "key": "token"
+          },
+          "serviceMonitor": {
+            "selectorMatchLabels": {
+              "app.kubernetes.io/instance": "dspace",
+              "app.kubernetes.io/name": "dspace"
+            },
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "authorization": {
+              "type": "Bearer",
+              "credentials": {
+                "name": "dspace-prod-metrics-token",
+                "key": "token"
+              }
+            },
+            "relabelings": [
+              {
+                "action": "replace",
+                "targetLabel": "app",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "environment",
+                "replacement": "prod"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "release",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "cluster",
+                "replacement": "sugarkube-prod"
+              }
+            ]
+          },
+          "targetLabels": {
+            "app": "dspace",
+            "environment": "prod",
+            "release": "dspace",
+            "cluster": "sugarkube-prod",
+            "namespace": "dspace"
+          },
+          "publicMetrics": {
+            "url": "https://democratized.space/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "dspace_http_requests_total",
+            "dspace_http_request_duration_seconds_bucket",
+            "dspace_dchat_requests_total",
+            "dspace_dependency_requests_total",
+            "dspace_instrumentation_up",
+            "dspace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "app": [
+              "dspace"
+            ],
+            "environment": [
+              "prod"
+            ],
+            "release": [
+              "dspace"
+            ],
+            "cluster": [
+              "sugarkube-prod"
+            ]
+          },
+          "derivedApplicationLabels": {},
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "bearer",
+            "cookie",
+            "email",
+            "hostname",
+            "jwt",
+            "node",
+            "passwd",
+            "passcode",
+            "remote_addr",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user"
+          ]
+        }
+      }
     }
   }
 }

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -184,7 +184,7 @@ def dspace_production_metrics_token_is_unsafe(
     """Return whether an associated resource has a non-legacy METRICS_TOKEN form."""
     if not contains_exact_scalar(document, {"METRICS_TOKEN"}):
         return False
-    if metrics_enabled or scalar(document.get("kind")) not in {
+    if scalar(document.get("kind")) not in {
         "Deployment", "StatefulSet", "DaemonSet"
     }:
         return True
@@ -201,10 +201,22 @@ def dspace_production_metrics_token_is_unsafe(
             if not isinstance(entry, dict) or scalar(entry.get("name")) != "METRICS_TOKEN":
                 continue
             value_from = entry.get("valueFrom")
+            secret_ref = value_from.get("secretKeyRef") if isinstance(value_from, dict) else None
             field_ref = value_from.get("fieldRef") if isinstance(value_from, dict) else None
+            if (
+                metrics_enabled
+                and set(entry) == {"name", "valueFrom"}
+                and isinstance(value_from, dict)
+                and set(value_from) == {"secretKeyRef"}
+                and isinstance(secret_ref, dict)
+                and set(secret_ref) == {"name", "key"}
+                and secret_ref == {"name": "dspace-prod-metrics-token", "key": "token"}
+            ):
+                safe_entries.add(id(entry))
             # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
             if (
-                set(entry) == {"name", "valueFrom"}
+                not metrics_enabled
+                and set(entry) == {"name", "valueFrom"}
                 and isinstance(value_from, dict) and set(value_from) == {"fieldRef"}
                 and isinstance(field_ref, dict) and set(field_ref) == {"fieldPath"}
                 and field_ref.get("fieldPath") == "metadata.uid"
@@ -327,25 +339,45 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                 errors.append(
                     "DSPACE ServiceMonitor bearerTokenSecret name and key must be nonempty"
                 )
-        production_leaks = {"dspace-staging-metrics-token", "sugarkube-int"}
+        production_leaks = {
+            "dspace-staging-metrics-token", "sugarkube-int",
+            "staging.democratized.space", "staging",
+        }
         metrics_enabled = (
             resolved_values_scalar(inputs.values, ("metrics", "enabled")).lower() == "true"
         )
-        if inputs.env == "prod" and (
-            service_monitors
-            or any(
-                isinstance(doc, dict)
-                and release_associated(doc, inputs.release, allow_name=False)
-                and (
-                    contains_exact_scalar(doc, production_leaks)
-                    or dspace_production_metrics_token_is_unsafe(
-                        doc, inputs, metrics_enabled=metrics_enabled
-                    )
-                )
-                for doc in documents
-            )
+        if inputs.env == "prod" and any(
+            isinstance(doc, dict)
+            and release_associated(doc, inputs.release, allow_name=False)
+            and (contains_exact_scalar(doc, production_leaks)
+                 or dspace_production_metrics_token_is_unsafe(
+                     doc, inputs, metrics_enabled=metrics_enabled))
+            for doc in documents
         ):
             errors.append("DSPACE production rendered staging-only metrics configuration")
+        if inputs.env == "prod" and service_monitors and not metrics_enabled:
+            errors.append("DSPACE production rendered staging-only metrics configuration")
+        if inputs.env == "prod" and metrics_enabled:
+            if len(service_monitors) != 1:
+                errors.append("DSPACE production must render exactly one ServiceMonitor")
+            for monitor in service_monitors:
+                metadata = monitor.get("metadata") if isinstance(monitor.get("metadata"), dict) else {}
+                labels = metadata.get("labels") if isinstance(metadata.get("labels"), dict) else {}
+                spec = monitor.get("spec") if isinstance(monitor.get("spec"), dict) else {}
+                endpoints = spec.get("endpoints")
+                endpoint = endpoints[0] if isinstance(endpoints, list) and len(endpoints) == 1 else None
+                auth = endpoint.get("bearerTokenSecret") if isinstance(endpoint, dict) else None
+                relabelings = endpoint.get("relabelings") if isinstance(endpoint, dict) else None
+                cluster_relabels = [item for item in relabelings if isinstance(item, dict)
+                                    and item.get("targetLabel") == "cluster"] if isinstance(relabelings, list) else []
+                if labels.get("release") != "kube-prometheus-stack":
+                    errors.append("DSPACE production ServiceMonitor discovery label mismatch")
+                if not isinstance(endpoint, dict) or endpoint.get("interval") != "30s" or endpoint.get("scrapeTimeout") != "10s":
+                    errors.append("DSPACE production ServiceMonitor timing contract mismatch")
+                if auth != {"name": "dspace-prod-metrics-token", "key": "token"}:
+                    errors.append("DSPACE production ServiceMonitor authentication contract mismatch")
+                if len(cluster_relabels) != 1 or cluster_relabels[0].get("replacement") != "sugarkube-prod":
+                    errors.append("DSPACE production ServiceMonitor cluster relabeling mismatch")
     return errors
 
 
@@ -513,6 +545,22 @@ def validate_dspace_values(manifest: str, inputs: ReleaseInputs) -> list[str]:
         for document in safe_yaml_documents(manifest)
     )
     errors: list[str] = []
+    if inputs.env == "prod":
+        expected = {
+            ("metrics", "enabled"): "true",
+            ("metrics", "auth", "existingSecret"): "dspace-prod-metrics-token",
+            ("metrics", "auth", "secretKey"): "token",
+            ("serviceMonitor", "enabled"): "true",
+            ("serviceMonitor", "interval"): "30s",
+            ("serviceMonitor", "scrapeTimeout"): "10s",
+            ("serviceMonitor", "additionalLabels", "release"): "kube-prometheus-stack",
+            ("serviceMonitor", "cluster"): "sugarkube-prod",
+        }
+        if any(
+            resolved_values_scalar(inputs.values, path).lower() != wanted.lower()
+            for path, wanted in expected.items()
+        ):
+            errors.append("DSPACE production values do not match the authenticated metrics contract")
     if rendered_monitor and not metrics_enabled:
         errors.append("DSPACE ServiceMonitor rendered while metrics.enabled is not true")
     if rendered_monitor and (not secret or not secret_key):

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -922,16 +922,27 @@ def verify_helm_stored_values(
         raise ManifestError("Helm stored image values do not match approved coordinates")
 
     if environment == "prod":
-        metrics = stored_values.get("metrics", {})
-        service_monitor = stored_values.get("serviceMonitor", {})
+        metrics = stored_values.get("metrics")
+        service_monitor = stored_values.get("serviceMonitor")
+        expected_metrics = {
+            "enabled": True,
+            "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+        }
+        expected_monitor = {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        }
         if (
-            not isinstance(metrics, dict)
-            or not isinstance(service_monitor, dict)
-            or metrics.get("enabled") is True
-            or service_monitor.get("enabled") is True
+            metrics != expected_metrics
+            or service_monitor != expected_monitor
             or contains_staging_reference(stored_values)
         ):
-            raise ManifestError("Helm stored production values contain staging-only settings")
+            raise ManifestError(
+                "Helm stored production metrics values do not match the approved contract"
+            )
     return {
         "check": "helmStoredValues",
         "passed": True,

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -212,11 +212,9 @@ def validate_inventory(doc):
         environments = appdoc["environments"]
         if not isinstance(environments, dict) or not environments:
             fail(f"application {app}.environments must be a nonempty object")
-        if set(environments) != {"staging"}:
-            fail("only staging app metrics verification is supported")
         for env, cfg in environments.items():
-            if env != "staging":
-                fail("only staging app metrics verification is supported")
+            if env not in {"staging", "prod"}:
+                fail("app metrics environment is unsupported")
             expect_keys(
                 cfg,
                 {
@@ -366,8 +364,8 @@ def normalize_live_env(env: str) -> str:
         value = value[4:].strip()
     if value == "int":
         value = "staging"
-    if value != "staging":
-        fail("application metrics live operations support staging only")
+    if value not in {"staging", "prod"}:
+        fail("application metrics live environment is unsupported")
     return value
 
 
@@ -406,10 +404,18 @@ def kjson(args):
     return doc
 
 
-def assert_context():
+def assert_context(env="staging"):
+    expected = "sugar-prod" if env == "prod" else "sugar-staging"
+    if env == "prod":
+        kubeconfig = os.environ.get("KUBECONFIG", "")
+        if not kubeconfig or not os.path.isabs(kubeconfig):
+            fail("production requires an explicit absolute KUBECONFIG", 3)
     ctx = run(["kubectl", "config", "current-context"]).strip()
-    if ctx != "sugar-staging":
-        fail(f"context mismatch: expected sugar-staging, got {ctx or '<none>'}", 3)
+    if ctx != expected:
+        fail(f"context mismatch: expected {expected}, got {ctx or '<none>'}", 3)
+    if env == "prod":
+        run([sys.executable, str(ROOT / "scripts/cluster_identity.py"), "assert",
+             "--kubeconfig", os.environ["KUBECONFIG"], "--env", "prod"])
 
 
 def appcfg(app, env):
@@ -448,11 +454,14 @@ def check_secret(cfg):
 
 
 def install_secret(cfg):
+    if "xtrace" in os.environ.get("SHELLOPTS", "").split(":"):
+        fail("shell xtrace must be disabled before credential installation")
     for bad in (
         "TOKEN",
         "METRICS_TOKEN",
         "TOKENPLACE_METRICS_TOKEN",
         "SUGARKUBE_APP_METRICS_TOKEN",
+        "DSPACE_METRICS_TOKEN",
     ):
         if bad in __import__("os").environ:
             fail("credential environment variables are refused")
@@ -700,7 +709,7 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                 series_name = sample_labels.get("__name__") if isinstance(sample_labels, dict) else None
                 if not isinstance(series_name, str) or not PROM_METRIC.fullmatch(series_name):
                     fail("Prometheus query sample is structurally invalid (details redacted)", 1)
-                if metric_family_from_series(series_name) == metric:
+                if series_name == metric or metric_family_from_series(series_name) == metric:
                     found.add(metric)
     return found
 
@@ -708,7 +717,7 @@ def verify(app, env):
     app = normalize_application_argument(app)
     env = normalize_live_env(env)
     cfg = appcfg(app, env)
-    assert_context()
+    assert_context(env)
     check_secret(cfg)
     derived_values = derive_build_labels_live(cfg)
     sm = kjson(
@@ -734,6 +743,9 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     authorization = ep.get("authorization")
     auth = authorization.get("credentials") if isinstance(authorization, dict) else None
+    if auth is None and isinstance(ep.get("bearerTokenSecret"), dict):
+        auth = ep["bearerTokenSecret"]
+        authorization = {"type": "Bearer"}
     selector = spec.get("selector")
     if not isinstance(authorization, dict) or not isinstance(auth, dict) or not isinstance(selector, dict):
         fail("ServiceMonitor response is structurally invalid", 1)
@@ -891,6 +903,9 @@ def validate_render(app: str, env: str, input_path: str, release_namespace: str 
         fail("rendered ServiceMonitor endpoint is structurally invalid")
     auth = ep.get("authorization")
     creds = auth.get("credentials") if isinstance(auth, dict) else None
+    if creds is None and isinstance(ep.get("bearerTokenSecret"), dict):
+        creds = ep["bearerTokenSecret"]
+        auth = {"type": "Bearer"}
     if not isinstance(auth, dict) or not isinstance(creds, dict):
         fail("rendered ServiceMonitor authorization is structurally invalid")
     if (ep.get("path") != cfg["serviceMonitor"]["path"] or ep.get("interval") != cfg["serviceMonitor"]["interval"] or ep.get("scrapeTimeout") != cfg["serviceMonitor"]["scrapeTimeout"] or auth.get("type") != cfg["serviceMonitor"]["authorization"]["type"] or creds.get("name") != cfg["secret"]["name"] or creds.get("key") != cfg["secret"]["key"] or ep.get("relabelings") != cfg["serviceMonitor"]["relabelings"]):
@@ -925,15 +940,16 @@ def main(argv=None):
         if a.mode == "verify-all":
             env = normalize_live_env(a.env)
             inv = load_config()
-            for app in inv["applications"]:
-                verify(app, env)
+            for app, app_doc in inv["applications"].items():
+                if env in app_doc["environments"]:
+                    verify(app, env)
             return 0
         if not a.app:
             fail("--app is required")
         app = normalize_application_argument(a.app)
         env = normalize_live_env(a.env)
         cfg = appcfg(app, env)
-        assert_context()
+        assert_context(env)
         if a.mode == "secret-check":
             check_secret(cfg)
         elif a.mode == "secret-install":

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -168,11 +168,17 @@ def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> 
     assert "cluster: sugarkube-int" in text
 
 
-def test_dspace_prod_values_do_not_enable_metrics_or_servicemonitor() -> None:
+def test_dspace_prod_values_enable_exact_authenticated_metrics_contract() -> None:
     text = OVERLAYS["prod"].read_text(encoding="utf-8")
 
-    assert "metrics:" not in text
-    assert "serviceMonitor:" not in text
+    assert "metrics:\n  enabled: true" in text
+    assert "existingSecret: dspace-prod-metrics-token" in text
+    assert "secretKey: token" in text
+    assert "serviceMonitor:\n  enabled: true" in text
+    assert "interval: 30s" in text
+    assert "scrapeTimeout: 10s" in text
+    assert "release: kube-prometheus-stack" in text
+    assert "cluster: sugarkube-prod" in text
     assert "dspace-staging-metrics-token" not in text
 
 
@@ -182,4 +188,7 @@ def test_dspace_fixtures_do_not_contain_real_credentials() -> None:
         assert (
             "dspace-staging-metrics-token" not in text or path.name == "dspace.values.staging.yaml"
         )
-        assert "secretKey: token" not in text or path.name == "dspace.values.staging.yaml"
+        assert "secretKey: token" not in text or path.name in {
+            "dspace.values.staging.yaml",
+            "dspace.values.prod.yaml",
+        }

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -208,10 +208,16 @@ if [[ "$*" == *"get values"* ]]; then
     echo 'Error: Kubernetes cluster unreachable for context sugar-staging' >&2
     exit 1
   fi
-  printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":{{"enabled":false}},"serviceMonitor":{{"enabled":false}},"ingress":{{"host":"%s"}}}}\n' \
+  metrics='{{"enabled":false}}'; monitor='{{"enabled":false}}'
+  if [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then
+    metrics='{{"enabled":true,"auth":{{"existingSecret":"dspace-prod-metrics-token","secretKey":"token"}}}}'
+    monitor='{{"enabled":true,"interval":"30s","scrapeTimeout":"10s","additionalLabels":{{"release":"kube-prometheus-stack"}},"cluster":"sugarkube-prod"}}'
+  fi
+  printf '{{"image":{{"repository":"%s","tag":"%s","pullPolicy":"%s"}},"metrics":%s,"serviceMonitor":%s,"ingress":{{"host":"%s"}}}}\n' \
     "${{SUGARKUBE_STUB_HELM_REPOSITORY:-ghcr.io/democratizedspace/dspace}}" \
     "${{SUGARKUBE_STUB_HELM_TAG:-main-abcdef0}}" \
     "${{SUGARKUBE_STUB_HELM_PULL_POLICY:-Always}}" \
+    "${{metrics}}" "${{monitor}}" \
     "${{SUGARKUBE_STUB_HELM_HOST:-example.test}}"
   exit 0
 fi
@@ -308,6 +314,7 @@ spec:
     [[ "$*" != *danielsmith.values.prod.yaml* ]] || host=danielsmith.io
     [[ "$*" != *jobbot3000.values.staging.yaml* ]] || host=staging.jobbot3000.tech
     [[ "$*" != *jobbot3000.values.prod.yaml* ]] || host=jobbot3000.example.test
+    deploy_env=staging; [[ "$*" != *dspace.values.prod.yaml* ]] || deploy_env=prod
     cat <<YAML
 apiVersion: apps/v1
 kind: Deployment
@@ -329,7 +336,7 @@ spec:
             - name: TOKENPLACE_CHART_VERSION
               value: "0.1.4"
             - name: TOKENPLACE_DEPLOY_ENV
-              value: staging
+              value: ${{deploy_env}}
 ---
 apiVersion: v1
 kind: Service
@@ -404,6 +411,38 @@ spec:
       bearerTokenSecret:
         name: dspace-staging-metrics-token
         key: token
+YAML
+    fi
+    if [ "${{app}}" = dspace ] && [[ "$*" == *dspace.values.prod.yaml* ]]; then
+      cat <<'YAML'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dspace
+  labels:
+    app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames: [dspace]
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - {{action: replace, targetLabel: app, replacement: dspace}}
+        - {{action: replace, targetLabel: environment, replacement: prod}}
+        - {{action: replace, targetLabel: release, replacement: dspace}}
+        - {{action: replace, targetLabel: cluster, replacement: sugarkube-prod}}
 YAML
     fi
   fi
@@ -5350,7 +5389,7 @@ import sys
 from scripts import observability_app_metrics as subject
 
 calls = []
-subject.assert_context = lambda: calls.append(["context"])
+subject.assert_context = lambda *args: calls.append(["context"])
 subject.install_secret = lambda cfg: calls.append(["secret-install", cfg["namespace"]])
 subject.check_secret = lambda cfg: calls.append(["secret-check", cfg["namespace"]])
 subject.verify = lambda app, env: calls.append(["verify", app, env])
@@ -5742,7 +5781,7 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
             )
 
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
     monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {"version": "main-deadbee", "revision": "main-deadbee"})
     monkeypatch.setattr(app_metrics, "kjson", fake_kjson)
@@ -5872,7 +5911,7 @@ def test_observability_app_metrics_verify_fails_on_public_200(monkeypatch):
     cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["tokenplace"]["environments"]["staging"]
     sm = {"spec": {"selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]}, "endpoints": [{"path": "/metrics", "interval": cfg["serviceMonitor"]["interval"], "scrapeTimeout": cfg["serviceMonitor"]["scrapeTimeout"], "authorization": {"type": "Bearer", "credentials": cfg["secret"]}, "relabelings": cfg["serviceMonitor"]["relabelings"]}]}}
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
     monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {"version": "main-deadbee", "revision": "main-deadbee"})
     monkeypatch.setattr(app_metrics, "kjson", lambda args: sm)
@@ -5933,7 +5972,7 @@ def _verify_base(monkeypatch, cfg, prom_func):
         def open(self, url, timeout):
             raise app_metrics.urllib.error.HTTPError(url, 401, "unauthorized", {}, None)
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
     monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {"version": "main-deadbee", "revision": "main-deadbee"})
     monkeypatch.setattr(app_metrics, "kjson", lambda args: sm)
@@ -6119,7 +6158,7 @@ def test_observability_app_metrics_malformed_kubernetes_nested_objects_fail_cont
 ):
     cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["tokenplace"]["environments"]["staging"]
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
     monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {})
     monkeypatch.setattr(app_metrics, "kjson", lambda args: service_monitor)
@@ -6271,7 +6310,7 @@ def test_observability_app_metrics_prom_rejects_non_object_data(monkeypatch, dat
 
 
 def test_observability_app_metrics_verify_all_uses_every_configured_app(monkeypatch):
-    doc = {"schemaVersion": 1, "applications": {"first": {}, "second": {}}}
+    doc = {"schemaVersion": 1, "applications": {"first": {"environments": {"staging": {}}}, "second": {"environments": {"staging": {}}}}}
     called = []
     monkeypatch.setattr(app_metrics, "load_config", lambda: doc)
     monkeypatch.setattr(app_metrics, "verify", lambda app, env: called.append((app, env)))
@@ -6281,7 +6320,7 @@ def test_observability_app_metrics_verify_all_uses_every_configured_app(monkeypa
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):
-    forbidden = ["prod", "production", "", "dev", "qa"]
+    forbidden = ["production", "", "dev", "qa"]
     for env in forbidden:
         def fail_load_config(env=env):
             raise AssertionError(f"loaded config for {env!r}")
@@ -6289,11 +6328,12 @@ def test_observability_app_metrics_live_environment_normalization_and_rejection(
         monkeypatch.setattr(app_metrics, "load_config", fail_load_config)
         with pytest.raises(SystemExit) as excinfo:
             app_metrics.appcfg("tokenplace", env)
-        assert "staging only" in str(excinfo.value)
+        assert "unsupported" in str(excinfo.value)
         assert app_metrics.main(["verify-all", "--env", env]) == 2
 
     assert app_metrics.normalize_live_env("env=env=int") == "staging"
     assert app_metrics.normalize_live_env("env=staging") == "staging"
+    assert app_metrics.normalize_live_env("prod") == "prod"
 
 
 @pytest.mark.parametrize("app", ["app=", "app=foo=bar", "app=Bad_Name", "-bad"])
@@ -6304,7 +6344,7 @@ def test_observability_app_metrics_rejects_malformed_app_before_live_operations(
         app_metrics, "load_config", lambda: pytest.fail("inventory lookup must not run")
     )
     monkeypatch.setattr(
-        app_metrics, "assert_context", lambda: pytest.fail("context check must not run")
+        app_metrics, "assert_context", lambda *args: pytest.fail("context check must not run")
     )
     monkeypatch.setattr(
         app_metrics, "install_secret", lambda cfg: pytest.fail("credential handling must not run")
@@ -6327,7 +6367,7 @@ def test_observability_app_metrics_rejects_empty_application_argument(app):
 def test_observability_app_metrics_positional_values_remain_compatible(monkeypatch):
     calls = []
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: {"namespace": app})
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: calls.append("context"))
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: calls.append("context"))
     monkeypatch.setattr(
         app_metrics, "check_secret", lambda cfg: calls.append((cfg["namespace"], "staging"))
     )
@@ -6337,7 +6377,7 @@ def test_observability_app_metrics_positional_values_remain_compatible(monkeypat
 
 
 def test_observability_app_metrics_verify_all_uses_normalized_requested_env(monkeypatch):
-    doc = {"schemaVersion": 1, "applications": {"first": {}, "second": {}}}
+    doc = {"schemaVersion": 1, "applications": {"first": {"environments": {"staging": {}}}, "second": {"environments": {"staging": {}}}}}
     called = []
     monkeypatch.setattr(app_metrics, "load_config", lambda: doc)
     monkeypatch.setattr(app_metrics, "verify", lambda app, env: called.append((app, env)))
@@ -6391,7 +6431,7 @@ def test_observability_app_metrics_public_redirect_is_not_followed_and_redacted(
             )
 
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
     monkeypatch.setattr(
         app_metrics,
@@ -6582,7 +6622,7 @@ def test_observability_app_metrics_main_dispatches_exactly(
         app_metrics, "validate_render", lambda *args: calls.append(args)
     )
     monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: "cfg")
-    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda *args: None)
     monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: calls.append((cfg,)))
     monkeypatch.setattr(app_metrics, "install_secret", lambda cfg: calls.append((cfg,)))
     monkeypatch.setattr(app_metrics, "verify", lambda app, env: calls.append((app, env)))
@@ -7040,9 +7080,9 @@ def test_observability_app_metrics_install_secret_subprocess_failures_are_redact
         (lambda d: d.update({"applications": []}), "applications"),
         (
             lambda d: d["applications"]["tokenplace"]["environments"].update(
-                {"prod": {}}
+                {"qa": {}}
             ),
-            "only staging",
+            "unsupported",
         ),
         (
             lambda d: d["applications"]["tokenplace"]["environments"][

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -682,9 +682,34 @@ def test_helm_stored_values_reject_production_staging_leaks_secret_safely(
         },
         **leak,
     }
-    with pytest.raises(manifest.ManifestError, match="staging-only settings") as raised:
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
         manifest.verify_helm_stored_values(value, stored, "prod")
     assert "dspace-staging-metrics-token" not in str(raised.value)
+
+
+def test_helm_stored_values_accept_exact_production_metrics_contract() -> None:
+    value = split_candidate("prod")
+    stored = {
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": value["imageTag"],
+            "pullPolicy": "Always",
+        },
+        "metrics": {
+            "enabled": True,
+            "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
+        },
+        "serviceMonitor": {
+            "enabled": True,
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "additionalLabels": {"release": "kube-prometheus-stack"},
+            "cluster": "sugarkube-prod",
+        },
+    }
+    result = manifest.verify_helm_stored_values(value, stored, "prod")
+    assert result["passed"] is True
+    assert "dspace-prod-metrics-token" not in str(result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Allow the repository to express and verify authenticated DSPACE /metrics in production without promoting or changing the application/image/chart coordinates, and fail closed on any deviation from the narrow production contract.
- Replace the previous blanket refusal of any production ServiceMonitor with strict, environment-aware structural guards and a values-only reconciliation surface.

### Description

- Add the exact production values contract to `docs/examples/dspace.values.prod.yaml` enabling metrics and declaring `existingSecret: dspace-prod-metrics-token` and the ServiceMonitor timing/labels/cluster values.
- Strengthen render-time validation in `scripts/app_chart.py` for DSPACE: forbid literal Secrets and staging scalars, allow the chart-3.0.2 pod-UID fallback when metrics are off, and require exactly one authenticated ServiceMonitor (release label `kube-prometheus-stack`, cluster relabeling `sugarkube-prod`, endpoint timing and bearer-token name/key) when production metrics are enabled.
- Replace the obsolete production-staging rejection in `scripts/dspace_release_manifest.py::verify_helm_stored_values` with an exact production metrics contract check while preserving image-coordinate assertions and without storing secret values.
- Extend the generic metrics lifecycle in `scripts/observability_app_metrics.py` to support `prod` in inventory and live operations, including explicit kubeconfig/context/cluster checks, refusal of credential-bearing env, xtrace guard, interactive hidden input install path, secret-check and verification that accepts `bearerTokenSecret` shape, and robust Prometheus target/family checks driven by `platform/observability/app-metrics.json`.
- Add a production DSPACE entry to `platform/observability/app-metrics.json` describing the ServiceMonitor name, secret name/key, expected target count (2), required metric families, relabelings, and public /metrics unauthenticated status (401).
- Update docs and runbook guidance in `docs/apps/dspace.md` and `docs/observability-operations.md` to document the operator workflow: explicit production kubeconfig/context `sugar-prod`, run-from-`sugarkube3` caveat, credential install/check, guarded values-only reconciliation, and post-rollout verification steps.
- Tests and harness adjustments: update and add focused unit tests to recognize and assert the exact production values contract and stored-values verification; adapt test harness stubs to render the authenticated production ServiceMonitor for offline verification and keep staging behavior unchanged.

### Testing

- `python3 scripts/observability_app_metrics.py validate` — passed (inventory validated).
- Unit test suites run (focused and combined):
  - `pytest -q tests/test_dspace_runtime_values.py` — passed.
  - `pytest -q tests/test_release_manifest.py` — passed.
  - `pytest -q tests/test_generic_app_just_recipes.py` (focused runs during development and final filtered runs) — passed in CI-like local stubs (test subsets exercise app-metrics and DSPACE guarded flows; overall local runs reported success for exercised suites).
  - `pytest -q tests/test_observability_helm.py` — passed in local stubbed runs.
  - Combined targeted runs used during development exercised the new production checks (Prometheus target/family logic, ServiceMonitor shape, secret-check, and stored-values acceptance/rejection) and succeeded against the repository's offline test harness.
- Additional validations: `linkchecker --no-warnings README.md docs/` — ran and reported no link errors; `git diff --cached | ./scripts/scan-secrets.py` — ran and reported no committed secrets in the staged diff.
- Not-run / environment notes: `python3 scripts/app_chart.py preflight --env prod` could not perform the live Helm/OCI chart show/render because `helm` was unavailable in the execution environment, so an exact online digest-qualified preflight was not executed here (the repo tests include offline stubs which are authoritative). `pyspelling` required `aspell` on PATH and was not available in the runtime used for this run; `pre-commit run --all-files` was invoked but some repository-wide hooks required the normal CI environment/tooling (formatters/lint) — I ran `black` on the edited files and resolved formatting locally as part of the patch cycle.

Notes and residual risks

- No secret values or credential materials were committed; the changes only reference the exact Secret name/key and enforce the contract.
- The guarded operator installation/check paths require an explicit production kubeconfig and TTY (described in the updated docs); operators must follow the runbook to perform the actual production reconciliation and credential installation.
- An exact online Helm/OCI preflight against GHCR and a live production cluster must be run by an operator with access to `helm`, `kubectl`, and the production kubeconfig (the repository changes enable the verifier and guarded reconciliation but do not deploy anything).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a791316a960832fba19bb1a7e565b5e)