### PR TITLE
Fix Cloudflare WAN drill to require exact /usr/local/bin/crictl path

### DIFF
--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -10,6 +10,7 @@ readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
+readonly CRICTL_PATH=/usr/local/bin/crictl
 
 execute=0
 manual_node_plan=0
@@ -59,14 +60,14 @@ render_manual_node_plan() {
   printf 'If either DISRUPTION command fails or you abort after any disruption, immediately run both CLEANUP commands.\n'
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL_PATH} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL_PATH} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     watchdog_body="/bin/sh -c 'test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = \"\$1\" || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf \"%s\\n\" \"\${ruleset}\" | /usr/bin/jq -e --arg table ${table} '\"'\"'[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0'\"'\"' >/dev/null' sh \"\${netns}\""
     watchdog="${resolve} && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t \"\${pid}\" -n ${watchdog_body} && sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     printf 'WATCHDOG node=%q pod=%q uid=%q owner=%q table=%q command=%q\n' "${pod_nodes[$i]}" "${pod_names[$i]}" "${pod_uids[$i]}" "${owner}" "${table}" "${watchdog}"
   done
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL_PATH} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL_PATH} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     guard="sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     disruption="${resolve} && ${guard} && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null && sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
     cleanup="${resolve} && { sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
@@ -102,7 +103,7 @@ manual_cleanup() {
   printf 'MANUAL CLEANUP REQUIRED (run through an authenticated, host-key-verified node session):\n' >&2
   for i in "${!pod_nodes[@]}"; do
     printf '  node=%q command=%q\n' "${pod_nodes[$i]}" \
-      "test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
+      "test \"\$(sudo ${CRICTL_PATH} inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
   done
 }
 
