### PR TITLE
Normalize DSPACE metrics reconcile arguments (justfile + tests)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1796,11 +1796,55 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
 dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
-    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
-      --configuration-reconciliation --environment prod \
-      --manifest '{{ manifest }}' --evidence '{{ evidence }}' \
-      --smoke-runner '{{ smoke_runner }}' --kubeconfig '{{ kubeconfig }}' \
-      --verifier '{{ verifier }}' --confirm '{{ confirm }}' --config '{{ config }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    values=(
+      {{ quote(manifest) }}
+      {{ quote(evidence) }}
+      {{ quote(smoke_runner) }}
+      {{ quote(kubeconfig) }}
+      {{ quote(verifier) }}
+      {{ quote(confirm) }}
+      {{ quote(config) }}
+    )
+    prefixes=(manifest evidence smoke_runner kubeconfig verifier confirm config)
+    required=(manifest evidence smoke_runner kubeconfig verifier confirm)
+    for index in "${!values[@]}"; do
+      value="${values[index]}"
+      prefix="${prefixes[index]}"
+      if [ "${index}" = 4 ] && [[ "${value}" == confirm=* ]]; then
+        values[5]="${value#confirm=}"
+        values[4]="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
+        continue
+      fi
+      if [[ "${value}" == "${prefix}="* ]]; then
+        value="${value#${prefix}=}"
+      elif [[ "${value}" == *=* ]]; then
+        echo "ERROR: expected ${prefix}=... or a plain positional value, got '${value%%=*}=...'" >&2
+        exit 2
+      fi
+      if [[ "${value}" == *=* ]]; then
+        echo "ERROR: malformed ${prefix} argument." >&2
+        exit 2
+      fi
+      values[index]="${value}"
+    done
+    for index in "${!required[@]}"; do
+      if [ -z "${values[index]}" ]; then
+        echo "ERROR: ${required[index]} must not be empty." >&2
+        exit 2
+      fi
+    done
+
+    reconcile_command=(
+      python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
+      --configuration-reconciliation --environment prod
+      --manifest "${values[0]}" --evidence "${values[1]}"
+      --smoke-runner "${values[2]}" --kubeconfig "${values[3]}"
+      --verifier "${values[4]}" --confirm "${values[5]}" --config "${values[6]}"
+    )
+    "${reconcile_command[@]}"
 
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2958,6 +2958,120 @@ def _run_dspace_manifest_rollback(
     return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
 
 
+def _run_dspace_prod_metrics_reconcile(
+    tmp_path: Path, args: list[str]
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "metrics-reconcile-bin"
+    bin_dir.mkdir(parents=True)
+    log = tmp_path / "metrics-reconcile-argv.log"
+    _write_executable(bin_dir / "python3", f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {str(log)!r}\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = _run_just(["dspace-prod-metrics-reconcile", *args], env)
+    return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_arguments(
+    tmp_path: Path,
+) -> None:
+    values = [
+        str(tmp_path / "finalized prod evidence.json"),
+        str(tmp_path / "fresh evidence.json"),
+        str(tmp_path / "smoke runner"),
+        str(tmp_path / "production kubeconfig"),
+        "dspace:prod:" + "a" * 40,
+    ]
+    prefixed = [
+        f"{name}={value}"
+        for name, value in zip(
+            ("manifest", "evidence", "smoke_runner", "kubeconfig", "confirm"),
+            values,
+            strict=True,
+        )
+    ]
+
+    documented_result, documented_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "documented", prefixed
+    )
+    positional_result, positional_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "positional",
+        [*values[:4], str(REPO_ROOT / "scripts/dspace_runtime_verifier.py"), values[4]],
+    )
+
+    assert documented_result.returncode == 0, documented_result.stderr
+    assert positional_result.returncode == 0, positional_result.stderr
+    expected = [
+        str(REPO_ROOT / "scripts/dspace_manifest_rollback.py"),
+        "--configuration-reconciliation",
+        "--environment",
+        "prod",
+        "--manifest",
+        values[0],
+        "--evidence",
+        values[1],
+        "--smoke-runner",
+        values[2],
+        "--kubeconfig",
+        values[3],
+        "--verifier",
+        str(REPO_ROOT / "scripts/dspace_runtime_verifier.py"),
+        "--confirm",
+        values[4],
+        "--config",
+        "",
+    ]
+    assert documented_argv == expected
+    assert positional_argv == expected
+    assert all("credential" not in argument.lower() for argument in documented_argv)
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_config(
+    tmp_path: Path,
+) -> None:
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path,
+        ["manifest.json", "evidence.json", "smoke", "kubeconfig", "confirm=confirm-value"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert argv[argv.index("--verifier") + 1] == str(
+        REPO_ROOT / "scripts/dspace_runtime_verifier.py"
+    )
+    assert argv[argv.index("--config") + 1] == ""
+
+    custom_verifier = str(tmp_path / "custom verifier")
+    custom_config = str(tmp_path / "custom config.env")
+    custom_result, custom_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "custom",
+        [
+            "manifest=m.json",
+            "evidence=e.json",
+            "smoke_runner=smoke",
+            "kubeconfig=kubeconfig",
+            f"verifier={custom_verifier}",
+            "confirm=confirm-value",
+            f"config={custom_config}",
+        ],
+    )
+    assert custom_result.returncode == 0, custom_result.stderr
+    assert custom_argv[custom_argv.index("--verifier") + 1] == custom_verifier
+    assert custom_argv[custom_argv.index("--config") + 1] == custom_config
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_path: Path) -> None:
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path,
+        ["evidence=manifest.json", "evidence.json", "smoke", "kubeconfig", "confirm=confirm-value"],
+    )
+
+    assert result.returncode != 0
+    assert "expected manifest=... or a plain positional value" in result.stderr
+    assert argv == []
+
+
 @pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_recovery_staging_config_uses_production_chart_pin(
     tmp_path: Path, generic_app_stub_env: dict[str, str]


### PR DESCRIPTION
### Motivation

- Ensure the documented `just dspace-prod-metrics-reconcile manifest=... evidence=...` invocation forwards clean filesystem paths and values to `scripts/dspace_manifest_rollback.py` and reject malformed inputs before any Python runs.

### Description

- Convert `dspace-prod-metrics-reconcile` into a safely quoted shebang Bash recipe that uses Just quoting helpers and a shell `values` array (no `eval`).
- Add slot-aware normalization that strips only the allowed prefixes `manifest=`, `evidence=`, `smoke_runner=`, `kubeconfig=`, `verifier=`, `confirm=`, and `config=` while preserving positional compatibility and the bundled default verifier.
- Fail early for cross-prefixed, malformed (unexpected `=` in the wrong slot), or empty required arguments and preserve all reconciler safety properties (explicit prod kubeconfig, exact confirmation, no reuse-values behavior, etc.).
- Add deterministic tests that render/invoke the recipe and assert: the documented prefixed form and positional form produce identical clean argv, default verifier and empty config are preserved, custom verifier/config are forwarded, wrong prefixes fail before Python is invoked, paths with spaces remain single arguments, and no credential values are introduced/logged.
- Files changed: `justfile`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Ran `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile` and observed `3 passed` for the focused cases.
- Ran `pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` and observed full-suite success: `480 passed` (all tests passed in this environment).
- Ran `just --unstable --fmt --check` which completed successfully in this environment (note: formatting check requires `--unstable` for the local `just` version).
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` with no issues reported.
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in the environment (command not found), so that hook was not executed here.

Changed files (committed):
- `justfile`
- `tests/test_generic_app_just_recipes.py`

Verification commands executed (and results):
- `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile` — passed (3 tests).
- `pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — passed (480 tests).
- `just --unstable --fmt --check` — passed in this environment (note `--unstable` required locally).
- `git diff --check` — passed (no whitespace errors).
- `git diff --cached | ./scripts/scan-secrets.py` — passed (no secrets detected).
- `pre-commit run --all-files` — not run because `pre-commit` is not available in this environment.

Residual notes and risks

- The change is intentionally minimal and scoped to argument normalization and tests; no runtime reconciliation or Kubernetes operations were performed.
- Creating a pull request was not performed from this environment (no `make_pr` helper and `gh` is unauthenticated), but changes have been committed locally with message `Normalize DSPACE metrics reconcile arguments`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a911c9c24832f87a8a01a93b23c33)