### PR TITLE
Fix Cloudflare WAN interruption proof (require zero readyConnections per connector)

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -567,8 +567,15 @@ part of this rollout.
    privileged namespace operation, and rejects an ambiguous sandbox or pre-existing owner table. Each
    transient watchdog enters and holds the validated namespace before disruption, avoiding delayed PID
    reuse, and all watchdog binary paths are preflighted on both affected nodes. It then proves the
-   original UIDs become NotReady with zero HA connections and
-   unchanged restart counts. Cleanup deletes only the exact owner table, including after signals and
+   original UIDs become NotReady with unchanged restart counts. For each original process it enters
+   the already validated network namespace and requires a sanitized `/ready` result of HTTP 503 with
+   `readyConnections: 0`, while both Prometheus targets remain up. This is authoritative because
+   cloudflared readiness counts connected edge sessions. The HA gauge is retained as supporting
+   interruption and recovery evidence, but is not an interruption gate: a retrying `Serve` attempt is
+   counted before dialing and can leave one gauge connection per connector after its connected edge
+   sessions have reached zero. Every poll is written to deterministic, sanitized JSONL, including on
+   failure; connector IDs and raw readiness bodies are never persisted or returned by the node.
+   Cleanup deletes only the exact owner table, including after signals and
    partial or ambiguously reported setup. A node remains cleanup-eligible until both exact deletion and
    table absence are proven; normal-cleanup failure leaves it available to the EXIT retry. Failure to
    prove automatic cleanup fails closed and prints exact UID/inode-guarded, node-specific manual cleanup
@@ -576,10 +583,26 @@ part of this rollout.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
    Helm histories, including the single deployed observability release at the explicitly approved
-   revision, Secret metadata, and Deployment state must be unchanged; and
+   revision, Secret metadata, and Deployment desired/ownership state (UID, generation, labels,
+   annotations, and spec) must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.
+
+   Deployment `metadata.resourceVersion` may advance when its status reconciles across the readiness
+   transition, so it is recorded but excluded from the desired-state fingerprint. The final
+   `status.observedGeneration` must still equal the unchanged `metadata.generation`.
+
+   The authorized August 11, 2026 staging attempt safely cleaned up but did **not** pass. Both original
+   pods became NotReady with unchanged UIDs and restart counts, both metrics targets remained up, and
+   the HA total fell from eight to two rather than the old contract's required zero. Cleanup and later
+   reconciliation proved no drill tables or watchdog units remained, both original connectors returned
+   healthy, all 16 staging endpoints returned HTTP 200, Helm histories and Secret metadata were
+   unchanged, and the repository verifier passed. The Deployment resourceVersion also advanced during
+   status-only reconciliation. This was a failed proof caused by the old helper assumptions, not a
+   passing drill and not evidence for #2407. A live retry requires this fix to be merged, a fresh
+   read-only gate, newly approved exact main and observability revisions, and separate explicit staging
+   authorization. Production remains explicitly out of scope.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -9,6 +9,7 @@ readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
+readonly CURL='/usr/bin/curl'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -186,7 +187,8 @@ jq -e --arg image "${EXPECTED_IMAGE}" '
  and .spec.template.spec.containers[0].readinessProbe.httpGet.path=="/ready"
  and .spec.template.spec.containers[0].readinessProbe.httpGet.port==2000
 ' <<<"${deployment}" >/dev/null || die 'Deployment ownership, replicas, immutable image is not approved, or probe lifecycle is unsafe'
-deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_generation="$(jq -r '.metadata.generation' <<<"${deployment}")"
 
 # Reuse the repository verifier's complete strategy/topology/probe contract before mutation.
 just cf-tunnel-verify env=staging
@@ -236,7 +238,7 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
   resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
@@ -290,20 +292,47 @@ done
 
 disruption_started="${SECONDS}"
 deadline=$((SECONDS+90)); interrupted=0
+: >"${evidence_dir}/interruption-observations.jsonl"
 while ((SECONDS < deadline)); do
   current="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
   unchanged="$(jq --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" --argjson r0 "${pod_restarts[0]}" --argjson r1 "${pod_restarts[1]}" '
     [.items[]|select(.metadata.deletionTimestamp==null)] as $p | ($p|length)==2 and
     ([$p[].metadata.uid]|sort)==([$u0,$u1]|sort) and
     all($p[];([.status.containerStatuses[].restartCount]|add)==(if .metadata.uid==$u0 then $r0 else $r1 end))' <<<"${current}")"
