### PR TITLE
Fix dspace-prod-metrics-reconcile argument handling and add tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -1796,11 +1796,75 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
 dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
-    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
-      --configuration-reconciliation --environment prod \
-      --manifest '{{ manifest }}' --evidence '{{ evidence }}' \
-      --smoke-runner '{{ smoke_runner }}' --kubeconfig '{{ kubeconfig }}' \
-      --verifier '{{ verifier }}' --confirm '{{ confirm }}' --config '{{ config }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    manifest_path={{ quote(manifest) }}
+    evidence_path={{ quote(evidence) }}
+    smoke_path={{ quote(smoke_runner) }}
+    kubeconfig_path={{ quote(kubeconfig) }}
+
+    required_values=("${manifest_path}" "${evidence_path}" "${smoke_path}" "${kubeconfig_path}")
+    required_names=(manifest evidence smoke_runner kubeconfig)
+    for index in "${!required_values[@]}"; do
+      value="${required_values[index]}"
+      name="${required_names[index]}"
+      if [[ "${value}" == "${name}="* ]]; then
+        value="${value#*=}"
+      elif [[ "${value}" == *=* ]]; then
+        echo "ERROR: expected ${name}=... or a plain positional ${name} value." >&2
+        exit 2
+      fi
+      if [ -z "${value}" ]; then
+        echo "ERROR: ${name} must not be empty." >&2
+        exit 2
+      fi
+      required_values[index]="${value}"
+    done
+    manifest_path="${required_values[0]}"
+    evidence_path="${required_values[1]}"
+    smoke_path="${required_values[2]}"
+    kubeconfig_path="${required_values[3]}"
+
+    verifier_path="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
+    confirmation=''
+    config_path=''
+    optional_values=({{ quote(verifier) }} {{ quote(confirm) }} {{ quote(config) }})
+    optional_names=(verifier confirm config)
+    for index in "${!optional_values[@]}"; do
+      value="${optional_values[index]}"
+      [ -n "${value}" ] || continue
+      case "${value}" in
+        verifier=*) verifier_path="${value#verifier=}" ;;
+        confirm=*) confirmation="${value#confirm=}" ;;
+        config=*) config_path="${value#config=}" ;;
+        *=*) echo "ERROR: unexpected argument prefix in ${value%%=*}=..." >&2; exit 2 ;;
+        *)
+          case "${optional_names[index]}" in
+            verifier) verifier_path="${value}" ;;
+            confirm) confirmation="${value}" ;;
+            config) config_path="${value}" ;;
+          esac
+          ;;
+      esac
+    done
+    if [ -z "${verifier_path}" ]; then
+      echo "ERROR: verifier must not be empty." >&2
+      exit 2
+    fi
+
+    reconcile_command=(
+      python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
+      --configuration-reconciliation
+      --environment prod
+      --manifest "${manifest_path}"
+      --evidence "${evidence_path}"
+      --smoke-runner "${smoke_path}"
+      --kubeconfig "${kubeconfig_path}"
+      --verifier "${verifier_path}"
+      --confirm "${confirmation}"
+      --config "${config_path}"
+    )
+    "${reconcile_command[@]}"
 
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -46,6 +46,125 @@ def _write_executable(path: Path, body: str) -> None:
     path.chmod(0o755)
 
 
