### PR TITLE
Normalize dspace-prod-metrics-reconcile arguments and add deterministic tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -1796,11 +1796,62 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
 dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
-    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
-      --configuration-reconciliation --environment prod \
-      --manifest '{{ manifest }}' --evidence '{{ evidence }}' \
-      --smoke-runner '{{ smoke_runner }}' --kubeconfig '{{ kubeconfig }}' \
-      --verifier '{{ verifier }}' --confirm '{{ confirm }}' --config '{{ config }}'
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    required_values=({{ quote(manifest) }} {{ quote(evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }})
+    required_names=(manifest evidence smoke_runner kubeconfig)
+    for index in "${!required_values[@]}"; do
+      value="${required_values[index]}"
+      name="${required_names[index]}"
+      if [[ "${value}" == "${name}="* ]]; then value="${value#*=}"; fi
+      if [[ -z "${value}" || "${value}" == *=* ]]; then
+        printf 'ERROR: %s must be a non-empty value or use the %s= prefix.\n' "${name}" "${name}" >&2
+        exit 2
+      fi
+      required_values[index]="${value}"
+    done
+
+    verifier_path="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py"
+    confirmation=''
+    config_path=''
+    optional_values=({{ quote(verifier) }} {{ quote(confirm) }} {{ quote(config) }})
+    optional_names=(verifier_path confirmation config_path)
+    optional_prefixes=(verifier confirm config)
+    for index in "${!optional_values[@]}"; do
+      value="${optional_values[index]}"
+      [ -n "${value}" ] || continue
+      matched=false
+      for prefix_index in "${!optional_prefixes[@]}"; do
+        prefix="${optional_prefixes[prefix_index]}"
+        if [[ "${value}" == "${prefix}="* ]]; then
+          value="${value#*=}"
+          if [[ -z "${value}" && "${prefix}" != config ]]; then
+            printf 'ERROR: %s must not be empty.\n' "${prefix}" >&2
+            exit 2
+          fi
+          printf -v "${optional_names[prefix_index]}" '%s' "${value}"
+          matched=true
+          break
+        fi
+      done
+      if ! ${matched}; then
+        if [[ "${value}" == *=* ]]; then
+          printf 'ERROR: argument %s has an unexpected prefix.\n' "$((index + 5))" >&2
+          exit 2
+        fi
+        printf -v "${optional_names[index]}" '%s' "${value}"
+      fi
+    done
+
+    rollback_command=(
+      python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
+      --configuration-reconciliation --environment prod
+      --manifest "${required_values[0]}" --evidence "${required_values[1]}"
+      --smoke-runner "${required_values[2]}" --kubeconfig "${required_values[3]}"
+      --verifier "${verifier_path}" --confirm "${confirmation}" --config "${config_path}"
+    )
+    "${rollback_command[@]}"
 
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -24,6 +24,106 @@ from scripts.app_verify import base_url_from_host, tokenplace_meta_failure
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _run_dspace_prod_metrics_reconcile(
+    tmp_path: Path, ensure_just_available: Path, arguments: list[str]
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    argv_log = tmp_path / "argv.json"
+    _write_executable(
+        bin_dir / "python3",
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "open(os.environ['ARGV_LOG'], 'w', encoding='utf-8').write(json.dumps(sys.argv[1:]))\n",
+    )
+    env = os.environ | {"PATH": f"{bin_dir}:{os.environ['PATH']}", "ARGV_LOG": str(argv_log)}
+    result = subprocess.run(
+        [str(ensure_just_available), "dspace-prod-metrics-reconcile", *arguments],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, json.loads(argv_log.read_text(encoding="utf-8")) if argv_log.exists() else []
+
+
+def _reconcile_values(tmp_path: Path) -> list[str]:
+    return [
+        str(tmp_path / "approved manifest.json"),
+        str(tmp_path / "fresh evidence.json"),
+        str(tmp_path / "smoke runner"),
+        str(tmp_path / "prod kubeconfig"),
+    ]
+
+
+def test_dspace_prod_metrics_reconcile_documented_and_positional_forms_match(
+    tmp_path: Path, ensure_just_available: Path
+) -> None:
+    values = _reconcile_values(tmp_path)
+    documented = [
+        f"manifest={values[0]}",
+        f"evidence={values[1]}",
+        f"smoke_runner={values[2]}",
+        f"kubeconfig={values[3]}",
+        "confirm=dspace:prod:" + "a" * 40,
+    ]
+    documented_result, documented_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "documented", ensure_just_available, documented
+    )
+    positional_result, positional_argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "positional",
+        ensure_just_available,
+        [*values, str(REPO_ROOT / "scripts/dspace_runtime_verifier.py"), documented[-1][8:], ""],
+    )
+
+    assert documented_result.returncode == positional_result.returncode == 0
+    assert documented_argv == positional_argv
+    assert documented_argv[documented_argv.index("--verifier") + 1] == str(
+        REPO_ROOT / "scripts/dspace_runtime_verifier.py"
+    )
+    assert documented_argv[documented_argv.index("--config") + 1] == ""
+    for value in values:
+        assert value in documented_argv
+    assert not any(
+        argument.startswith(("manifest=", "evidence=", "smoke_runner=", "kubeconfig="))
+        for argument in documented_argv
+    )
+
+
+def test_dspace_prod_metrics_reconcile_preserves_optional_verifier_and_config(
+    tmp_path: Path, ensure_just_available: Path
+) -> None:
+    values = _reconcile_values(tmp_path)
+    verifier = str(tmp_path / "custom verifier")
+    config = str(tmp_path / "optional config.json")
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "optional",
+        ensure_just_available,
+        [*values, f"verifier={verifier}", "confirm=confirmed", f"config={config}"],
+    )
+
+    assert result.returncode == 0
+    assert argv[argv.index("--verifier") + 1] == verifier
+    assert argv[argv.index("--config") + 1] == config
+    assert argv[argv.index("--confirm") + 1] == "confirmed"
+
+
+def test_dspace_prod_metrics_reconcile_rejects_wrong_required_prefix_before_python(
+    tmp_path: Path, ensure_just_available: Path
+) -> None:
+    values = _reconcile_values(tmp_path)
+    result, argv = _run_dspace_prod_metrics_reconcile(
+        tmp_path / "wrong-prefix",
+        ensure_just_available,
+        [f"evidence={values[0]}", *values[1:]],
+    )
+
+    assert result.returncode == 2
+    assert argv == []
+    assert "manifest must be a non-empty value or use the manifest= prefix" in result.stderr
+
+
 def _release_deployment(app: str, body: str = "") -> str:
     container = "relay" if app == "tokenplace" else app
     return f"""apiVersion: apps/v1


### PR DESCRIPTION
### Motivation
- The documented `just dspace-prod-metrics-reconcile manifest=... evidence=... smoke_runner=... kubeconfig=... confirm=...` form could forward `name=` prefixes into the Python reconciler; the recipe must pass clean paths/values. 
- Keep backwards compatibility with positional parameters while ensuring malformed or cross-prefixed inputs are rejected before any Python/production logic runs.

### Description
- Converted `dspace-prod-metrics-reconcile` into a safely quoted `#!/usr/bin/env bash` recipe that uses `{{ quote(...) }}` and shell arrays to build the argv list. 
- Added explicit parsing that accepts either the documented `name=value` prefixes or plain positional values, strips only the expected prefixes (`manifest=`, `evidence=`, `smoke_runner=`, `kubeconfig=`, `verifier=`, `confirm=`, `config=`), and rejects empty, cross-prefixed, or malformed required arguments before invoking Python. 
- Preserved the default bundled verifier and optional empty `config`, avoided `eval`, and continued to forward all safety-critical flags (`--kubeconfig`, `--confirm`, `--verifier`, `--smoke-runner`, etc.) exactly as the reconciler expects. 
- Added deterministic tests that stub `python3` to capture the final argv and verify: documented and positional forms produce identical clean argv; optional `verifier` and `config` behavior is preserved; wrong prefixes fail early; paths with spaces remain single arguments. 
- Files changed: `justfile`, `tests/test_generic_app_just_recipes.py`.

### Testing
- Ran the focused recipe tests: `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile` — result: `3 passed, 419 deselected`.
- Ran the narrow combined tests: `pytest -q tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — result: `480 passed` (full run of those test sets completed successfully).
- Verified `just` formatting check: `just --fmt --check` requires the unstable flag in this environment; `just --unstable --fmt --check` was run and completed without error for the changed recipe.
- Secrets and staged-diff checks: `git diff --cached | ./scripts/scan-secrets.py` returned clean for the staged changes.
- `pre-commit run --all-files` was executed but flagged unrelated repository-wide YAML/lint issues outside the scope of this change; those pre-existing failures are unrelated to the two modified files and were not changed here.

All automated tests added for this change passed; the recipe now reliably forwards clean values to `scripts/dspace_manifest_rollback.py` and rejects malformed inputs before Python runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a91211784832f9cb7e61e80ab3883)