+  declare -a ready_observations=()
+  ready_query_failed=0
+  for i in 0 1; do
+    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && raw=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n ${CURL} -sS --max-time 5 -w '\\n%{http_code}' http://127.0.0.1:2000/ready)\" && status=\"\${raw##*$'\\n'}\" && body=\"\${raw%$'\\n'*}\" && printf '%s' \"\${body}\" | /usr/bin/jq -c --arg status \"\${status}\" 'if type==\"object\" and (.readyConnections|type)==\"number\" and (\$status|test(\"^[0-9]{3}$\")) then {httpStatus:(\$status|tonumber),readyConnections:.readyConnections} else error(\"invalid readiness response\") end'"
+    if observation="$(node_exec "${pod_nodes[$i]}" "${ready_command}")" &&
+      jq -e 'keys == ["httpStatus","readyConnections"] and (.httpStatus|type)=="number" and (.readyConnections|type)=="number"' <<<"${observation}" >/dev/null; then
+      ready_observations+=("${observation}")
+    else
+      ready_observations+=('{"httpStatus":null,"readyConnections":null}')
+      ready_query_failed=1
+    fi
+  done
+  targets=-1
+  if metric_response="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)')" &&
+    metric_value="$(jq -er '.data.result[0].value[1]' <<<"${metric_response}")" && [[ "${metric_value}" =~ ^[0-9]+$ ]]; then
+    targets="${metric_value}"
+  fi
+  ha=-1
+  if metric_response="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})')" &&
+    metric_value="$(jq -er '.data.result[0].value[1]' <<<"${metric_response}")" && [[ "${metric_value}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    ha="${metric_value}"
+  fi
+  jq -cn --argjson elapsed "$((SECONDS-disruption_started))" --argjson pods "$(jq -c --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" '[.items[] | select(.metadata.uid==$u0 or .metadata.uid==$u1) | {uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")][0].status//null)}] | sort_by(.uid)' <<<"${current}")" --argjson readiness "$(printf '%s\n' "${ready_observations[@]}" | jq -s .)" --argjson targets "${targets}" --argjson ha "${ha}" '{elapsedSeconds:$elapsed,pods:$pods,readiness:$readiness,prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
   [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
+  ((ready_query_failed==0)) || die 'connector readiness endpoint could not be queried and parsed'
+  [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  [[ "${same}" == true ]] || { sleep 5; continue; }
-  [[ "$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')" == 0 ]] && { interrupted=1; break; }
+  if [[ "${same}" == true ]] && printf '%s\n' "${ready_observations[@]}" | jq -se 'length==2 and all(.[];.httpStatus==503 and .readyConnections==0)' >/dev/null; then interrupted=1; break; fi
+  if [[ "${same}" == true ]]; then
+    die 'did not prove same-process NotReady and zero ready connections'
+  fi
   sleep 5
 done
-((interrupted)) || die 'did not prove same-process NotReady and zero HA connections'
-prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' >"${evidence_dir}/interruption-metrics.json"
+((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
 remaining=$((DISRUPTION_SECONDS-(SECONDS-disruption_started)))
 if ((remaining > 0)); then sleep "${remaining}"; fi
 
@@ -345,6 +374,7 @@ recovery_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json
 validate_observability_history "${recovery_obs_history}" 'post-cleanup'
 [[ "${recovery_obs_history}" == "${obs_history}" ]] || die "observability Helm history changed (expected deployed revision ${expected_observability_revision}; observed ${observed_observability_revision})"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
-[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
+[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment desired state or ownership changed'
+[[ "$(jq -r '.status.observedGeneration' <<<"${final_deployment}")" == "${deployment_generation}" ]] || die 'Deployment has not observed its unchanged generation'
 just cf-tunnel-verify env=staging
 printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -36,7 +36,10 @@ class StatefulDrillHarness:
             "same_node": False, "alerts": 0, "endpoint": 200,
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "crictl_paths": ["/usr/local/bin/crictl"],
-            "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
+            "restart": [0, 0], "pod_uids": ["uid-1", "uid-2"],
+            "tables": [False, False], "watchdogs": [False, False],
+            "ready_connections": [0, 0], "ready_malformed": [False, False],
+            "targets_during_disruption": 2, "deployment_change": False,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
         state.update(overrides)
@@ -152,13 +155,16 @@ elif name == "kubectl":
     if "current-context" in joined: out(state["context"])
     elif "get deployment" in joined:
         used = image if state["image_ok"] else "cloudflare/cloudflared:wrong"
-        out(json.dumps({"metadata":{"labels":{"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
+        changed = state.get("disrupted_once", False)
+        labels={"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}
+        if changed and state["deployment_change"]: labels["unauthorized"]="change"
+        out(json.dumps({"metadata":{"uid":"deployment-uid","generation":1,"resourceVersion":"2" if changed else "1","labels":labels},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
     elif "get pods" in joined:
         items=[]
         for i in range(state["pod_count"]):
             disrupted = i < 2 and state["tables"][i]
             restart = state["restart"][i] if i < 2 else 0
-            items.append({"metadata":{"name":f"connector-{i+1}","uid":f"uid-{i+1}","labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
+            items.append({"metadata":{"name":f"connector-{i+1}","uid":state["pod_uids"][i],"labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
         out(json.dumps({"items":items}))
         event("pods", uids=[p["metadata"]["uid"] for p in items], restarts=[p["status"]["containerStatuses"][0]["restartCount"] for p in items], ready=[p["status"]["conditions"][0]["status"] for p in items])
     elif "get secret" in joined:
@@ -168,7 +174,8 @@ elif name == "kubectl":
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
         if "ALERTS" in query: value=state["alerts"]
-        elif "sum(cloudflared" in query: value=0 if all(state["tables"]) else 8
+        elif "sum(cloudflared" in query: value=2 if all(state["tables"]) else 8
+        elif "count(up" in query: value=state["targets_during_disruption"] if all(state["tables"]) else 2
         else: value=2
         event("prometheus", query=query, value=value)
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
@@ -183,11 +190,14 @@ elif name == "node-executor":
     if "test -x" in command:
         requested_path = command.split("test -x ", 1)[1].split()[0]
         sys.exit(0 if requested_path in state["crictl_paths"] else 1)
+    if "http://127.0.0.1:2000/ready" in command:
+        if state["ready_malformed"][idx]: sys.exit(22)
+        out(json.dumps({"httpStatus":503,"readyConnections":state["ready_connections"][idx]}))
     if "crictl pods --name" in command and "inspectp" not in command:
         if state["sandbox_fail"]: out("ambiguous\nsecond"); sys.exit(0)
         out(("a" if idx == 0 else "b")*12)
     elif command.startswith("sudo /usr/local/bin/crictl inspectp"):
-        out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
+        out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":state["pod_uids"][idx]}},"info":{"pid":101+idx}}))
     elif command.startswith("sudo /usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
     elif "systemd-run" in command:
@@ -197,7 +207,7 @@ elif name == "node-executor":
         event("watchdog", node=node, verified=True)
         out(str(501+idx))
     elif "add table inet" in command:
-        state["tables"][idx]=True; save(); event("table", node=node, present=True)
+        state["tables"][idx]=True; state["disrupted_once"]=True; save(); event("table", node=node, present=True)
         if state["install_fail"] == idx: sys.exit(44)
     elif "delete table inet" in command:
         state["tables"][idx]=False; save(); event("table", node=node, present=False); out("")
@@ -628,7 +638,7 @@ def test_lifecycle_contract_is_checked_before_disruption() -> None:
 
 
 def test_interruption_requires_same_uids_and_restart_counts() -> None:
-    assert "did not prove same-process NotReady and zero HA connections" in TEXT
+    assert "did not prove same-process NotReady and zero ready connections" in TEXT
     interruption = TEXT.split("deadline=$((SECONDS+90))", 1)[1].split(
         'sleep "${DISRUPTION_SECONDS}"', 1
     )[0]
@@ -692,7 +702,7 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert any(event["ready"] == ["False", "False"] for event in pod_events)
     assert pod_events[-1]["ready"] == ["True", "True"]
     assert all(event["uids"] == ["uid-1", "uid-2"] and event["restarts"] == [0, 0] for event in pod_events)
-    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 0 for event in events if event.get("event") == "prometheus")
+    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 2 for event in events if event.get("event") == "prometheus")
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
@@ -700,8 +710,45 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert "observability revision expected=10 observed=10" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
-    assert (harness.evidence / "interruption-metrics.json").exists()
+    observations = [json.loads(line) for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()]
+    assert observations[-1]["prometheusTargetCount"] == 2
+    assert observations[-1]["haConnections"] == 2
+    assert observations[-1]["readiness"] == [{"httpStatus": 503, "readyConnections": 0}] * 2
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+@pytest.mark.parametrize(("override", "message"), [
+    ({"ready_connections": [1, 0]}, "zero ready connections"),
+    ({"ready_malformed": [False, True]}, "could not be queried and parsed"),
+    ({"targets_during_disruption": 1}, "Prometheus target became unavailable"),
+])
+def test_interruption_authoritative_proof_fails_closed_with_evidence(
+    tmp_path: Path, override: dict[str, object], message: str
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, **override)
+    result = harness.run()
+    assert result.returncode != 0
+    assert message in result.stderr
+    observations = [json.loads(line) for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()]
+    assert observations
+    assert set(observations[-1]) == {"elapsedSeconds", "pods", "readiness", "prometheusTargetCount", "haConnections"}
+    assert harness.current()["tables"] == [False, False]
+
+
+def test_deployment_resource_version_only_change_passes(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    result = harness.run()
+    assert result.returncode == 0, result.stderr
+    preflight = json.loads((harness.evidence / "preflight.json").read_text())
+    assert preflight["deployment"]["metadata"]["resourceVersion"] == "1"
+    assert harness.current()["disrupted_once"] is True
+
+
+def test_deployment_desired_or_ownership_change_fails(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, deployment_change=True)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "Deployment desired state or ownership changed" in result.stderr
 
 
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The authorized August 11 staging run showed both connector pods become NotReady while the cloudflared HA gauge stayed >0, exposing an invalid helper assumption that HA==0 implied zero ready sessions. Upstream cloudflared increments an HA Serve attempt before dialing, so the GAUGE can remain at a small nonzero floor during WAN loss.  
- The drill must remain a same-process proof (no restarts or UID changes) while providing an authoritative check that each original process has zero ready edge sessions, not relying on the aggregate HA gauge alone.  
- Deployment `metadata.resourceVersion` can advance during status-only reconciliation and must not cause the desired-state invariance check to fail; desired/ownership fields should be fingerprinted instead.

### Description
- For each selected connector the helper now queries the connector `/ready` endpoint from inside that pod's already-validated network namespace using `nsenter` + a preflighted `curl` path, and parses/sanitizes only `httpStatus` and `readyConnections`; `connectorId` and raw bodies are never persisted.  
- The interruption gate no longer requires HA==0; it requires both pods Ready=False and for each original connector a sanitized `/ready` response of HTTP 503 and `readyConnections: 0`, while both Prometheus targets remain up; the HA gauge is still recorded as supporting evidence.  
- The Deployment fingerprint excludes dynamic status fields such as `resourceVersion` and other status-only fields and instead fingerprints UID, generation, labels, annotations and `spec`; the final `status.observedGeneration` is required to equal the unchanged `metadata.generation`.  
- Every interruption poll (success or failure) appends a deterministic, sanitized JSONL observation to `interruption-observations.jsonl` containing elapsed time, pod uid/restart/Ready state, sanitized `/ready` fields, Prometheus target counts, and observed HA values; tests and docs updated to model the realistic HA-floor-of-2 behavior and focused failure cases.  

### Testing
- Ran static shell check: `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — OK.  
- Ran unit/integration harness: `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — all tests passed.  
- Verified offline plan rendering: `just cf-tunnel-wan-dependency-loss-drill env=staging` — printed the non-mutating manual-node plan only.  
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — no issues found.  

Notes and safety boundaries: the change is an offline, repository-only fix to the drill helper, its offline harness, and documentation; it does not perform any live cluster mutation or read Secret values, and a future live retry remains gated by separate approvals and the existing `--execute` staging-only confirmation. Pre-commit/pyspelling/linkchecker hooks were not available in this execution environment and so were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b86f44bcc832faf4c4483561e6850)