### PR TITLE
Normalize DSPACE production reconcile arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -1803,9 +1803,13 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       local name="$1" value="$2" required="$3"
       if [[ "${value}" == "${name}="* ]]; then
         value="${value#"${name}="}"
-      elif [[ "${value}" == *=* ]]; then
-        echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
-        return 2
+      else
+        case "${value}" in
+          manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+            echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
+            return 2
+            ;;
+        esac
       fi
       if [[ "${required}" == true && -z "${value}" ]]; then
         echo "ERROR: ${name} must not be empty." >&2
@@ -1834,7 +1838,10 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        *=*) echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2; exit 2 ;;
+        manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
+          exit 2
+          ;;
         *) printf -v "${optional_names[index]}" '%s' "${value}" ;;
       esac
     done

--- a/justfile
+++ b/justfile
@@ -1796,11 +1796,62 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
 dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
-    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
-      --configuration-reconciliation --environment prod \
-      --manifest '{{ manifest }}' --evidence '{{ evidence }}' \
-      --smoke-runner '{{ smoke_runner }}' --kubeconfig '{{ kubeconfig }}' \
-      --verifier '{{ verifier }}' --confirm '{{ confirm }}' --config '{{ config }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    normalize_argument() {
+      local name="$1" value="$2" required="$3"
+      if [[ "${value}" == "${name}="* ]]; then
+        value="${value#"${name}="}"
+      elif [[ "${value}" == *=* ]]; then
+        echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
+        return 2
+      fi
+      if [[ "${required}" == true && -z "${value}" ]]; then
+        echo "ERROR: ${name} must not be empty." >&2
+        return 2
+      fi
+      printf '%s' "${value}"
+    }
+
+    manifest_path="$(normalize_argument manifest {{ quote(manifest) }} true)"
+    evidence_path="$(normalize_argument evidence {{ quote(evidence) }} true)"
+    smoke_path="$(normalize_argument smoke_runner {{ quote(smoke_runner) }} true)"
+    kubeconfig_path="$(normalize_argument kubeconfig {{ quote(kubeconfig) }} true)"
+    verifier_path="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
+    confirmation=''
+    config_path=''
+    optional_values=(
+      {{ quote(verifier) }}
+      {{ quote(confirm) }}
+      {{ quote(config) }}
+    )
+    optional_names=(verifier_path confirmation config_path)
+    for index in "${!optional_values[@]}"; do
+      value="${optional_values[index]}"
+      [ -n "${value}" ] || continue
+      case "${value}" in
+        verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
+        confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
+        config=*) config_path="$(normalize_argument config "${value}" false)" ;;
+        *=*) echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2; exit 2 ;;
+        *) printf -v "${optional_names[index]}" '%s' "${value}" ;;
+      esac
+    done
+
+    reconciliation_command=(
+      python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
+      --configuration-reconciliation
+      --environment prod
+      --manifest "${manifest_path}"
+      --evidence "${evidence_path}"
+      --smoke-runner "${smoke_path}"
+      --kubeconfig "${kubeconfig_path}"
+      --verifier "${verifier_path}"
+      --confirm "${confirmation}"
+      --config "${config_path}"
+    )
+    "${reconciliation_command[@]}"
 
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2958,6 +2958,87 @@ def _run_dspace_manifest_rollback(
     return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
 
 
+def _run_dspace_prod_metrics_reconcile(
+    tmp_path: Path, args: list[str]
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "reconcile-bin"
+    bin_dir.mkdir()
+    log = tmp_path / "reconcile-argv.log"
+    _write_executable(
+        bin_dir / "python3",
+        f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {str(log)!r}\n",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = _run_just(["dspace-prod-metrics-reconcile", *args], env)
+    return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+@pytest.mark.parametrize("named", [True, False])
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_forms(
+    tmp_path: Path, named: bool
+) -> None:
+    values = {
+        "manifest": str(tmp_path / "finalized manifest.json"),
+        "evidence": str(tmp_path / "fresh evidence.json"),
+        "smoke_runner": str(tmp_path / "smoke runner"),
+        "kubeconfig": str(tmp_path / "production kubeconfig"),
+        "verifier": str(tmp_path / "runtime verifier"),
+        "confirm": "dspace:prod:0123456789abcdef0123456789abcdef01234567",
+        "config": str(tmp_path / "production config.env"),
+    }
+    args = [f"{name}={value}" if named else value for name, value in values.items()]
+
+    result, argv = _run_dspace_prod_metrics_reconcile(tmp_path, args)
+
+    assert result.returncode == 0, result.stderr
+    for name, value in values.items():
+        option = f"--{name.replace('_', '-')}"
+        assert argv[argv.index(option) + 1] == value
+    assert not any(value.startswith(tuple(f"{name}=" for name in values)) for value in argv)
+    assert not any("token" in value.lower() or "credential" in value.lower() for value in argv)
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_config(
+    tmp_path: Path,
+) -> None:
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path,
+        [
+            "manifest=/tmp/manifest.json",
+            "evidence=/tmp/evidence.json",
+            "smoke_runner=/tmp/smoke-runner",
+            "kubeconfig=/tmp/kubeconfig",
+            "confirm=dspace:prod:0123456789abcdef0123456789abcdef01234567",
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert argv[argv.index("--verifier") + 1] == str(
+        REPO_ROOT / "scripts/dspace_runtime_verifier.py"
+    )
+    assert argv[argv.index("--config") + 1] == ""
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_path: Path) -> None:
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path,
+        [
+            "evidence=/tmp/manifest.json",
+            "/tmp/evidence.json",
+            "/tmp/smoke-runner",
+            "/tmp/kubeconfig",
+        ],
+    )
+
+    assert result.returncode != 0
+    assert "manifest must be positional or use the manifest= prefix" in result.stderr
+    assert argv == []
+
+
 @pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_recovery_staging_config_uses_production_chart_pin(
     tmp_path: Path, generic_app_stub_env: dict[str, str]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2980,13 +2980,13 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
     tmp_path: Path, named: bool
 ) -> None:
     values = {
-        "manifest": str(tmp_path / "finalized manifest.json"),
-        "evidence": str(tmp_path / "fresh evidence.json"),
-        "smoke_runner": str(tmp_path / "smoke runner"),
-        "kubeconfig": str(tmp_path / "production kubeconfig"),
-        "verifier": str(tmp_path / "runtime verifier"),
-        "confirm": "dspace:prod:0123456789abcdef0123456789abcdef01234567",
-        "config": str(tmp_path / "production config.env"),
+        "manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "evidence": str(tmp_path / "fresh evidence=run-42.json"),
+        "smoke_runner": str(tmp_path / "smoke runner=production"),
+        "kubeconfig": str(tmp_path / "production kubeconfig=primary"),
+        "verifier": str(tmp_path / "runtime verifier=v2"),
+        "confirm": "dspace:prod:revision=0123456789abcdef0123456789abcdef01234567",
+        "config": str(tmp_path / "production config=final.env"),
     }
     args = [f"{name}={value}" if named else value for name, value in values.items()]
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2959,10 +2959,10 @@ def _run_dspace_manifest_rollback(
 
 
 def _run_dspace_prod_metrics_reconcile(
-    tmp_path: Path, args: list[str]
+    tmp_path: Path, args: list[str], env_overrides: dict[str, str] | None = None
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     bin_dir = tmp_path / "reconcile-bin"
-    bin_dir.mkdir()
+    bin_dir.mkdir(parents=True)
     log = tmp_path / "reconcile-argv.log"
     _write_executable(
         bin_dir / "python3",
@@ -2970,14 +2970,14 @@ def _run_dspace_prod_metrics_reconcile(
     )
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env.update(env_overrides or {})
     result = _run_just(["dspace-prod-metrics-reconcile", *args], env)
     return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
 
 
-@pytest.mark.parametrize("named", [True, False])
 @pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_forms(
-    tmp_path: Path, named: bool
+    tmp_path: Path,
 ) -> None:
     values = {
         "manifest": str(tmp_path / "finalized manifest=approved.json"),
@@ -2988,16 +2988,30 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
         "confirm": "dspace:prod:revision=0123456789abcdef0123456789abcdef01234567",
         "config": str(tmp_path / "production config=final.env"),
     }
-    args = [f"{name}={value}" if named else value for name, value in values.items()]
+    credential_sentinel = "reconcile-test-credential-7eaf21c9"
+    environment = {"DSPACE_TEST_CREDENTIAL": credential_sentinel}
+    named_args = [f"{name}={value}" for name, value in values.items()]
+    positional_args = list(values.values())
 
-    result, argv = _run_dspace_prod_metrics_reconcile(tmp_path, args)
+    named_result, named_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "named", named_args, environment
+    )
+    positional_result, positional_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "positional", positional_args, environment
+    )
 
-    assert result.returncode == 0, result.stderr
+    assert named_result.returncode == 0, named_result.stderr
+    assert positional_result.returncode == 0, positional_result.stderr
+    assert named_argv == positional_argv
     for name, value in values.items():
         option = f"--{name.replace('_', '-')}"
-        assert argv[argv.index(option) + 1] == value
-    assert not any(value.startswith(tuple(f"{name}=" for name in values)) for value in argv)
-    assert not any("token" in value.lower() or "credential" in value.lower() for value in argv)
+        assert named_argv[named_argv.index(option) + 1] == value
+    prefixes = tuple(f"{name}=" for name in values)
+    assert not any(value.startswith(prefixes) for value in named_argv)
+    for result in (named_result, positional_result):
+        assert credential_sentinel not in result.stdout
+        assert credential_sentinel not in result.stderr
+    assert credential_sentinel not in named_argv
 
 
 @pytest.mark.usefixtures("ensure_just_available")


### PR DESCRIPTION
### Motivation
- The `dspace-prod-metrics-reconcile` just recipe forwarded documented `name=value` tokens literally, causing arguments such as `manifest=/path/file.json` to be passed to the Python reconciler instead of clean paths.
- Make the documented `just dspace-prod-metrics-reconcile manifest=... evidence=...` invocation reliably pass safe, single argv values while preserving backwards compatibility with plain positional arguments.

### Description
- Convert `dspace-prod-metrics-reconcile` into a Bash shebang recipe and add a `normalize_argument` helper that only strips the expected prefixes (`manifest=`, `evidence=`, `smoke_runner=`, `kubeconfig=`, `verifier=`, `confirm=`, `config=`) and rejects malformed or cross-prefixed inputs before Python is invoked. (files changed: `justfile`).
- Preserve the bundled default verifier, allow an optional empty `config`, maintain safe quoting and a shell-array invocation for the Python rollback helper, and avoid use of `eval`. (file changed: `justfile`).
- Add deterministic tests that render/invoke the recipe and assert documented prefixed form and plain positional form forward identical, clean argv, check default verifier and empty config behavior, reject wrong prefixes early, and ensure paths containing spaces remain single arguments. (file changed: `tests/test_generic_app_just_recipes.py`).

### Testing
- Ran `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile` which completed with `4 passed, 419 deselected` and no regressions.\
- Ran `pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` which completed successfully with `481 passed`.\
- Ran formatting checks `just --unstable --fmt --check` which succeeded; `just --fmt --check` without `--unstable` is not available in this environment.\
- Ran repository validation steps `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` which reported no issues.\
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in the execution environment (environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a910bdf84832f9fba7b8a3e36f453)