### PR TITLE
Fix Cloudflare WAN drill: require per-pod /ready==503+0, exclude resourceVersion from Deployment fingerprint, and record JSONL evidence

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -567,19 +567,41 @@ part of this rollout.
    privileged namespace operation, and rejects an ambiguous sandbox or pre-existing owner table. Each
    transient watchdog enters and holds the validated namespace before disruption, avoiding delayed PID
    reuse, and all watchdog binary paths are preflighted on both affected nodes. It then proves the
-   original UIDs become NotReady with zero HA connections and
-   unchanged restart counts. Cleanup deletes only the exact owner table, including after signals and
-   partial or ambiguously reported setup. A node remains cleanup-eligible until both exact deletion and
+   original UIDs become NotReady with unchanged restart counts, while an identity-guarded query of
+   each original process's `/ready` endpoint from its validated network namespace returns HTTP 503
+   and a sanitized `readyConnections: 0`. Both Prometheus targets must remain up. The helper records
+   the HA gauge as supporting evidence, but does not require it to reach zero: cloudflared 2026.7.3
+   increments that gauge when a `Serve` attempt starts and decrements it only when the attempt returns,
+   so one retrying attempt per connector can leave an aggregate value of two after connected edge
+   sessions have reached zero. Every interruption poll is appended to sanitized JSONL, including on
+   failure; connector IDs and raw readiness responses are never retained. Cleanup deletes only the
+   exact owner table, including after signals and partial or ambiguously reported setup. A node
+   remains cleanup-eligible until both exact deletion and
    table absence are proven; normal-cleanup failure leaves it available to the EXIT retry. Failure to
    prove automatic cleanup fails closed and prints exact UID/inode-guarded, node-specific manual cleanup
    commands. The disruption is limited to three minutes, below the shortest five-minute alert threshold.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
    Helm histories, including the single deployed observability release at the explicitly approved
-   revision, Secret metadata, and Deployment state must be unchanged; and
+   revision, Secret metadata, and Deployment desired/ownership state (UID, generation, labels,
+   annotations, and spec) must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.
+
+   The Deployment `resourceVersion` may advance during status-only readiness reconciliation and is
+   therefore recorded as evidence rather than included in the desired-state fingerprint. Final
+   `status.observedGeneration` must still equal the unchanged generation.
+
+   On August 11, 2026, the first authorized execution of the namespace-local drill safely cleaned up
+   after the old helper rejected the real HA floor of two. Both original pods became NotReady without
+   UID or restart changes, their two metrics targets stayed up, and subsequent reconciliation proved
+   the exact nftables tables and watchdog units absent, both original connectors healthy, all 16
+   staging endpoints HTTP 200, unchanged Helm histories and Secret metadata, and a passing repository
+   verifier. This was a **failed proof contract**, not a passing drill and not evidence for #2407.
+   A live retry requires this fix to be merged, a fresh read-only gate, newly approved exact main and
+   observability revisions, and separate explicit staging authorization. Production remains out of
+   scope, and no Helm deployment is required for this helper-only correction.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -10,7 +10,7 @@ readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
 readonly NODE_CURL='/usr/bin/curl'
-readonly DISRUPTION_SECONDS=180
+readonly DISRUPTION_SECONDS="$([[ "${CF_DRILL_APPROVED_REVISION:-}" == approved && "${CF_DRILL_TEST_DISRUPTION_SECONDS:-}" =~ ^[1-9][0-9]*$ ]] && printf '%s' "${CF_DRILL_TEST_DISRUPTION_SECONDS}" || printf 180)"
 readonly RECOVERY_SECONDS=300
 
 execute=0
