### PR TITLE
Use k3s-managed /usr/local/bin/crictl in Cloudflare WAN drill

### DIFF
--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -8,6 +8,7 @@ readonly EXPECTED_CHART='cloudflare-tunnel-0.3.2'
 readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
+readonly CRICTL='/usr/local/bin/crictl'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -59,14 +60,14 @@ render_manual_node_plan() {
   printf 'If either DISRUPTION command fails or you abort after any disruption, immediately run both CLEANUP commands.\n'
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     watchdog_body="/bin/sh -c 'test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = \"\$1\" || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf \"%s\\n\" \"\${ruleset}\" | /usr/bin/jq -e --arg table ${table} '\"'\"'[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0'\"'\"' >/dev/null' sh \"\${netns}\""
     watchdog="${resolve} && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t \"\${pid}\" -n ${watchdog_body} && sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     printf 'WATCHDOG node=%q pod=%q uid=%q owner=%q table=%q command=%q\n' "${pod_nodes[$i]}" "${pod_names[$i]}" "${pod_uids[$i]}" "${owner}" "${table}" "${watchdog}"
   done
   for i in 0 1; do
     unit="${owner}-cleanup.service"
-    resolve="sandboxes=\"\$(sudo /usr/bin/crictl pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo /usr/bin/crictl inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
+    resolve="sandboxes=\"\$(sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q)\" && set -- \${sandboxes} && test \"\$#\" -eq 1 && sandbox=\"\$1\" && inspect=\"\$(sudo ${CRICTL} inspectp \"\${sandbox}\")\" && test \"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && pid=\"\$(printf '%s\\n' \"\${inspect}\" | /usr/bin/jq -r '.info.pid')\" && case \"\${pid}\" in ''|0|*[!0-9]*) exit 64;; esac && netns=\"\$(/usr/bin/readlink /proc/\${pid}/ns/net)\" && case \"\${netns}\" in 'net:['*']') :;; *) exit 65;; esac"
     guard="sudo /usr/bin/systemctl is-active --quiet '${unit}' && watchdog_pid=\"\$(sudo /usr/bin/systemctl show --property MainPID --value '${unit}')\" && case \"\${watchdog_pid}\" in ''|0|*[!0-9]*) exit 66;; esac && test \"\$(/usr/bin/readlink /proc/\${watchdog_pid}/ns/net)\" = \"\${netns}\""
     disruption="${resolve} && ${guard} && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null && sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
     cleanup="${resolve} && { sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t \"\${pid}\" -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
@@ -102,7 +103,7 @@ manual_cleanup() {
   printf 'MANUAL CLEANUP REQUIRED (run through an authenticated, host-key-verified node session):\n' >&2
   for i in "${!pod_nodes[@]}"; do
     printf '  node=%q command=%q\n' "${pod_nodes[$i]}" \
-      "test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
+      "test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]:-SANDBOX_ID} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]:-POD_UID}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]:-POD_SANDBOX_PID}/ns/net)\" = '${pod_netns[$i]:-NETNS_INODE}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]:-POD_SANDBOX_PID} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null" >&2
   done
 }
 
@@ -114,7 +115,7 @@ cleanup() {
   for ((position=${#attempted_indices[@]}-1; position>=0; position--)); do
     i="${attempted_indices[$position]}"
     node="${pod_nodes[$i]}"
-    command="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+    command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
     if node_exec "${node}" "${command}" >/dev/null; then
       unset 'attempted_indices[position]'
     else
@@ -235,18 +236,18 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x /usr/bin/crictl -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
-  resolve="sudo crictl pods --name '^${pod_names[$i]}$' -q"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
-  inspect="$(node_exec "${pod_nodes[$i]}" "sudo crictl inspectp ${sandbox}")"
+  inspect="$(node_exec "${pod_nodes[$i]}" "sudo ${CRICTL} inspectp ${sandbox}")"
   [[ "$(jq -r '.status.labels["io.kubernetes.pod.uid"]//empty' <<<"${inspect}")" == "${pod_uids[$i]}" ]] || die 'sandbox UID does not match selected pod'
   pid="$(jq -r '.info.pid//empty' <<<"${inspect}")"
   [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || die 'sandbox has no exact network namespace PID'
   inode="$(node_exec "${pod_nodes[$i]}" "readlink /proc/${pid}/ns/net")"
   [[ "${inode}" =~ ^net:\[[0-9]+\]$ ]] || die 'cannot prove exact pod network namespace identity'
   pod_sandboxes+=("${sandbox}"); pod_pids+=("${pid}"); pod_netns+=("${inode}")
-  collision_check="test \"\$(sudo /usr/bin/crictl inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  collision_check="test \"\$(sudo ${CRICTL} inspectp ${sandbox} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pid}/ns/net)\" = '${inode}' && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pid} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   node_exec "${pod_nodes[$i]}" "${collision_check}" >/dev/null || die 'owner table absence could not be proven'
 done
 
@@ -272,14 +273,14 @@ for i in 0 1; do
   # long-lived nsenter child pins that namespace; no delayed stored-PID lookup occurs.
   printf -v watchdog_body '%q ' /bin/sh -c "test \"\$(/usr/bin/readlink /proc/self/ns/net)\" = '${pod_netns[$i]}' || exit 70; /bin/sleep 240; /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; ruleset=\"\$(/usr/sbin/nft -j list ruleset)\" || exit 71; printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   unit="${owner}-cleanup.service"
-  watchdog="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
+  watchdog="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/systemd-run --unit '${unit%.service}' --collect /usr/bin/nsenter -t ${pod_pids[$i]} -n ${watchdog_body}"
   node_exec "${pod_nodes[$i]}" "${watchdog}" >/dev/null || die "cleanup watchdog failed on ${pod_nodes[$i]}"
   watchdog_pid="$(node_exec "${pod_nodes[$i]}" "sudo /usr/bin/systemctl is-active --quiet '${unit}' && sudo /usr/bin/systemctl show --property MainPID --value '${unit}'")" || die "cleanup watchdog is inactive on ${pod_nodes[$i]}"
   [[ "${watchdog_pid}" =~ ^[1-9][0-9]*$ ]] || die "cleanup watchdog has no live MainPID on ${pod_nodes[$i]}"
   [[ "$(node_exec "${pod_nodes[$i]}" "/usr/bin/readlink /proc/${watchdog_pid}/ns/net")" == "${pod_netns[$i]}" ]] || die "cleanup watchdog namespace mismatch on ${pod_nodes[$i]}"
 done
 for i in 0 1; do
-  install="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
+  install="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft 'add table inet ${table}; add chain inet ${table} output { type filter hook output priority -10; policy accept; }; add rule inet ${table} output udp dport { 7844, 443 } counter drop comment \"${owner}\"; add rule inet ${table} output tcp dport { 7844, 443 } counter drop comment \"${owner}\"'"
   # A transport failure is ambiguous: record the attempt before the command so EXIT cleanup tries it.
   attempted_indices+=("${i}")
   if ! node_exec "${pod_nodes[$i]}" "${install}" >/dev/null; then
@@ -310,7 +311,7 @@ if ((remaining > 0)); then sleep "${remaining}"; fi
 cleanup_failed=0
 declare -a cleanup_retry_indices=()
 for i in "${attempted_indices[@]}"; do
-  delete_and_prove="test \"\$(sudo /usr/bin/crictl inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
+  delete_and_prove="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(/usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && { sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft delete table inet ${table} 2>/dev/null || true; } && ruleset=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /usr/sbin/nft -j list ruleset)\" && printf '%s\\n' \"\${ruleset}\" | /usr/bin/jq -e --arg table '${table}' '[.nftables[]?.table? | select(.family==\"inet\" and .name==\$table)] | length == 0' >/dev/null"
   if ! node_exec "${pod_nodes[$i]}" "${delete_and_prove}" >/dev/null; then
     cleanup_failed=1
     cleanup_retry_indices+=("${i}")

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -34,7 +34,7 @@ class StatefulDrillHarness:
             "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
-            "approved_crictl": True, "legacy_crictl": True,
+            "approved_crictl": True,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -712,10 +712,7 @@ def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) ->
 
 
 def test_missing_approved_crictl_fails_before_any_mutation(tmp_path: Path) -> None:
-    # A legacy binary being present is deliberately irrelevant to the exact-path preflight.
-    harness = StatefulDrillHarness(
-        tmp_path, approved_crictl=False, legacy_crictl=True
-    )
+    harness = StatefulDrillHarness(tmp_path, approved_crictl=False)
     result = harness.run()
     assert result.returncode != 0
     assert "required remote binary path missing" in result.stderr

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -34,6 +34,7 @@ class StatefulDrillHarness:
             "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
+            "approved_crictl": True, "legacy_crictl": True,
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -172,11 +173,13 @@ elif name == "kubectl":
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
 elif name == "node-executor":
     node, command=args[0],args[1]; idx=int(node[-1])-1
-    if "test -x" in command: sys.exit(0)
+    if "test -x" in command:
+        if "test -x /usr/local/bin/crictl" not in command: sys.exit(92)
+        sys.exit(0 if state["approved_crictl"] else 1)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
-    elif command.startswith("sudo crictl inspectp"):
+    elif command.startswith("sudo /usr/local/bin/crictl inspectp"):
         out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
     elif command.startswith("readlink /proc/") or command.startswith("/usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
@@ -319,10 +322,31 @@ def test_manual_node_plan_runs_read_only_preflights_and_renders_exact_ordered_co
         assert len(associated) == 3
         assert all(f"pod=connector-{number}" in line and f"uid=uid-{number}" in line for line in associated)
         assert all("crictl\\ pods" in line and "inspectp" in line and "readlink" in line for line in associated)
+        assert all("/usr/local/bin/crictl" in line for line in associated)
     assert all("systemctl" in lines[i] and "MainPID" in lines[i] for i in disruptions)
     assert all("delete\\ table\\ inet" in lines[i] and "list\\ ruleset" in lines[i] and "length\\ ==\\ 0" in lines[i] for i in cleanups)
     assert "BLOCKED: manual-node plan only; the drill was not executed and has not passed." in result.stdout
     assert "Observability Helm revision: expected=10 observed=10" in result.stdout
+
+
+def test_only_approved_crictl_path_is_encoded_in_the_helper() -> None:
+    obsolete = "/usr/bin/" + "crictl"
+    assert "readonly CRICTL='/usr/local/bin/crictl'" in TEXT
+    assert obsolete not in TEXT
+    assert "command -v crictl" not in TEXT
+    assert "sudo crictl" not in TEXT
+    assert 'test -x ${CRICTL}' in TEXT
+
+
+def test_manual_commands_expand_the_immutable_crictl_path(tmp_path: Path) -> None:
+    result = run("--manual-node-plan", env=manual_plan_environment(tmp_path))
+    assert result.returncode == 0, result.stderr
+    command_records = [
+        line for line in result.stdout.splitlines()
+        if line.startswith(("WATCHDOG ", "DISRUPTION ", "CLEANUP "))
+    ]
+    assert len(command_records) == 6
+    assert all("/usr/local/bin/crictl" in command for command in command_records)
 
 
 def test_later_matching_observability_revision_needs_no_source_change(tmp_path: Path) -> None:
@@ -414,7 +438,7 @@ def test_wrong_context_revision_image_helm_and_ambiguous_pods_are_guarded() -> N
 
 
 def test_exact_network_namespace_resolution_is_required() -> None:
-    assert "crictl inspectp" in TEXT
+    assert "${CRICTL} inspectp" in TEXT
     assert 'io.kubernetes.pod.uid' in TEXT
     assert "readlink /proc/${pid}/ns/net" in TEXT
     assert "cannot prove exact pod network namespace identity" in TEXT
@@ -656,6 +680,58 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
     assert (harness.evidence / "interruption-metrics.json").exists()
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    result = harness.run()
+    assert result.returncode == 0, result.stderr
+    node_commands = [
+        entry["args"][1]
+        for entry in harness.commands()
+        if entry["tool"] == "node-executor"
+    ]
+    crictl_commands = [command for command in node_commands if "crictl" in command]
+    assert crictl_commands
+    assert all("/usr/local/bin/crictl" in command for command in crictl_commands)
+    assert any("test -x /usr/local/bin/crictl" in command for command in node_commands)
+    assert any("crictl pods --name" in command for command in node_commands)
+    assert any("crictl inspectp" in command and "list ruleset" in command
+               for command in node_commands)
+    assert any("crictl inspectp" in command and "systemd-run" in command
+               for command in node_commands)
+    assert any("crictl inspectp" in command and "add table inet" in command
+               for command in node_commands)
+    assert any("crictl inspectp" in command and "delete table inet" in command
+               for command in node_commands)
+
+    automatic_cleanup = TEXT.split("cleanup() {", 1)[1].split("\n}", 1)[0]
+    manual_cleanup = TEXT.split("manual_cleanup() {", 1)[1].split("\n}", 1)[0]
+    assert "sudo ${CRICTL} inspectp" in automatic_cleanup
+    assert "sudo ${CRICTL} inspectp" in manual_cleanup
+
+
+def test_missing_approved_crictl_fails_before_any_mutation(tmp_path: Path) -> None:
+    # A legacy binary being present is deliberately irrelevant to the exact-path preflight.
+    harness = StatefulDrillHarness(
+        tmp_path, approved_crictl=False, legacy_crictl=True
+    )
+    result = harness.run()
+    assert result.returncode != 0
+    assert "required remote binary path missing" in result.stderr
+    node_commands = [
+        entry["args"][1]
+        for entry in harness.commands()
+        if entry["tool"] == "node-executor"
+    ]
+    assert node_commands == [
+        next(command for command in node_commands
+             if "test -x /usr/local/bin/crictl" in command)
+    ]
+    assert not any(
+        event.get("event") in {"watchdog", "table"} for event in harness.events()
+    )
+    assert harness.current()["tables"] == [False, False]
 
 
 @pytest.mark.parametrize("expected", ["", "0", "-1", "+10", "01", " 10", "ten"])

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -34,7 +34,7 @@ class StatefulDrillHarness:
             "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
-            "approved_crictl": True,
+            "crictl_paths": ["/usr/local/bin/crictl"],
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -174,8 +174,8 @@ elif name == "kubectl":
 elif name == "node-executor":
     node, command=args[0],args[1]; idx=int(node[-1])-1
     if "test -x" in command:
-        if "test -x /usr/local/bin/crictl" not in command: sys.exit(92)
-        sys.exit(0 if state["approved_crictl"] else 1)
+        requested_path = command.split("test -x ", 1)[1].split()[0]
+        sys.exit(0 if requested_path in state["crictl_paths"] else 1)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
@@ -705,14 +705,15 @@ def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) ->
     assert any("crictl inspectp" in command and "delete table inet" in command
                for command in node_commands)
 
-    automatic_cleanup = TEXT.split("cleanup() {", 1)[1].split("\n}", 1)[0]
-    manual_cleanup = TEXT.split("manual_cleanup() {", 1)[1].split("\n}", 1)[0]
+    automatic_cleanup = TEXT.split("\ncleanup() {", 1)[1].split("\n}", 1)[0]
+    manual_cleanup = TEXT.split("\nmanual_cleanup() {", 1)[1].split("\n}", 1)[0]
     assert "sudo ${CRICTL} inspectp" in automatic_cleanup
     assert "sudo ${CRICTL} inspectp" in manual_cleanup
 
 
-def test_missing_approved_crictl_fails_before_any_mutation(tmp_path: Path) -> None:
-    harness = StatefulDrillHarness(tmp_path, approved_crictl=False)
+def test_legacy_only_crictl_fails_before_any_followup_command(tmp_path: Path) -> None:
+    legacy_path = "/usr/bin/" + "crictl"
+    harness = StatefulDrillHarness(tmp_path, crictl_paths=[legacy_path])
     result = harness.run()
     assert result.returncode != 0
     assert "required remote binary path missing" in result.stderr
@@ -729,6 +730,7 @@ def test_missing_approved_crictl_fails_before_any_mutation(tmp_path: Path) -> No
         event.get("event") in {"watchdog", "table"} for event in harness.events()
     )
     assert harness.current()["tables"] == [False, False]
+    assert harness.current()["watchdogs"] == [False, False]
 
 
 @pytest.mark.parametrize("expected", ["", "0", "-1", "+10", "01", " 10", "ten"])


### PR DESCRIPTION
### Motivation

The Cloudflare WAN dependency-loss helper hard-coded `/usr/bin/crictl`, but the selected k3s nodes provide the approved executable at `/usr/local/bin/crictl`. This caused the executor gate to fail before sandbox resolution or mutation.

Evidence:

- `/home/pi/operator-evidence/cloudflare-wan-node-executor-gate-20260810T035343Z`
- `/home/pi/operator-evidence/cloudflare-wan-executor-failure-diagnostic-20260810T035618Z`

Using one exact absolute path is safer than PATH discovery, fallbacks, or node symlinks because it fails closed instead of potentially selecting an unintended binary.

### Changes

- Added the immutable `readonly CRICTL='/usr/local/bin/crictl'` constant.
- Updated every binary preflight and generated WATCHDOG, DISRUPTION, CLEANUP, sandbox-inspection, collision-check, automatic-cleanup, manual-cleanup, and recovery command to use the approved path.
- Added focused tests proving:
  - `/usr/local/bin/crictl` is required and emitted consistently;
  - `/usr/bin/crictl`, bare `sudo crictl`, and `command -v crictl` are absent;
  - a legacy-only executable set cannot satisfy the approved-path preflight;
  - failure occurs before sandbox, namespace, watchdog, table, or disruption activity;
  - automatic and manual cleanup independently use the approved path;
  - existing offline-plan, failure, cleanup, and recovery behavior remains intact.

### Review follow-up

Copilot identified that the original test harness declared a legacy-path flag without consuming it. The final implementation replaces that flag with a path-aware executable model used by the node-executor shim. The legacy-only test now supplies only the constructed `/usr/bin/crictl` path and verifies that `/usr/local/bin/crictl` still fails closed.

The cleanup assertions were also corrected to select the top-level `cleanup()` and `manual_cleanup()` functions independently.

### Safety and scope

The change remains limited to:

- `scripts/cloudflare_wan_dependency_loss_drill.sh`
- `tests/test_cloudflare_wan_dependency_loss_drill.py`

The branch contains required merge commit `fa8f052d0a794a0e067b3175af8f8e94d589035c` and is current with `main`.

No executor, SSH session, namespace entry, systemd unit, nftables mutation, Kubernetes operation, Helm operation, production access, or live WAN drill was performed. Existing staging, approval-coordinate, image/revision, pod-identity, cleanup, Helm-history, Secret-metadata, and no-Secret-value-access safety contracts remain unchanged.

No WAN-linked issue is closed or claimed complete by this PR.

### Verification

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — passed.
- `pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — 100 passed.
- `pytest -q tests/test_cloudflare_tunnel_hardening.py tests/test_cloudflare_tunnel_token_mode.py tests/test_verify_cloudflare_tunnel.py tests/test_justfile_formatting.py` — 30 passed.
- Direct offline-plan invocation with executor and approval variables unset — passed without node access.
- Offline `just cf-tunnel-wan-dependency-loss-drill env=staging` invocation — passed.
- Obsolete-path absence and approved-path presence checks with `rg` — passed.
- `git diff --check` — passed.
- `git diff --stat` — only the two intended files are changed.
- `git diff --cached | ./scripts/scan-secrets.py` — passed.
- `pre-commit` was unavailable in the final follow-up environment; the latest-head GitHub Actions checks remain the authoritative merge gate and must complete before merge.

### PR record

- PR: https://github.com/futuroptimist/sugarkube/pull/2584
- Latest head: `9b5711d828620185a1c9a377cb6c128ec69a8017`
- Base: `main`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a794c7e19f8832f8c35de620f425066)