@@ -114,7 +115,7 @@ cleanup() {
   for ((position=${#attempted_indices[@]}-1; position>=0; position--)); do
     i="${attempted_indices[$position]}"
     node="${pod_nodes[$i]}"
-    command="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+    command="test \"\$(sudo ${CRICTL_PATH} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
     if node_exec "${node}" "${command}" >/dev/null; then
       unset 'attempted_indices[position]'
     else
@@ -235,18 +236,18 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x /usr/bin/crictl -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
-  resolve="sudo crictl pods --name '^${pod_names[$i]}$' -q"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL_PATH} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  resolve="sudo ${CRICTL_PATH} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
-  inspect="$(node_exec "${pod_nodes[$i]}" "sudo crictl inspectp ${sandbox}")"
+  inspect="$(node_exec "${pod_nodes[$i]}" "sudo ${CRICTL_PATH} inspectp ${sandbox}")"
   [[ "$(jq -r '.status.labels["io.kubernetes.pod.uid"]//empty' <<<"${inspect}")" == "${pod_uids[$i]}" ]] || die 'sandbox UID does not match selected pod'
   pid="$(jq -r '.info.pid//empty' <<<"${inspect}")"
   [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || die 'sandbox has no exact network namespace PID'
   inode="$(node_exec "${pod_nodes[$i]}" "readlink /proc/${pid}/ns/net")"
   [[ "${inode}" =~ ^net:\[[0-9]+\]$ ]] || die 'cannot prove exact pod network namespace identity'
   pod_sandboxes+=("${sandbox}"); pod_pids+=("${pid}"); pod_netns+=("${inode}")
-  collision_check="test \"\$(sudo /usr/bin/crictl inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  collision_check="test \"\$(sudo ${CRICTL_PATH} inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   node_exec "${pod_nodes[$i]}" "${collision_check}" >/dev/null || die 'owner table absence could not be proven'
 done
 
@@ -272,14 +273,14 @@ for i in 0 1; do
   # long-lived nsenter child pins that namespace; no delayed stored-PID lookup occurs.
   printf -v watchdog_body '%q ' /bin/sh -c "test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = '${pod_netns[$i]}' || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   unit="${owner}-cleanup.service"
-  watchdog="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
+  watchdog="test \"\$(sudo ${CRICTL_PATH} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
   node_exec "${pod_nodes[$i]}" "${watchdog}" >/dev/null || die "cleanup watchdog failed on ${pod_nodes[$i]}"
   watchdog_pid="$(node_exec "${pod_nodes[$i]}" "sudo /usr/bin/systemctl is-active --quiet '${unit}' && sudo /usr/bin/systemctl show --property MainPID --value '${unit}'")" || die "cleanup watchdog is inactive on ${pod_nodes[$i]}"
   [[ "${watchdog_pid}" =~ ^[1-9][0-9]*$ ]] || die "cleanup watchdog has no live MainPID on ${pod_nodes[$i]}"
   [[ "$(node_exec "${pod_nodes[$i]}" "/usr/bin/readlink /proc/${watchdog_pid}/ns/net")" == "${pod_netns[$i]}" ]] || die "cleanup watchdog namespace mismatch on ${pod_nodes[$i]}"
 done
 for i in 0 1; do
-  install="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
+  install="test \"\$(sudo ${CRICTL_PATH} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
   # A transport failure is ambiguous: record the attempt before the command so EXIT cleanup tries it.
   attempted_indices+=("${i}")
   if ! node_exec "${pod_nodes[$i]}" "${install}" >/dev/null; then
@@ -310,7 +311,7 @@ if ((remaining > 0)); then sleep "${remaining}"; fi
 cleanup_failed=0
 declare -a cleanup_retry_indices=()
 for i in "${attempted_indices[@]}"; do
-  delete_and_prove="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  delete_and_prove="test \"\$(sudo ${CRICTL_PATH} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   if ! node_exec "${pod_nodes[$i]}" "${delete_and_prove}" >/dev/null; then
     cleanup_failed=1
     cleanup_retry_indices+=("${i}")

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -18,6 +18,8 @@ TEXT = DRILL.read_text()
 
 
 CONFIRM = "DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY"
+CRICTL = "/usr/local/bin/crictl"
+OBSOLETE_CRICTL = "/usr/bin/" + "crictl"
 
 
 class StatefulDrillHarness:
@@ -35,7 +37,8 @@ class StatefulDrillHarness:
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
-            "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
+            "block_long_sleep": False, "local_crictl": True,
+            "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
         state.update(overrides)
         self.state.write_text(json.dumps(state))
@@ -172,11 +175,13 @@ elif name == "kubectl":
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
 elif name == "node-executor":
     node, command=args[0],args[1]; idx=int(node[-1])-1
-    if "test -x" in command: sys.exit(0)
+    if "test -x" in command:
+        if "/usr/local/bin/crictl" in command and not state["local_crictl"]: sys.exit(1)
+        sys.exit(0)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
-    elif command.startswith("sudo crictl inspectp"):
+    elif command.startswith("sudo /usr/local/bin/crictl inspectp"):
         out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
     elif command.startswith("readlink /proc/") or command.startswith("/usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
@@ -319,6 +324,7 @@ def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_co
         assert len(associated) == 3
         assert all(f"pod=connector-{number}" in line and f"uid=uid-{number}" in line for line in associated)
         assert all("crictl\\ pods" in line and "inspectp" in line and "readlink" in line for line in associated)
+        assert all(CRICTL in line for line in associated)
     assert all("systemctl" in lines[i] and "MainPID" in lines[i] for i in disruptions)
     assert all("delete\\ table\\ inet" in lines[i] and "list\\ ruleset" in lines[i] and "length\\ ==\\ 0" in lines[i] for i in cleanups)
     assert "BLOCKED: manual-node plan only; the drill was not executed and has not passed." in result.stdout
@@ -414,10 +420,44 @@ def test_wrong_context_revision_image_helm_and_ambiguous_pods_are_guarded() -> N
 
 
 def test_exact_network_namespace_resolution_is_required() -> None:
-    assert "crictl inspectp" in TEXT
+    assert "${CRICTL_PATH} inspectp" in TEXT
     assert 'io.kubernetes.pod.uid' in TEXT
     assert "readlink /proc/${pid}/ns/net" in TEXT
     assert "cannot prove exact pod network namespace identity" in TEXT
+
+
+def test_crictl_commands_use_only_the_immutable_approved_path() -> None:
+    assert "readonly CRICTL_PATH=/usr/local/bin/crictl" in TEXT
+    assert OBSOLETE_CRICTL not in TEXT
+    assert "command -v crictl" not in TEXT
+    assert 'test -x ${CRICTL_PATH}' in TEXT
+
+
+def test_missing_approved_crictl_path_fails_before_node_mutation(tmp_path: Path) -> None:
+    # Even if a different crictl exists on PATH, the exact approved path must pass
+    # the remote executable preflight before sandbox or namespace inspection.
+    harness = StatefulDrillHarness(tmp_path, local_crictl=False)
+    old_crictl = tmp_path / "crictl"
+    old_crictl.write_text("#!/bin/sh\nexit 0\n")
+    old_crictl.chmod(0o755)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "required remote binary path missing" in result.stderr
+    node_commands = [
+        entry["args"][1]
+        for entry in harness.commands()
+        if entry["tool"] == "node-executor"
+    ]
+    assert node_commands and node_commands[0].startswith(f"test -x {CRICTL}")
+    assert not any(
+        marker in command
+        for command in node_commands
+        for marker in (" pods --name", "inspectp", "readlink /proc/", "nsenter", "nft ")
+        if not command.startswith("test -x ")
+    )
+    assert not any(
+        event.get("event") in {"watchdog", "table"} for event in harness.events()
+    )
 
 
 def test_owner_collision_is_refused() -> None:
@@ -631,6 +671,19 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert result.returncode == 0, result.stderr
     commands = harness.commands()
     node_commands = [entry["args"][1] for entry in commands if entry["tool"] == "node-executor"]
+    crictl_commands = [command for command in node_commands if "crictl" in command]
+    assert crictl_commands
+    assert all(
+        CRICTL in command and OBSOLETE_CRICTL not in command
+        for command in crictl_commands
+    )
+    for marker in (
+        "test -x", "pods --name", "inspectp", "systemd-run", "add table inet",
+        "delete table inet", "list ruleset",
+    ):
+        matching = [command for command in node_commands if marker in command and "crictl" in command]
+        assert matching, f"expected crictl coverage for {marker}"
+        assert all(CRICTL in command for command in matching)
     watchdogs = [i for i, command in enumerate(node_commands) if "systemd-run --unit" in command]
     installs = [i for i, command in enumerate(node_commands) if "add table inet" in command]
     deletes = [command for command in node_commands if "delete table inet" in command]


### PR DESCRIPTION
### Motivation

- The node executor gate and diagnostic captures show target k3s nodes provide the k3s-managed `crictl` at `/usr/local/bin/crictl` while the helper hard-coded `/usr/bin/crictl`, causing preflight failures (evidence: `/home/pi/operator-evidence/cloudflare-wan-node-executor-gate-20260810T035343Z` and `/home/pi/operator-evidence/cloudflare-wan-executor-failure-diagnostic-20260810T035618Z`).
- The intent is to make the helper fail closed unless the approved k3s-managed executable exists, avoiding accidental execution with an unintended `crictl` binary discovered via `PATH` or introduced by node symlinks.

### Description

- Introduce one immutable constant `CRICTL_PATH=/usr/local/bin/crictl` and replace every `crictl` invocation and preflight literal in `scripts/cloudflare_wan_dependency_loss_drill.sh` with fully-qualified uses of `${CRICTL_PATH}`, including preflight checks, sandbox resolution, `inspectp` calls, collision checks, watchdog setup, disruption, automatic cleanup, and manual-cleanup output.
- Adjust remote preflight to require `test -x ${CRICTL_PATH}` so the helper fails closed if that exact path is not executable, and preserve all existing fully-qualified other binaries and safety contracts (watchdog ordering, UID/PID/namespace validation, unique nftables owner tables, reverse-order cleanup, manual-plan vs execute gating, observability/Helm checks, and no Secret value access).
- Add focused tests in `tests/test_cloudflare_wan_dependency_loss_drill.py` that assert the helper requires `/usr/local/bin/crictl`, that `/usr/bin/crictl` is not emitted, that all WATCHDOG/DISRUPTION/CLEANUP/inspection/collision/preflight/execution commands use the approved path, and that the existence of only a PATH-resolved `crictl` does not satisfy the contract.
- Changed files: `scripts/cloudflare_wan_dependency_loss_drill.sh` and `tests/test_cloudflare_wan_dependency_loss_drill.py`, commit `a201888ee314d0ea271b3b2f9b1525ed62b0efcf` on branch `codex/fix-cloudflare-crictl-path` and required ancestor merge commit `fa8f052d0a794a0e067b3175af8f8e94d589035c` is present.
- Why exact `/usr/local/bin/crictl` is safer: it prevents environment-dependent executable substitution via `PATH` and avoids implicit trust in node-maintained symlinks, thereby failing closed if the k3s-managed binary is absent and reducing risk of running an unexpected binary in sensitive cleanup/mutation commands.

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — passed.
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — passed (98 tests).
- `pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_justfile_formatting.py` — passed (30 tests).
- Offline helper invocations with required env vars unset produced the expected offline plan output for both direct script and `just` recipe and did not perform any node or cluster actions.
- Ripgrep checks: `/usr/bin/crictl` is absent from the modified files and `/usr/local/bin/crictl` is present in both the script and tests — passed.
- `git diff --check`, `git diff --stat`, and staged secret scan (`git diff --cached | ./scripts/scan-secrets.py`) — passed.
- `pre-commit run --files scripts/cloudflare_wan_dependency_loss_drill.sh tests/test_cloudflare_wan_dependency_loss_drill.py` — local two-file hooks passed but the repository-wide `run-checks` hook triggered existing unrelated flake8 issues elsewhere (pre-existing warnings), so full pre-commit suite reported a non-fixable project-wide failure unrelated to this two-file change.
- `git push` / PR creation: push failed due to missing GitHub credentials in this environment (no authenticated host), so a hosted PR URL could not be produced; local branch `codex/fix-cloudflare-crictl-path` and commit `a201888ee314d0ea271b3b2f9b1525ed62b0efcf` are available locally.
- Safety confirmation: no live infrastructure was contacted or changed during verification — no executor invocation, no SSH, no systemd, nftables, namespace, Kubernetes, Helm, or WAN mutation occurred.

Changed paths:
- scripts/cloudflare_wan_dependency_loss_drill.sh
- tests/test_cloudflare_wan_dependency_loss_drill.py

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a794c76c968832fa1d74ba3dfb750a7)