@@ -238,7 +238,7 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${NODE_CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${NODE_CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /usr/bin/sed -a -x /usr/bin/tail -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
   resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
@@ -291,9 +291,9 @@ for i in 0 1; do
 done
 
 disruption_started="${SECONDS}"
-deadline=$((SECONDS+90)); interrupted=0
+proof_deadline=$((SECONDS+90)); disruption_deadline=$((disruption_started+DISRUPTION_SECONDS)); interrupted=0
 : >"${evidence_dir}/interruption-observations.jsonl"
-while ((SECONDS < deadline)); do
+while ((SECONDS < disruption_deadline)); do
   current="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
   unchanged="$(jq --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" --argjson r0 "${pod_restarts[0]}" --argjson r1 "${pod_restarts[1]}" '
     [.items[]|select(.metadata.deletionTimestamp==null)] as $p | ($p|length)==2 and
@@ -301,7 +301,7 @@ while ((SECONDS < deadline)); do
     all($p[];([.status.containerStatuses[].restartCount]|add)==(if .metadata.uid==$u0 then $r0 else $r1 end))' <<<"${current}")"
   declare -a ready_observations=(); readiness_valid=1
   for i in 0 1; do
-    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n ${NODE_CURL} -sS --max-time 5 -w '\\n%{http_code}\\n' http://127.0.0.1:2000/ready | /bin/sh -c 'IFS= read -r body && IFS= read -r status && printf \"%s\\n\" \"\$body\" | /usr/bin/jq -c --argjson httpStatus \"\$status\" '\"'\"'{httpStatus:\$httpStatus,readyConnections:(.readyConnections | select(type==\"number\" and .>=0))}'\"'\"''"
+    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && response=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n ${NODE_CURL} -sS --max-time 5 -w '\\n%{http_code}' http://127.0.0.1:2000/ready)\" && status=\"\$(printf '%s\\n' \"\${response}\" | /usr/bin/tail -n 1)\" && body=\"\$(printf '%s\\n' \"\${response}\" | /usr/bin/sed '\$d')\" && printf '%s\\n' \"\${body}\" | /usr/bin/jq -c --argjson httpStatus \"\${status}\" '{httpStatus:\$httpStatus,readyConnections:(.readyConnections | select(type==\"number\" and .>=0))}'"
     observation="$(node_exec "${pod_nodes[$i]}" "${ready_command}")" || observation=''
     if ! /usr/bin/jq -e 'keys==["httpStatus","readyConnections"] and (.httpStatus|type)=="number" and (.readyConnections|type)=="number"' <<<"${observation}" >/dev/null 2>&1; then
       observation='{"httpStatus":null,"readyConnections":null}'
@@ -309,22 +309,23 @@ while ((SECONDS < deadline)); do
     fi
     ready_observations+=("${observation}")
   done
-  targets="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"-1"')"
-  ha="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')"
+  prometheus_valid=1
+  if ! targets="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -er '.data.result[0].value[1] | tonumber')"; then targets=null; prometheus_valid=0; fi
+  if ! ha="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -er '.data.result[0].value[1] | tonumber')"; then ha=null; prometheus_valid=0; fi
   jq -nc --argjson elapsed "$((SECONDS-disruption_started))" --argjson pods "$(jq -c --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" '[.items[]|select(.metadata.uid==$u0 or .metadata.uid==$u1)|{uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")|.status][0]//null)}] | sort_by(.uid)' <<<"${current}")" --argjson r0 "${ready_observations[0]}" --argjson r1 "${ready_observations[1]}" --argjson targets "${targets}" --argjson ha "${ha}" '{schemaVersion:1,elapsedSeconds:$elapsed,pods:$pods,readiness:[$r0,$r1],prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
   ((readiness_valid)) || die 'connector readiness endpoint was unavailable or malformed'
+  ((prometheus_valid)) || die 'Prometheus observation was unavailable or malformed during interruption'
   [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
   [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
-  if [[ "${same}" == true ]] && /usr/bin/jq -e 'all(.[];.httpStatus==503 and .readyConnections==0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then interrupted=1; break; fi
+  if [[ "${same}" == true ]] && /usr/bin/jq -e 'all(.[];.httpStatus==503 and .readyConnections==0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then interrupted=1; fi
   if [[ "${same}" == true ]] && /usr/bin/jq -e 'any(.[];.readyConnections>0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then
     die 'did not prove same-process NotReady and zero ready connections'
   fi
+  ((interrupted || SECONDS < proof_deadline)) || die 'did not prove same-process NotReady and zero ready connections'
   sleep 5
 done
 ((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
-remaining=$((DISRUPTION_SECONDS-(SECONDS-disruption_started)))
-if ((remaining > 0)); then sleep "${remaining}"; fi
 
 # Remove only the two exact drill-owned tables now; EXIT cleanup remains a second attempt.
 cleanup_failed=0

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -309,15 +309,16 @@ while ((SECONDS < disruption_deadline)); do
     fi
     ready_observations+=("${observation}")
   done
-  prometheus_valid=1
-  if ! targets="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -er '.data.result[0].value[1] | tonumber')"; then targets=null; prometheus_valid=0; fi
-  if ! ha="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -er '.data.result[0].value[1] | tonumber')"; then ha=null; prometheus_valid=0; fi
+  targets_valid=1; ha_valid=1
+  if ! targets="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -er '.data.result[0].value[1] | tonumber | select(. >= 0)')"; then targets=null; targets_valid=0; fi
+  if ! ha="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -er '.data.result[0].value[1] | tonumber | select(. >= 0)')"; then ha=null; ha_valid=0; fi
   jq -nc --argjson elapsed "$((SECONDS-disruption_started))" --argjson pods "$(jq -c --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" '[.items[]|select(.metadata.uid==$u0 or .metadata.uid==$u1)|{uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")|.status][0]//null)}] | sort_by(.uid)' <<<"${current}")" --argjson r0 "${ready_observations[0]}" --argjson r1 "${ready_observations[1]}" --argjson targets "${targets}" --argjson ha "${ha}" '{schemaVersion:1,elapsedSeconds:$elapsed,pods:$pods,readiness:[$r0,$r1],prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
   ((readiness_valid)) || die 'connector readiness endpoint was unavailable or malformed'
-  ((prometheus_valid)) || die 'Prometheus observation was unavailable or malformed during interruption'
+  ((targets_valid)) || die 'Prometheus target observation was unavailable or malformed during interruption'
+  [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
+  ((ha_valid)) || die 'Prometheus HA observation was unavailable or malformed during interruption'
   [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
   if [[ "${same}" == true ]] && /usr/bin/jq -e 'all(.[];.httpStatus==503 and .readyConnections==0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then interrupted=1; fi
   if [[ "${same}" == true ]] && /usr/bin/jq -e 'any(.[];.readyConnections>0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then
     die 'did not prove same-process NotReady and zero ready connections'

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -10,7 +10,11 @@ readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
 readonly NODE_CURL='/usr/bin/curl'
-readonly DISRUPTION_SECONDS="$([[ "${CF_DRILL_APPROVED_REVISION:-}" == approved && "${CF_DRILL_TEST_DISRUPTION_SECONDS:-}" =~ ^[1-9][0-9]*$ ]] && printf '%s' "${CF_DRILL_TEST_DISRUPTION_SECONDS}" || printf 180)"
+DISRUPTION_SECONDS=180
+if [[ "${CF_DRILL_APPROVED_REVISION:-}" == approved && "${CF_DRILL_TEST_DISRUPTION_SECONDS:-}" =~ ^[1-9][0-9]*$ ]]; then
+  DISRUPTION_SECONDS="${CF_DRILL_TEST_DISRUPTION_SECONDS}"
+fi
+readonly DISRUPTION_SECONDS
 readonly RECOVERY_SECONDS=300
 
 execute=0
@@ -318,13 +322,24 @@ while ((SECONDS < disruption_deadline)); do
   [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
   ((ha_valid)) || die 'Prometheus HA observation was unavailable or malformed during interruption'
   [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
-  same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  if [[ "${same}" == true ]] && /usr/bin/jq -e 'all(.[];.httpStatus==503 and .readyConnections==0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then interrupted=1; fi
-  if [[ "${same}" == true ]] && /usr/bin/jq -e 'any(.[];.readyConnections>0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then
-    die 'did not prove same-process NotReady and zero ready connections'
+  outage_observed=0
+  if jq -e --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" '
+      [.items[] | select(.metadata.uid==$u0 or .metadata.uid==$u1)] as $p |
+      ($p|length)==2 and all($p[]; any(.status.conditions[]?; .type=="Ready" and .status=="False"))
+    ' <<<"${current}" >/dev/null &&
+    /usr/bin/jq -e 'length==2 and all(.[];.httpStatus==503 and .readyConnections==0)' \
+      <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then
+    outage_observed=1
   fi
+  if ((interrupted && !outage_observed)); then
+    die 'same-process NotReady and zero ready connections did not persist throughout disruption'
+  fi
+  ((outage_observed)) && interrupted=1
   ((interrupted || SECONDS < proof_deadline)) || die 'did not prove same-process NotReady and zero ready connections'
-  sleep 5
+  remaining=$((disruption_deadline-SECONDS))
+  if ((remaining > 0)); then
+    sleep $((remaining < 5 ? remaining : 5))
+  fi
 done
 ((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
 

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -9,6 +9,7 @@ readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
+readonly NODE_CURL='/usr/bin/curl'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -186,7 +187,8 @@ jq -e --arg image "${EXPECTED_IMAGE}" '
  and .spec.template.spec.containers[0].readinessProbe.httpGet.path=="/ready"
  and .spec.template.spec.containers[0].readinessProbe.httpGet.port==2000
 ' <<<"${deployment}" >/dev/null || die 'Deployment ownership, replicas, immutable image is not approved, or probe lifecycle is unsafe'
-deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_generation="$(jq -r '.metadata.generation' <<<"${deployment}")"
 
 # Reuse the repository verifier's complete strategy/topology/probe contract before mutation.
 just cf-tunnel-verify env=staging
@@ -236,7 +238,7 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${NODE_CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
   resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
@@ -290,20 +292,37 @@ done
 
 disruption_started="${SECONDS}"
 deadline=$((SECONDS+90)); interrupted=0
+: >"${evidence_dir}/interruption-observations.jsonl"
 while ((SECONDS < deadline)); do
   current="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
   unchanged="$(jq --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" --argjson r0 "${pod_restarts[0]}" --argjson r1 "${pod_restarts[1]}" '
     [.items[]|select(.metadata.deletionTimestamp==null)] as $p | ($p|length)==2 and
     ([$p[].metadata.uid]|sort)==([$u0,$u1]|sort) and
     all($p[];([.status.containerStatuses[].restartCount]|add)==(if .metadata.uid==$u0 then $r0 else $r1 end))' <<<"${current}")"
+  declare -a ready_observations=(); readiness_valid=1
+  for i in 0 1; do
+    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n ${NODE_CURL} -sS --max-time 5 -w '\\n%{http_code}\\n' http://127.0.0.1:2000/ready | /bin/sh -c 'IFS= read -r body && IFS= read -r status && printf \"%s\\n\" \"\$body\" | /usr/bin/jq -c --argjson httpStatus \"\$status\" '\"'\"'{httpStatus:\$httpStatus,readyConnections:(.readyConnections | select(type==\"number\" and .>=0))}'\"'\"''"
+    observation="$(node_exec "${pod_nodes[$i]}" "${ready_command}")" || observation=''
+    if ! /usr/bin/jq -e 'keys==["httpStatus","readyConnections"] and (.httpStatus|type)=="number" and (.readyConnections|type)=="number"' <<<"${observation}" >/dev/null 2>&1; then
+      observation='{"httpStatus":null,"readyConnections":null}'
+      readiness_valid=0
+    fi
+    ready_observations+=("${observation}")
+  done
+  targets="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' | jq -r '.data.result[0].value[1]//"-1"')"
+  ha="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')"
+  jq -nc --argjson elapsed "$((SECONDS-disruption_started))" --argjson pods "$(jq -c --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" '[.items[]|select(.metadata.uid==$u0 or .metadata.uid==$u1)|{uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")|.status][0]//null)}] | sort_by(.uid)' <<<"${current}")" --argjson r0 "${ready_observations[0]}" --argjson r1 "${ready_observations[1]}" --argjson targets "${targets}" --argjson ha "${ha}" '{schemaVersion:1,elapsedSeconds:$elapsed,pods:$pods,readiness:[$r0,$r1],prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
+  ((readiness_valid)) || die 'connector readiness endpoint was unavailable or malformed'
   [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  [[ "${same}" == true ]] || { sleep 5; continue; }
-  [[ "$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')" == 0 ]] && { interrupted=1; break; }
+  [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
+  if [[ "${same}" == true ]] && /usr/bin/jq -e 'all(.[];.httpStatus==503 and .readyConnections==0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then interrupted=1; break; fi
+  if [[ "${same}" == true ]] && /usr/bin/jq -e 'any(.[];.readyConnections>0)' <<<"$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" >/dev/null; then
+    die 'did not prove same-process NotReady and zero ready connections'
+  fi
   sleep 5
 done
-((interrupted)) || die 'did not prove same-process NotReady and zero HA connections'
-prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' >"${evidence_dir}/interruption-metrics.json"
+((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
 remaining=$((DISRUPTION_SECONDS-(SECONDS-disruption_started)))
 if ((remaining > 0)); then sleep "${remaining}"; fi
 
@@ -345,6 +364,7 @@ recovery_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json
 validate_observability_history "${recovery_obs_history}" 'post-cleanup'
 [[ "${recovery_obs_history}" == "${obs_history}" ]] || die "observability Helm history changed (expected deployed revision ${expected_observability_revision}; observed ${observed_observability_revision})"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
-[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
+[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment desired state or ownership changed'
+[[ "$(jq -r '.status.observedGeneration' <<<"${final_deployment}")" == "${deployment_generation}" ]] || die 'Deployment observedGeneration does not match unchanged generation'
 just cf-tunnel-verify env=staging
 printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -26,6 +26,7 @@ class StatefulDrillHarness:
 
     def __init__(self, tmp_path: Path, **overrides: object) -> None:
         self.root = tmp_path
+        self.root.mkdir(parents=True, exist_ok=True)
         self.state = tmp_path / "state.json"
         self.log = tmp_path / "commands.jsonl"
         self.evidence = tmp_path / "evidence"
@@ -35,9 +36,13 @@ class StatefulDrillHarness:
             "obs_revision": 10, "obs_deployed_entries": 1, "obs_revision_after_cleanup": None,
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
-            "crictl_paths": ["/usr/local/bin/crictl"],
+            "binary_paths": ["/usr/local/bin/crictl", "/usr/bin/curl", "/usr/bin/jq",
+                             "/usr/bin/readlink", "/usr/bin/nsenter", "/usr/bin/systemd-run",
+                             "/usr/bin/systemctl", "/usr/bin/sed", "/usr/bin/tail",
+                             "/bin/sh", "/bin/sleep", "/usr/sbin/nft"],
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "ready_connections": [0, 0], "ready_malformed": -1, "metrics_targets_during": 2,
+            "prometheus_failure": None, "metrics_drop_after_poll": None,
             "deployment_change": False, "restart_during": -1, "uid_during": -1,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -57,6 +62,7 @@ class StatefulDrillHarness:
             "CF_DRILL_APPROVED_REVISION": "approved",
             "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "10",
             "CF_DRILL_NODE_EXECUTOR": str(node),
+            "CF_DRILL_TEST_DISRUPTION_SECONDS": "1",
         }
 
     def start(self, wrapper: list[str] | None = None) -> subprocess.Popen[str]:
@@ -146,7 +152,7 @@ elif name == "ruby":
 elif name == "curl": event("endpoint", response=state["endpoint"]); out(str(state["endpoint"]))
 elif name == "date": out("20260809T000000Z")
 elif name == "sleep":
-    if state["block_long_sleep"] and args and int(args[0]) > 30:
+    if state["block_long_sleep"] and args:
         state["sleeping"] = True; save()
         while True: time.sleep(.05)
 elif name == "kubectl":
@@ -174,9 +180,15 @@ elif name == "kubectl":
         out("secret-uid\t12\t2026-08-09T00:00:00Z")
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
+        if state["prometheus_failure"] == "request" and all(state["tables"]): sys.exit(52)
+        if state["prometheus_failure"] == "parse" and all(state["tables"]): out("not-json"); sys.exit(0)
         if "ALERTS" in query: value=state["alerts"]
         elif "sum(cloudflared" in query: value=2 if all(state["tables"]) else 8
-        elif "count(up" in query: value=state["metrics_targets_during"] if all(state["tables"]) else 2
+        elif "count(up" in query:
+            count = state.get("disrupted_target_polls", 0)
+            if all(state["tables"]): state["disrupted_target_polls"] = count + 1
+            drop = state["metrics_drop_after_poll"]
+            value = 1 if all(state["tables"]) and drop is not None and count >= drop else (state["metrics_targets_during"] if all(state["tables"]) else 2)
         else: value=2
         event("prometheus", query=query, value=value)
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
@@ -189,7 +201,8 @@ elif name == "node-executor":
         event("unprivileged_cross_process_readlink", node=node, command=command)
         sys.exit(1)
     if "test -x" in command:
-        sys.exit(0 if "/usr/local/bin/crictl" in state["crictl_paths"] else 1)
+        required = re.findall(r"(?:^| -a )-x ([^ ]+)", command)
+        sys.exit(0 if all(path in state["binary_paths"] for path in required) else 1)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
@@ -662,7 +675,7 @@ def test_accidental_restart_is_rejected() -> None:
 
 
 def test_timeout_and_signals_run_cleanup() -> None:
-    assert "DISRUPTION_SECONDS=180" in TEXT
+    assert "CF_DRILL_TEST_DISRUPTION_SECONDS" in TEXT
     assert "RECOVERY_SECONDS=300" in TEXT
     assert "trap 'exit 130' INT" in TEXT
     assert "trap 'exit 143' TERM" in TEXT
@@ -746,6 +759,48 @@ def test_interruption_and_invariance_fail_closed(tmp_path: Path, override: dict[
         assert (harness.evidence / "interruption-observations.jsonl").exists()
 
 
+@pytest.mark.parametrize("failure", ["request", "parse"])
+def test_prometheus_failure_is_recorded_before_fail_closed(
+    tmp_path: Path, failure: str,
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, prometheus_failure=failure)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "Prometheus observation was unavailable or malformed" in result.stderr
+    path = harness.evidence / "interruption-observations.jsonl"
+    observations = [json.loads(line) for line in path.read_text().splitlines()]
+    assert observations[-1]["prometheusTargetCount"] is None
+    assert observations[-1]["haConnections"] is None
+
+
+def test_invariants_are_polled_for_full_disruption_window(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, metrics_drop_after_poll=1)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "Prometheus target became unavailable" in result.stderr
+    path = harness.evidence / "interruption-observations.jsonl"
+    assert len(path.read_text().splitlines()) >= 2
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["/usr/local/bin/crictl", "/usr/bin/curl", "/usr/bin/jq", "/usr/bin/nsenter",
+     "/usr/bin/sed", "/usr/bin/tail"],
+)
+def test_missing_required_remote_binary_fails_closed(
+    tmp_path: Path, missing: str,
+) -> None:
+    paths = list(StatefulDrillHarness(tmp_path).current()["binary_paths"])
+    paths.remove(missing)
+    harness = StatefulDrillHarness(tmp_path / "missing", binary_paths=paths)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "required remote binary path missing" in result.stderr
+    assert not any(
+        "add table inet" in entry["args"][1]
+        for entry in harness.commands() if entry["tool"] == "node-executor"
+    )
+
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:
     harness = StatefulDrillHarness(tmp_path)
     result = harness.run()
@@ -789,7 +844,7 @@ def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) ->
 
 def test_legacy_only_crictl_fails_before_any_followup_command(tmp_path: Path) -> None:
     legacy_path = "/usr/bin/" + "crictl"
-    harness = StatefulDrillHarness(tmp_path, crictl_paths=[legacy_path])
+    harness = StatefulDrillHarness(tmp_path, binary_paths=[legacy_path])
     result = harness.run()
     assert result.returncode != 0
     assert "required remote binary path missing" in result.stderr

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -43,6 +43,7 @@ class StatefulDrillHarness:
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
             "ready_connections": [0, 0], "ready_malformed": -1, "metrics_targets_during": 2,
             "prometheus_failure": None, "metrics_drop_after_poll": None,
+            "recover_after_poll": None,
             "deployment_change": False, "restart_during": -1, "uid_during": -1,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
@@ -62,7 +63,9 @@ class StatefulDrillHarness:
             "CF_DRILL_APPROVED_REVISION": "approved",
             "CF_DRILL_EXPECTED_OBSERVABILITY_REVISION": "10",
             "CF_DRILL_NODE_EXECUTOR": str(node),
-            "CF_DRILL_TEST_DISRUPTION_SECONDS": "1",
+            # Signal/timeout tests need enough budget to reach and block in the
+            # disruption sleep even on a heavily loaded CI worker.
+            "CF_DRILL_TEST_DISRUPTION_SECONDS": "30" if state["block_long_sleep"] else "1",
         }
 
     def start(self, wrapper: list[str] | None = None) -> subprocess.Popen[str]:
@@ -168,10 +171,12 @@ elif name == "kubectl":
         items=[]
         for i in range(state["pod_count"]):
             disrupted = i < 2 and state["tables"][i]
+            recovered_during = (disrupted and state["recover_after_poll"] is not None
+                                and state.get("disrupted_target_polls", 0) >= state["recover_after_poll"])
             restart = state["restart"][i] if i < 2 else 0
             if disrupted and state["restart_during"] == i: restart += 1
             uid = f"replacement-{i+1}" if disrupted and state["uid_during"] == i else f"uid-{i+1}"
-            items.append({"metadata":{"name":f"connector-{i+1}","uid":uid,"labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
+            items.append({"metadata":{"name":f"connector-{i+1}","uid":uid,"labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted and not recovered_during else "True"}],"containerStatuses":[{"restartCount":restart}]}})
         out(json.dumps({"items":items}))
         event("pods", uids=[p["metadata"]["uid"] for p in items], restarts=[p["status"]["containerStatuses"][0]["restartCount"] for p in items], ready=[p["status"]["conditions"][0]["status"] for p in items])
     elif "get secret" in joined:
@@ -216,7 +221,9 @@ elif name == "node-executor":
         out(f"net:[{1001+idx}]")
     elif "http://127.0.0.1:2000/ready" in command:
         if state["ready_malformed"] == idx: out("not-json"); sys.exit(0)
-        connected = state["ready_connections"][idx] if state["tables"][idx] else 4
+        recovered_during = (state["tables"][idx] and state["recover_after_poll"] is not None
+                            and state.get("disrupted_target_polls", 0) >= state["recover_after_poll"])
+        connected = state["ready_connections"][idx] if state["tables"][idx] and not recovered_during else 4
         out(json.dumps({"httpStatus":503 if connected == 0 else 200,"readyConnections":connected}))
     elif "systemd-run" in command:
         state["watchdogs"][idx]=True; save(); event("watchdog", node=node, verified=False)
@@ -800,6 +807,39 @@ def test_invariants_are_polled_for_full_disruption_window(tmp_path: Path) -> Non
     assert "Prometheus target became unavailable" in result.stderr
     path = harness.evidence / "interruption-observations.jsonl"
     assert len(path.read_text().splitlines()) >= 2
+
+
+def test_full_disruption_rejects_recovery_after_initial_proof(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, recover_after_poll=1)
+    harness.env["CF_DRILL_TEST_DISRUPTION_SECONDS"] = "7"
+    result = harness.run()
+    assert result.returncode != 0
+    assert "did not persist throughout disruption" in result.stderr
+    observations = [
+        json.loads(line)
+        for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()
+    ]
+    assert len(observations) >= 2
+    assert observations[0]["pods"][0]["ready"] == "False"
+    assert observations[0]["readiness"] == [
+        {"httpStatus": 503, "readyConnections": 0},
+        {"httpStatus": 503, "readyConnections": 0},
+    ]
+    assert observations[-1]["pods"][0]["ready"] == "True"
+    assert observations[-1]["readiness"] == [
+        {"httpStatus": 200, "readyConnections": 4},
+        {"httpStatus": 200, "readyConnections": 4},
+    ]
+    assert harness.current()["tables"] == [False, False]
+
+
+def test_disruption_duration_default_override_gate_and_capped_sleep() -> None:
+    assert "DISRUPTION_SECONDS=180" in TEXT
+    assert '[[ "${CF_DRILL_APPROVED_REVISION:-}" == approved' in TEXT
+    assert 'DISRUPTION_SECONDS="${CF_DRILL_TEST_DISRUPTION_SECONDS}"' in TEXT
+    assert "readonly DISRUPTION_SECONDS" in TEXT
+    assert "remaining=$((disruption_deadline-SECONDS))" in TEXT
+    assert "sleep $((remaining < 5 ? remaining : 5))" in TEXT
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -37,6 +37,8 @@ class StatefulDrillHarness:
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "crictl_paths": ["/usr/local/bin/crictl"],
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
+            "ready_connections": [0, 0], "ready_malformed": -1, "metrics_targets_during": 2,
+            "deployment_change": False, "restart_during": -1, "uid_during": -1,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
         state.update(overrides)
@@ -152,13 +154,18 @@ elif name == "kubectl":
     if "current-context" in joined: out(state["context"])
     elif "get deployment" in joined:
         used = image if state["image_ok"] else "cloudflare/cloudflared:wrong"
-        out(json.dumps({"metadata":{"labels":{"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
+        disrupted = any(state["tables"])
+        labels={"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}
+        if state["deployment_change"] and state.get("was_disrupted"): labels["changed"]="true"
+        out(json.dumps({"metadata":{"uid":"deployment-uid","resourceVersion":"2" if state.get("was_disrupted") else "1","generation":1,"labels":labels,"annotations":{}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
     elif "get pods" in joined:
         items=[]
         for i in range(state["pod_count"]):
             disrupted = i < 2 and state["tables"][i]
             restart = state["restart"][i] if i < 2 else 0
-            items.append({"metadata":{"name":f"connector-{i+1}","uid":f"uid-{i+1}","labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
+            if disrupted and state["restart_during"] == i: restart += 1
+            uid = f"replacement-{i+1}" if disrupted and state["uid_during"] == i else f"uid-{i+1}"
+            items.append({"metadata":{"name":f"connector-{i+1}","uid":uid,"labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
         out(json.dumps({"items":items}))
         event("pods", uids=[p["metadata"]["uid"] for p in items], restarts=[p["status"]["containerStatuses"][0]["restartCount"] for p in items], ready=[p["status"]["conditions"][0]["status"] for p in items])
     elif "get secret" in joined:
@@ -168,7 +175,8 @@ elif name == "kubectl":
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
         if "ALERTS" in query: value=state["alerts"]
-        elif "sum(cloudflared" in query: value=0 if all(state["tables"]) else 8
+        elif "sum(cloudflared" in query: value=2 if all(state["tables"]) else 8
+        elif "count(up" in query: value=state["metrics_targets_during"] if all(state["tables"]) else 2
         else: value=2
         event("prometheus", query=query, value=value)
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
@@ -181,8 +189,7 @@ elif name == "node-executor":
         event("unprivileged_cross_process_readlink", node=node, command=command)
         sys.exit(1)
     if "test -x" in command:
-        requested_path = command.split("test -x ", 1)[1].split()[0]
-        sys.exit(0 if requested_path in state["crictl_paths"] else 1)
+        sys.exit(0 if "/usr/local/bin/crictl" in state["crictl_paths"] else 1)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
@@ -190,6 +197,10 @@ elif name == "node-executor":
         out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
     elif command.startswith("sudo /usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
+    elif "http://127.0.0.1:2000/ready" in command:
+        if state["ready_malformed"] == idx: out("not-json"); sys.exit(0)
+        connected = state["ready_connections"][idx] if state["tables"][idx] else 4
+        out(json.dumps({"httpStatus":503 if connected == 0 else 200,"readyConnections":connected}))
     elif "systemd-run" in command:
         state["watchdogs"][idx]=True; save(); event("watchdog", node=node, verified=False)
     elif "systemctl is-active" in command:
@@ -197,7 +208,7 @@ elif name == "node-executor":
         event("watchdog", node=node, verified=True)
         out(str(501+idx))
     elif "add table inet" in command:
-        state["tables"][idx]=True; save(); event("table", node=node, present=True)
+        state["tables"][idx]=True; state["was_disrupted"]=True; save(); event("table", node=node, present=True)
         if state["install_fail"] == idx: sys.exit(44)
     elif "delete table inet" in command:
         state["tables"][idx]=False; save(); event("table", node=node, present=False); out("")
@@ -628,13 +639,21 @@ def test_lifecycle_contract_is_checked_before_disruption() -> None:
 
 
 def test_interruption_requires_same_uids_and_restart_counts() -> None:
-    assert "did not prove same-process NotReady and zero HA connections" in TEXT
+    assert "did not prove same-process NotReady and zero ready connections" in TEXT
     interruption = TEXT.split("deadline=$((SECONDS+90))", 1)[1].split(
         'sleep "${DISRUPTION_SECONDS}"', 1
     )[0]
     assert ".metadata.uid==$u0" in interruption
     assert "restartCount" in interruption
     assert 'status=="False"' in interruption
+
+
+def test_deployment_fingerprint_excludes_resource_version_and_status() -> None:
+    fingerprint = TEXT.split('deployment_fingerprint="', 1)[1].split('"\n', 1)[0]
+    assert "resourceVersion" not in fingerprint
+    assert "status" not in fingerprint
+    assert "labels" in fingerprint and "annotations" in fingerprint and "spec" in fingerprint
+    assert "Deployment observedGeneration does not match unchanged generation" in TEXT
 
 
 def test_accidental_restart_is_rejected() -> None:
@@ -692,7 +711,7 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert any(event["ready"] == ["False", "False"] for event in pod_events)
     assert pod_events[-1]["ready"] == ["True", "True"]
     assert all(event["uids"] == ["uid-1", "uid-2"] and event["restarts"] == [0, 0] for event in pod_events)
-    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 0 for event in events if event.get("event") == "prometheus")
+    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 2 for event in events if event.get("event") == "prometheus")
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
@@ -700,8 +719,31 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert "observability revision expected=10 observed=10" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
-    assert (harness.evidence / "interruption-metrics.json").exists()
+    observations = [json.loads(line) for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()]
+    assert observations[-1]["readiness"] == [{"httpStatus": 503, "readyConnections": 0}] * 2
+    assert observations[-1]["prometheusTargetCount"] == 2
+    assert observations[-1]["haConnections"] == 2
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"ready_connections": [1, 0]}, "zero ready connections"),
+        ({"ready_malformed": 1}, "readiness endpoint was unavailable or malformed"),
+        ({"metrics_targets_during": 1}, "Prometheus target became unavailable"),
+        ({"restart_during": 0}, "connector UID/restart set changed"),
+        ({"uid_during": 1}, "connector UID/restart set changed"),
+        ({"deployment_change": True}, "Deployment desired state or ownership changed"),
+    ],
+)
+def test_interruption_and_invariance_fail_closed(tmp_path: Path, override: dict[str, object], message: str) -> None:
+    harness = StatefulDrillHarness(tmp_path, **override)
+    result = harness.run()
+    assert result.returncode != 0
+    assert message in result.stderr
+    if harness.evidence.exists():
+        assert (harness.evidence / "interruption-observations.jsonl").exists()
 
 
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -180,8 +180,12 @@ elif name == "kubectl":
         out("secret-uid\t12\t2026-08-09T00:00:00Z")
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
-        if state["prometheus_failure"] == "request" and all(state["tables"]): sys.exit(52)
-        if state["prometheus_failure"] == "parse" and all(state["tables"]): out("not-json"); sys.exit(0)
+        metric = "ha" if "sum(cloudflared" in query else "target" if "count(up" in query else None
+        failure = state["prometheus_failure"]
+        if all(state["tables"]) and failure and failure[0] == metric:
+            if failure[1] == "request": sys.exit(52)
+            if failure[1] == "malformed": out("not-json"); sys.exit(0)
+            if failure[1] == "no_result": out(json.dumps({"data":{"result":[]}})); sys.exit(0)
         if "ALERTS" in query: value=state["alerts"]
         elif "sum(cloudflared" in query: value=2 if all(state["tables"]) else 8
         elif "count(up" in query:
@@ -201,7 +205,7 @@ elif name == "node-executor":
         event("unprivileged_cross_process_readlink", node=node, command=command)
         sys.exit(1)
     if "test -x" in command:
-        required = re.findall(r"(?:^| -a )-x ([^ ]+)", command)
+        required = re.findall(r"(?:test| -a) -x ([^ ]+)", command)
         sys.exit(0 if all(path in state["binary_paths"] for path in required) else 1)
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
@@ -759,22 +763,38 @@ def test_interruption_and_invariance_fail_closed(tmp_path: Path, override: dict[
         assert (harness.evidence / "interruption-observations.jsonl").exists()
 
 
-@pytest.mark.parametrize("failure", ["request", "parse"])
+@pytest.mark.parametrize("metric", ["target", "ha"])
+@pytest.mark.parametrize("failure", ["request", "malformed", "no_result"])
 def test_prometheus_failure_is_recorded_before_fail_closed(
-    tmp_path: Path, failure: str,
+    tmp_path: Path, metric: str, failure: str,
 ) -> None:
-    harness = StatefulDrillHarness(tmp_path, prometheus_failure=failure)
+    harness = StatefulDrillHarness(tmp_path, prometheus_failure=[metric, failure])
     result = harness.run()
     assert result.returncode != 0
-    assert "Prometheus observation was unavailable or malformed" in result.stderr
+    label = "HA" if metric == "ha" else "target"
+    assert f"Prometheus {label} observation was unavailable or malformed" in result.stderr
     path = harness.evidence / "interruption-observations.jsonl"
     observations = [json.loads(line) for line in path.read_text().splitlines()]
-    assert observations[-1]["prometheusTargetCount"] is None
-    assert observations[-1]["haConnections"] is None
+    assert len(observations) == 1
+    observation = observations[0]
+    unavailable = "prometheusTargetCount" if metric == "target" else "haConnections"
+    available = "haConnections" if metric == "target" else "prometheusTargetCount"
+    assert observation[unavailable] is None
+    assert observation[available] == 2
+    assert observation["schemaVersion"] == 1
+    assert observation["readiness"] == [
+        {"httpStatus": 503, "readyConnections": 0},
+        {"httpStatus": 503, "readyConnections": 0},
+    ]
+    evidence = path.read_text()
+    assert "connectorId" not in evidence
+    assert "SENTINEL-SECRET-MUST-NOT-LEAK" not in evidence
+    assert harness.current()["tables"] == [False, False]
 
 
 def test_invariants_are_polled_for_full_disruption_window(tmp_path: Path) -> None:
     harness = StatefulDrillHarness(tmp_path, metrics_drop_after_poll=1)
+    harness.env["CF_DRILL_TEST_DISRUPTION_SECONDS"] = "7"
     result = harness.run()
     assert result.returncode != 0
     assert "Prometheus target became unavailable" in result.stderr
@@ -800,6 +820,18 @@ def test_missing_required_remote_binary_fails_closed(
         "add table inet" in entry["args"][1]
         for entry in harness.commands() if entry["tool"] == "node-executor"
     )
+
+
+def test_missing_exact_node_curl_fails_before_watchdog_or_tables(tmp_path: Path) -> None:
+    paths = list(StatefulDrillHarness(tmp_path).current()["binary_paths"])
+    paths.remove("/usr/bin/curl")
+    harness = StatefulDrillHarness(tmp_path / "missing-curl", binary_paths=paths)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "required remote binary path missing" in result.stderr
+    assert not any(event.get("event") in {"watchdog", "table"} for event in harness.events())
+    assert harness.current()["tables"] == [False, False]
+    assert harness.current()["watchdogs"] == [False, False]
 
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:
     harness = StatefulDrillHarness(tmp_path)


### PR DESCRIPTION
### Motivation

- The live staging run exposed that the HA gauge can remain >0 while readiness reaches zero because cloudflared increments a retrying Serve attempt; the helper must not treat aggregate HA==0 as authoritative.  The proof contract must instead validate each connector's `/ready` endpoint inside its exact network namespace. 
- The Deployment comparison used `resourceVersion` (a status-only churn field) which can advance during a genuine readiness transition; that must be excluded from the desired-state fingerprint. 
- Interruption polls produced useful evidence only on success; failing probes must persist deterministic, sanitized observations for diagnosis without leaking connector secrets/IDs.

### Description

- Query readiness inside each validated pod network namespace: preflight the on-node `curl` path, use the node executor plus `crictl`/`nsenter` guards to call `http://127.0.0.1:2000/ready` from each connector's netns, parse and sanitize only `httpStatus` and `readyConnections`, and never persist `connectorId` or raw token data. (`scripts/cloudflare_wan_dependency_loss_drill.sh`) 
- Replace the old HA==0 interruption requirement with a per-pod authoritative check that both pods are `Ready=False` in Kubernetes and that both sanitized `/ready` responses are `HTTP 503` with `readyConnections: 0`, while still recording the HA gauge as supporting evidence and requiring Prometheus targets remain up. The helper fails closed on malformed/unavailable `/ready` output, identity changes, restarts, or metrics-target drops. (`scripts/cloudflare_wan_dependency_loss_drill.sh`) 
- Produce deterministic JSONL interruption observations on every poll (success or failure) containing `schemaVersion`, `elapsedSeconds`, pod UID/restart/Ready state, sanitized readiness objects, `prometheusTargetCount`, and `haConnections`; these are suitable for automated tests and later issue evidence. (`scripts/cloudflare_wan_dependency_loss_drill.sh`) 
- Change Deployment fingerprint to include stable desired/ownership state only (UID, generation, labels, annotations, and `spec`) and explicitly require `status.observedGeneration` to equal the unchanged `metadata.generation`; `resourceVersion` and other dynamic status fields are recorded but excluded from the equality check. (`scripts/cloudflare_wan_dependency_loss_drill.sh`) 
- Update the stateful offline test harness to model the realistic HA-floor-of-2 interruption and add focused failure scenarios for: non-zero `/ready` `readyConnections`, malformed readiness output, Prometheus target drop during interruption, UID/restart changes, and a desired-state Deployment change; ensure a resourceVersion-only change passes. (`tests/test_cloudflare_wan_dependency_loss_drill.py`) 
- Update docs to explain the cloudflared HA gauge semantics, the authoritative zero-ready-connections proof, why `resourceVersion` may advance, and to record the August attempt as a safely cleaned-up failed proof contract and not evidence for #2407. (`docs/cloudflare_tunnel.md`)

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — syntax check passed. 
- `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — focused suite passed locally (stateful harness and parametrized failure cases exercised); tests covering the modified contract passed. 
- `just cf-tunnel-wan-dependency-loss-drill env=staging` — printed the offline, non-mutating manual plan only (no cluster or node commands executed). 
- `git diff --cached | ./scripts/scan-secrets.py` — secret scan on staged changes returned clean. 
- `linkchecker --no-warnings README.md docs/` — executed and found no link errors in docs. 

Not-run / environment notes:

- `pre-commit run --all-files` was not available in the execution environment (pre-commit binary missing), and repository-wide linter checks (`scripts/checks.sh`) revealed pre-existing unrelated Flake8 style issues across other files; these are not introduced by this PR and were not changed beyond the scope described above. 
- `pyspelling` could not run here because `aspell` is not installed in the environment. 

Residual risks and follow-ups:

- This change is helper-only and does not mutate clusters, Helm releases, or Secrets; a new live staging execution must be separately authorized and only attempted after merging this fix and independently approving exact observability and revision coordinates. 
- Additional CI/maintainer checks (full `pre-commit` and repository-wide lint fixes) are suggested but out of scope for this safety-focused fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b86eb689c832f9bedd7ac6a83473e)