+def _run_dspace_metrics_reconcile_recipe(
+    tmp_path: Path, ensure_just_available: Path, arguments: list[str]
+) -> tuple[subprocess.CompletedProcess[str], list[str] | None]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    argv_log = tmp_path / "argv.json"
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/usr/bin/env python3
+import json
+import sys
+with open({str(argv_log)!r}, "w", encoding="utf-8") as stream:
+    json.dump(sys.argv[1:], stream)
+""",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["SUGARKUBE_TEST_CREDENTIAL"] = "metrics-credential-must-not-leak"
+    result = subprocess.run(
+        [str(ensure_just_available), "dspace-prod-metrics-reconcile", *arguments],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    argv = json.loads(argv_log.read_text(encoding="utf-8")) if argv_log.exists() else None
+    return result, argv
+
+
+def _flag_value(arguments: list[str], flag: str) -> str:
+    return arguments[arguments.index(flag) + 1]
+
+
+def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_forms(
+    tmp_path, ensure_just_available
+) -> None:
+    values = [
+        str(tmp_path / "final manifest.json"),
+        str(tmp_path / "fresh evidence.json"),
+        str(tmp_path / "smoke runner"),
+        str(tmp_path / "prod kubeconfig"),
+    ]
+    confirmation = "dspace:prod:" + "a" * 40
+    documented = [
+        f"manifest={values[0]}",
+        f"evidence={values[1]}",
+        f"smoke_runner={values[2]}",
+        f"kubeconfig={values[3]}",
+        f"confirm={confirmation}",
+    ]
+    documented_result, documented_argv = _run_dspace_metrics_reconcile_recipe(
+        tmp_path / "documented", ensure_just_available, documented
+    )
+    positional_result, positional_argv = _run_dspace_metrics_reconcile_recipe(
+        tmp_path / "positional", ensure_just_available, values + ["", confirmation]
+    )
+
+    assert documented_result.returncode == positional_result.returncode == 0
+    assert documented_argv == positional_argv
+    assert documented_argv is not None
+    assert [
+        _flag_value(documented_argv, flag)
+        for flag in ("--manifest", "--evidence", "--smoke-runner", "--kubeconfig")
+    ] == values
+    assert _flag_value(documented_argv, "--confirm") == confirmation
+    assert _flag_value(documented_argv, "--config") == ""
+    assert _flag_value(documented_argv, "--verifier") == str(
+        REPO_ROOT / "scripts/dspace_runtime_verifier.py"
+    )
+    assert all(
+        not value.startswith(("manifest=", "evidence=", "smoke_runner=", "kubeconfig="))
+        for value in documented_argv
+    )
+    assert "metrics-credential-must-not-leak" not in "\n".join(documented_argv)
+    assert "metrics-credential-must-not-leak" not in (
+        documented_result.stdout + documented_result.stderr
+    )
+
+
+def test_dspace_prod_metrics_reconcile_preserves_prefixed_verifier_and_config(
+    tmp_path, ensure_just_available
+) -> None:
+    verifier = str(tmp_path / "custom verifier")
+    config = str(tmp_path / "custom config.yaml")
+    result, argv = _run_dspace_metrics_reconcile_recipe(
+        tmp_path / "optional",
+        ensure_just_available,
+        [
+            "manifest.json",
+            "evidence.json",
+            "smoke runner",
+            "prod config",
+            f"verifier={verifier}",
+            "confirm=dspace:prod:" + "b" * 40,
+            f"config={config}",
+        ],
+    )
+
+    assert result.returncode == 0
+    assert argv is not None
+    assert _flag_value(argv, "--verifier") == verifier
+    assert _flag_value(argv, "--config") == config
+
+
+def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(
+    tmp_path, ensure_just_available
+) -> None:
+    result, argv = _run_dspace_metrics_reconcile_recipe(
+        tmp_path / "wrong-prefix",
+        ensure_just_available,
+        ["evidence=manifest.json", "evidence.json", "smoke", "kubeconfig"],
+    )
+
+    assert result.returncode == 2
+    assert argv is None
+    assert "expected manifest=" in result.stderr
+
+
 @pytest.fixture()
 def generic_app_stub_env(tmp_path: Path, ensure_just_available: Path) -> dict[str, str]:
     assert ensure_just_available.exists()


### PR DESCRIPTION
### Motivation

- The documented `just dspace-prod-metrics-reconcile manifest=... evidence=...` invocation could forward `name=` prefixes or space-containing paths directly into the Python reconciler, risking incorrect argv parsing.  The recipe must normalize and validate arguments before invoking `scripts/dspace_manifest_rollback.py` while preserving existing safety properties.

### Description

- Convert the `dspace-prod-metrics-reconcile` recipe into a safe `#!/usr/bin/env bash` shebang recipe that uses `{{ quote(...) }}` and shell arrays to construct the final command without `eval`.
- Normalize and validate required inputs (`manifest`, `evidence`, `smoke_runner`, `kubeconfig`) to accept either the documented `name=...` prefixed form or plain positional values, strip only the expected prefixes, and reject cross-prefixed or malformed values before calling Python.
- Preserve the bundled default verifier and allow optional `verifier`, `confirm`, and `config` parameters to be passed either prefixed or positionally, rejecting unexpected prefixed forms for optional slots and keeping `config` optional/empty.
- Keep the reconciler invocation and all its safety properties intact (explicit production kubeconfig, exact confirmation, fresh evidence requirement, upgrade-only behavior, no `--reuse-values`).
- Add deterministic tests in `tests/test_generic_app_just_recipes.py` that run the actual Just recipe with a stubbed `python3` to confirm: the documented prefixed form and the plain positional form produce identical clean argv; prefixed `verifier`/`config` are preserved; malformed prefixes fail before Python runs; paths with spaces remain single argv entries; and credentials do not leak into arguments or logs.

### Testing

- Ran `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile`, which passed (the new recipe-focused tests succeeded).
- Ran `pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py`, which passed (full test set containing the change succeeded).
- Verified Just formatting check with the unstable flag using `just --unstable --fmt --check`, which succeeded; note that `just --fmt --check` requires `--unstable` in this environment.
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py`, both succeeded with no trailing-whitespace or secret-detection failures; `pre-commit run --all-files` was not run because `pre-commit` is not installed in the execution environment.

No cluster, Helm, Secret, Kubernetes, or production changes were performed; documentation examples remain copy/paste-ready and unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a911a6930832fb7eececd3baa6346)