### PR TITLE
Fix Cloudflare WAN drill: require /usr/local/bin/crictl and fail closed

### DIFF
--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -8,6 +8,7 @@ readonly EXPECTED_CHART='cloudflare-tunnel-0.3.2'
 readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
+readonly CRICTL=/usr/local/bin/crictl
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -59,14 +60,14 @@ render_manual_node_plan() {
   printf 'If either DISRUPTION command fails or you abort after any disruption, immediately run both CLEANUP commands.\n'
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     watchdog_body="/bin/sh -c 'test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = \"\$1\" || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf \"%s\\n\" \"\${ruleset}\" | /usr/bin/jq -e --arg table ${table} '\"'\"'[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0'\"'\"' >/dev/null' sh \"\${netns}\""
     watchdog="${resolve} && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t \"\${pid}\" -n ${watchdog_body} && sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     printf 'WATCHDOG node=%q pod=%q uid=%q owner=%q table=%q command=%q\n' "${pod_nodes[$i]}" "${pod_names[$i]}" "${pod_uids[$i]}" "${owner}" "${table}" "${watchdog}"
   done
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     guard="sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     disruption="${resolve} && ${guard} && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null && sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
     cleanup="${resolve} && { sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
@@ -102,7 +103,7 @@ manual_cleanup() {
   printf 'MANUAL CLEANUP REQUIRED (run through an authenticated, host-key-verified node session):\n' >&2
   for i in "${!pod_nodes[@]}"; do
     printf '  node=%q command=%q\n' "${pod_nodes[$i]}" \
-      "test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
+      "test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
   done
 }
 
@@ -114,7 +115,7 @@ cleanup() {
   for ((position=${#attempted_indices[@]}-1; position>=0; position--)); do
     i="${attempted_indices[$position]}"
     node="${pod_nodes[$i]}"
-    command="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+    command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
     if node_exec "${node}" "${command}" >/dev/null; then
       unset 'attempted_indices[position]'
     else
@@ -235,18 +236,18 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x /usr/bin/crictl -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
-  resolve="sudo crictl pods --name '^${pod_names[$i]}$' -q"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
-  inspect="$(node_exec "${pod_nodes[$i]}" "sudo crictl inspectp ${sandbox}")"
+  inspect="$(node_exec "${pod_nodes[$i]}" "sudo ${CRICTL} inspectp ${sandbox}")"
   [[ "$(jq -r '.status.labels["io.kubernetes.pod.uid"]//empty' <<<"${inspect}")" == "${pod_uids[$i]}" ]] || die 'sandbox UID does not match selected pod'
   pid="$(jq -r '.info.pid//empty' <<<"${inspect}")"
   [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || die 'sandbox has no exact network namespace PID'
   inode="$(node_exec "${pod_nodes[$i]}" "readlink /proc/${pid}/ns/net")"
   [[ "${inode}" =~ ^net:\[[0-9]+\]$ ]] || die 'cannot prove exact pod network namespace identity'
   pod_sandboxes+=("${sandbox}"); pod_pids+=("${pid}"); pod_netns+=("${inode}")
-  collision_check="test \"\$(sudo /usr/bin/crictl inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  collision_check="test \"\$(sudo ${CRICTL} inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   node_exec "${pod_nodes[$i]}" "${collision_check}" >/dev/null || die 'owner table absence could not be proven'
 done
 
@@ -272,14 +273,14 @@ for i in 0 1; do
   # long-lived nsenter child pins that namespace; no delayed stored-PID lookup occurs.
   printf -v watchdog_body '%q ' /bin/sh -c "test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = '${pod_netns[$i]}' || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   unit="${owner}-cleanup.service"
-  watchdog="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
+  watchdog="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
   node_exec "${pod_nodes[$i]}" "${watchdog}" >/dev/null || die "cleanup watchdog failed on ${pod_nodes[$i]}"
   watchdog_pid="$(node_exec "${pod_nodes[$i]}" "sudo /usr/bin/systemctl is-active --quiet '${unit}' && sudo /usr/bin/systemctl show --property MainPID --value '${unit}'")" || die "cleanup watchdog is inactive on ${pod_nodes[$i]}"
   [[ "${watchdog_pid}" =~ ^[1-9][0-9]*$ ]] || die "cleanup watchdog has no live MainPID on ${pod_nodes[$i]}"
   [[ "$(node_exec "${pod_nodes[$i]}" "/usr/bin/readlink /proc/${watchdog_pid}/ns/net")" == "${pod_netns[$i]}" ]] || die "cleanup watchdog namespace mismatch on ${pod_nodes[$i]}"
 done
 for i in 0 1; do
-  install="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
+  install="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
   # A transport failure is ambiguous: record the attempt before the command so EXIT cleanup tries it.
   attempted_indices+=("${i}")
   if ! node_exec "${pod_nodes[$i]}" "${install}" >/dev/null; then
@@ -310,7 +311,7 @@ if ((remaining > 0)); then sleep "${remaining}"; fi
 cleanup_failed=0
 declare -a cleanup_retry_indices=()
 for i in "${attempted_indices[@]}"; do
-  delete_and_prove="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  delete_and_prove="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   if ! node_exec "${pod_nodes[$i]}" "${delete_and_prove}" >/dev/null; then
     cleanup_failed=1
     cleanup_retry_indices+=("${i}")

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -34,6 +34,7 @@ class StatefulDrillHarness:
             "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
+            "local_crictl": True, "usr_bin_crictl": False,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -172,11 +173,14 @@ elif name == "kubectl":
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
 elif name == "node-executor":
     node, command=args[0],args[1]; idx=int(node[-1])-1
-    if "test -x" in command: sys.exit(0)
+    if "test -x" in command:
+        if "test -x /usr/local/bin/crictl" in command and not state["local_crictl"]:
+            sys.exit(1)
+        sys.exit(0)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
-    elif command.startswith("sudo crictl inspectp"):
+    elif command.startswith("sudo /usr/local/bin/crictl inspectp"):
         out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
     elif command.startswith("readlink /proc/") or command.startswith("/usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
@@ -414,10 +418,89 @@ def test_wrong_context_revision_image_helm_and_ambiguous_pods_are_guarded() -> N
 
 
 def test_exact_network_namespace_resolution_is_required() -> None:
-    assert "crictl inspectp" in TEXT
+    assert "${CRICTL} inspectp" in TEXT
     assert 'io.kubernetes.pod.uid' in TEXT
     assert "readlink /proc/${pid}/ns/net" in TEXT
     assert "cannot prove exact pod network namespace identity" in TEXT
+
+
+def test_crictl_uses_one_immutable_approved_absolute_path() -> None:
+    assert "readonly CRICTL=/usr/local/bin/crictl" in TEXT
+    assert "test -x ${CRICTL}" in TEXT
+    obsolete_path = "/usr/bin/" + "crictl"
+    assert obsolete_path not in TEXT
+    assert "command -v crictl" not in TEXT
+    assert "sudo crictl" not in TEXT
+
+
+def test_manual_plan_records_use_the_approved_crictl_path(tmp_path: Path) -> None:
+    result = run("--manual-node-plan", env=manual_plan_environment(tmp_path))
+    assert result.returncode == 0, result.stderr
+    records = [
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith(("WATCHDOG ", "DISRUPTION ", "CLEANUP "))
+    ]
+    assert len(records) == 6
+    assert all("/usr/local/bin/crictl" in record for record in records)
+
+
+def test_every_execution_crictl_command_uses_the_approved_path(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    result = harness.run()
+    assert result.returncode == 0, result.stderr
+    node_commands = [
+        entry["args"][1]
+        for entry in harness.commands()
+        if entry["tool"] == "node-executor"
+    ]
+    crictl_commands = [command for command in node_commands if "crictl" in command]
+    assert crictl_commands
+    assert all("/usr/local/bin/crictl" in command for command in crictl_commands)
+    assert any("test -x /usr/local/bin/crictl" in command for command in node_commands)
+    assert any("pods --name" in command for command in crictl_commands)
+    assert any("inspectp" in command and "list ruleset" in command for command in crictl_commands)
+    assert any("inspectp" in command and "systemd-run" in command for command in crictl_commands)
+    assert any("inspectp" in command and "add table inet" in command for command in crictl_commands)
+    assert any("inspectp" in command and "delete table inet" in command for command in crictl_commands)
+
+
+@pytest.mark.parametrize("usr_bin_crictl", [False, True])
+def test_missing_approved_crictl_path_fails_before_node_events(
+    tmp_path: Path, usr_bin_crictl: bool,
+) -> None:
+    harness = StatefulDrillHarness(
+        tmp_path, local_crictl=False, usr_bin_crictl=usr_bin_crictl
+    )
+    result = harness.run()
+    assert result.returncode != 0
+    assert "required remote binary path missing" in result.stderr
+    node_commands = [
+        entry["args"][1]
+        for entry in harness.commands()
+        if entry["tool"] == "node-executor"
+    ]
+    assert node_commands == [
+        next(command for command in node_commands if "test -x /usr/local/bin/crictl" in command)
+    ]
+    assert not any(
+        event.get("event") in {"watchdog", "table"} for event in harness.events()
+    )
+    assert not any(
+        marker in command
+        for command in node_commands
+        for marker in ("/proc/", "nsenter", "add table", "delete table")
+        if "test -x" not in command
+    )
+
+
+def test_cleanup_command_builders_use_the_approved_crictl_path() -> None:
+    automatic = TEXT.split("cleanup() {", 1)[1].split("for arg in", 1)[0]
+    manual = TEXT.split("manual_cleanup() {", 1)[1].split("cleanup() {", 1)[0]
+    normal = TEXT.split("declare -a cleanup_retry_indices=()", 1)[1]
+    assert "sudo ${CRICTL} inspectp" in automatic
+    assert "sudo ${CRICTL} inspectp" in manual
+    assert "sudo ${CRICTL} inspectp" in normal
 
 
 def test_owner_collision_is_refused() -> None:


### PR DESCRIPTION
### Motivation
- Two operator evidence captures show the executor gate failed because the helper required the nonexistent `/usr/bin/crictl`: `/home/pi/operator-evidence/cloudflare-wan-node-executor-gate-20260810T035343Z` and `/home/pi/operator-evidence/cloudflare-wan-executor-failure-diagnostic-20260810T035618Z`.
- The selected k3s nodes actually provide `crictl` at `/usr/local/bin/crictl`, so PATH or obsolete hard-coded `/usr/bin/crictl` lookups caused a preflight mismatch and early gate failure.
- Requiring the exact k3s-managed absolute path and failing closed avoids ambiguous PATH discovery, fallback semantics, symlink/agent drift, and any operator-supplied or node-wide configuration changes that could hide executable mismatches. 

### Description
- Introduce one immutable shell constant `readonly CRICTL=/usr/local/bin/crictl` and replace every `crictl` invocation and preflight with that constant so generated local and remote commands embed the fully qualified approved path in-place. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Update remote preflight, manual plan rendering, watchdog, disruption, automatic cleanup, manual cleanup, sandbox inspection, and collision checks to use `sudo ${CRICTL}` (and `test -x ${CRICTL}`) consistently while preserving all existing safety contracts and command templates. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Add focused offline tests that assert the approved-path contract and fail-closed semantics, verify `/usr/bin/crictl` no longer appears in emitted commands, and exercise the cases where only the obsolete path exists. (`tests/test_cloudflare_wan_dependency_loss_drill.py`)
- Scope of change limited to the two files above and no operator-facing behavior or semantics beyond the approved-path enforcement were altered. Commit SHA: `e4f738c924538ea14dcf7fd7642556af82765431`, required ancestor merge commit `fa8f052d0a794a0e067b3175af8f8e94d589035c` is present.

### Testing
- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — PASS.
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — PASS (102 passed).
- `pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_justfile_formatting.py` — PASS (30 passed).
- Offline plan verification with executor/approval env unset: `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION -u CF_DRILL_APPROVED_REVISION bash scripts/cloudflare_wan_dependency_loss_drill.sh` — produced offline plan only and PASS.
- Offline Just recipe plan: `env -u CF_DRILL_NODE_EXECUTOR -u CF_DRILL_EXPECTED_OBSERVABILITY_REVISION -u CF_DRILL_APPROVED_REVISION just cf-tunnel-wan-dependency-loss-drill env=staging` — offline plan only and PASS.
- Emitted-path checks: `! rg -n '/usr/bin/crictl' scripts/cloudflare_wan_dependency_loss_drill.sh tests/test_cloudflare_wan_dependency_loss_drill.py` — PASS, and `rg -n '/usr/local/bin/crictl' scripts/cloudflare_wan_dependency_loss_drill.sh tests/test_cloudflare_wan_dependency_loss_drill.py` — PASS.
- Safety/CI checks: `git diff --check`, `git diff --stat`, and `git diff --cached | ./scripts/scan-secrets.py` — PASS for the committed changes; `pre-commit` runs the repository-wide hooks and surfaced pre-existing unrelated flake8/KiCad baseline issues, but the focused changes passed secret scans and local repository checks.
- Push/PR creation: `git push -u origin codex/fix-cloudflare-crictl-path` — NOT RUN (failed due to missing GitHub credentials in this environment); therefore no PR URL was created here.

No live infrastructure was changed during this work (no `--execute`, no SSH connections, no namespaces entered, no systemd units created, no nftables mutations, and no Kubernetes/Helm operations were performed), and the change preserves every existing safety contract while making the helper require the exact approved `/usr/local/bin/crictl` executable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a794c6b5c44832f86499255bf4766df)