### PR TITLE
Fix staging Cloudflare WAN dependency-loss proof contract

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -519,6 +519,16 @@ part of this rollout.
    service impact. Treat the attempt as an **inconclusive dependency-loss test**, not evidence that the
    same processes survive and reconnect after WAN loss. Operator captures remain local and must not be
    committed.
+
+   The first authorized namespace-local attempt on August 11, 2026 also did **not** pass. Both original
+   pods became NotReady with unchanged UIDs and restart counts, both metrics targets stayed up, and the
+   aggregate HA gauge fell from eight to two rather than zero. Cleanup removed both drill-owned tables
+   and watchdog units, and reconciliation proved healthy connectors and endpoints with unchanged Helm
+   histories and Secret metadata. The old helper incorrectly treated the HA gauge as authoritative and
+   included Deployment `resourceVersion` in its invariance fingerprint. This was a safely cleaned-up
+   failed proof, not evidence for issue #2407. A retry requires this fix to be merged, a fresh read-only
+   gate, newly approved exact main and observability revisions, and separate explicit staging
+   authorization. Production remains out of scope.
 5. Use the repository-owned helper for any future, separately authorized attempt. Its default is a
    non-mutating plan:
 
@@ -566,9 +576,14 @@ part of this rollout.
    sandbox to its PID and network-namespace inode, revalidates those three identities before every
    privileged namespace operation, and rejects an ambiguous sandbox or pre-existing owner table. Each
    transient watchdog enters and holds the validated namespace before disruption, avoiding delayed PID
-   reuse, and all watchdog binary paths are preflighted on both affected nodes. It then proves the
-   original UIDs become NotReady with zero HA connections and
-   unchanged restart counts. Cleanup deletes only the exact owner table, including after signals and
+   reuse, and all watchdog binary paths, including the exact `curl` path, are preflighted on both
+   affected nodes. It then proves that the original UIDs become NotReady with unchanged restart counts,
+   each validated process network namespace returns a sanitized `/ready` result of HTTP 503 with
+   `readyConnections: 0`, and both Prometheus targets remain up. The HA gauge remains supporting
+   evidence, not an outage oracle: cloudflared increments it when a Serve attempt starts and decrements
+   it only when that attempt returns, so WAN loss can leave one retrying Serve attempt per connector
+   even though the readiness connection tracker has no connected edge session. Every poll is persisted
+   as sanitized JSONL, including on a failed proof. Cleanup deletes only the exact owner table, including after signals and
    partial or ambiguously reported setup. A node remains cleanup-eligible until both exact deletion and
    table absence are proven; normal-cleanup failure leaves it available to the EXIT retry. Failure to
    prove automatic cleanup fails closed and prints exact UID/inode-guarded, node-specific manual cleanup
@@ -576,10 +591,14 @@ part of this rollout.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
    Helm histories, including the single deployed observability release at the explicitly approved
-   revision, Secret metadata, and Deployment state must be unchanged; and
+   revision, Secret metadata, and Deployment desired/ownership state must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.
+
+   Deployment `metadata.resourceVersion` may advance during status-only readiness reconciliation, so it
+   is recorded but excluded from desired-state equality. UID, generation, labels, annotations, and spec
+   must remain identical, and final `status.observedGeneration` must equal the unchanged generation.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -9,6 +9,7 @@ readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
+readonly CURL='/usr/bin/curl'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -186,7 +187,8 @@ jq -e --arg image "${EXPECTED_IMAGE}" '
  and .spec.template.spec.containers[0].readinessProbe.httpGet.path=="/ready"
  and .spec.template.spec.containers[0].readinessProbe.httpGet.port==2000
 ' <<<"${deployment}" >/dev/null || die 'Deployment ownership, replicas, immutable image is not approved, or probe lifecycle is unsafe'
-deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_generation="$(jq -r '.metadata.generation' <<<"${deployment}")"
 
 # Reuse the repository verifier's complete strategy/topology/probe contract before mutation.
 just cf-tunnel-verify env=staging
@@ -236,7 +238,7 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
   resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
@@ -296,14 +298,36 @@ while ((SECONDS < deadline)); do
     [.items[]|select(.metadata.deletionTimestamp==null)] as $p | ($p|length)==2 and
     ([$p[].metadata.uid]|sort)==([$u0,$u1]|sort) and
     all($p[];([.status.containerStatuses[].restartCount]|add)==(if .metadata.uid==$u0 then $r0 else $r1 end))' <<<"${current}")"
-  [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  [[ "${same}" == true ]] || { sleep 5; continue; }
-  [[ "$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')" == 0 ]] && { interrupted=1; break; }
+  ready_results=()
+  ready_queries_ok=1
+  for i in 0 1; do
+    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n /bin/sh -c 'body=\"\$(${CURL} -sS --max-time 5 -w \"\\n%{http_code}\" http://127.0.0.1:2000/ready)\" || exit 81; status=\"\${body##*\n}\"; payload=\"\${body%\n*}\"; printf \"%s\" \"\${payload}\" | /usr/bin/jq -ce --argjson status \"\${status}\" '\"'\"'{httpStatus:\$status,readyConnections:(.readyConnections | select(type==\"number\" and floor==. and .>=0))}'\"'\"' '"
+    if ready_result="$(node_exec "${pod_nodes[$i]}" "${ready_command}" 2>/dev/null)" &&
+      jq -e 'keys == ["httpStatus","readyConnections"]' <<<"${ready_result}" >/dev/null 2>&1; then
+      ready_results+=("${ready_result}")
+    else
+      ready_queries_ok=0
+      ready_results+=('{"httpStatus":null,"readyConnections":null}')
+    fi
+  done
+  target_raw="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)' 2>/dev/null || true)"
+  target_count="$(jq -er '.data.result[0].value[1] | tonumber' <<<"${target_raw}" 2>/dev/null || printf '%s' -1)"
+  ha_raw="$(prom_query 'cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}' 2>/dev/null || true)"
+  ha_values="$(jq -ec '[.data.result[]?.value[1] | tonumber] | sort' <<<"${ha_raw}" 2>/dev/null || printf '[]')"
+  elapsed=$((SECONDS-disruption_started))
+  jq -cn --argjson elapsed "${elapsed}" --argjson pods "$(jq -c '[.items[] | {uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")][0].status//null)}] | sort_by(.uid)' <<<"${current}")" --argjson ready "$(printf '%s\n' "${ready_results[@]}" | jq -s .)" --argjson targets "${target_count}" --argjson ha "${ha_values}" '{elapsedSeconds:$elapsed,pods:$pods,readyEndpoints:$ready,prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
+  [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
+  ((ready_queries_ok)) || die 'connector readiness endpoint was unavailable or malformed during interruption'
+  [[ "${target_count}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
+  ready_zero="$(printf '%s\n' "${ready_results[@]}" | jq -s 'length==2 and all(.[];.httpStatus==503 and .readyConnections==0)')"
+  if [[ "${same}" == true && "${ready_zero}" != true ]]; then
+    die 'a NotReady connector still reports ready connections'
+  fi
+  [[ "${same}" == true && "${ready_zero}" == true ]] && { interrupted=1; break; }
   sleep 5
 done
-((interrupted)) || die 'did not prove same-process NotReady and zero HA connections'
-prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' >"${evidence_dir}/interruption-metrics.json"
+((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
 remaining=$((DISRUPTION_SECONDS-(SECONDS-disruption_started)))
 if ((remaining > 0)); then sleep "${remaining}"; fi
 
@@ -345,6 +369,7 @@ recovery_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json
 validate_observability_history "${recovery_obs_history}" 'post-cleanup'
 [[ "${recovery_obs_history}" == "${obs_history}" ]] || die "observability Helm history changed (expected deployed revision ${expected_observability_revision}; observed ${observed_observability_revision})"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
-[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
+[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment desired or ownership state changed'
+[[ "$(jq -r '.status.observedGeneration' <<<"${final_deployment}")" == "${deployment_generation}" ]] || die 'Deployment has not observed its unchanged generation'
 just cf-tunnel-verify env=staging
 printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -37,6 +37,9 @@ class StatefulDrillHarness:
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "crictl_paths": ["/usr/local/bin/crictl"],
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
+            "ready_connections": [0, 0], "ready_malformed": -1,
+            "prom_targets_during": 2, "ha_during": [1, 1],
+            "deployment_change": False,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
         state.update(overrides)
@@ -152,7 +155,11 @@ elif name == "kubectl":
     if "current-context" in joined: out(state["context"])
     elif "get deployment" in joined:
         used = image if state["image_ok"] else "cloudflare/cloudflared:wrong"
-        out(json.dumps({"metadata":{"labels":{"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
+        state["deployment_calls"] = state.get("deployment_calls", 0) + 1
+        disrupted_once = state.get("ever_disrupted", False)
+        labels={"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}
+        if state["deployment_change"] and state["deployment_calls"] > 1: labels["changed"]="yes"
+        out(json.dumps({"metadata":{"uid":"deployment-uid","generation":1,"resourceVersion":"2" if disrupted_once else "1","labels":labels},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}})); save()
     elif "get pods" in joined:
         items=[]
         for i in range(state["pod_count"]):
@@ -168,7 +175,11 @@ elif name == "kubectl":
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
         if "ALERTS" in query: value=state["alerts"]
-        elif "sum(cloudflared" in query: value=0 if all(state["tables"]) else 8
+        elif query.strip().endswith('cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"}'):
+            values = state["ha_during"] if all(state["tables"]) else [4,4]
+            event("prometheus", query=query, value=values)
+            out(json.dumps({"data":{"result":[{"value":[0,str(v)]} for v in values]}})); save(); sys.exit(0)
+        elif "up{" in query: value=state["prom_targets_during"] if all(state["tables"]) else 2
         else: value=2
         event("prometheus", query=query, value=value)
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
@@ -197,8 +208,11 @@ elif name == "node-executor":
         event("watchdog", node=node, verified=True)
         out(str(501+idx))
     elif "add table inet" in command:
-        state["tables"][idx]=True; save(); event("table", node=node, present=True)
+        state["tables"][idx]=True; state["ever_disrupted"]=True; save(); event("table", node=node, present=True)
         if state["install_fail"] == idx: sys.exit(44)
+    elif "/ready" in command:
+        if state["ready_malformed"] == idx: out("not-json")
+        else: out(json.dumps({"httpStatus":503,"readyConnections":state["ready_connections"][idx]}))
     elif "delete table inet" in command:
         state["tables"][idx]=False; save(); event("table", node=node, present=False); out("")
     elif "list ruleset" in command:
@@ -628,7 +642,7 @@ def test_lifecycle_contract_is_checked_before_disruption() -> None:
 
 
 def test_interruption_requires_same_uids_and_restart_counts() -> None:
-    assert "did not prove same-process NotReady and zero HA connections" in TEXT
+    assert "did not prove same-process NotReady and zero ready connections" in TEXT
     interruption = TEXT.split("deadline=$((SECONDS+90))", 1)[1].split(
         'sleep "${DISRUPTION_SECONDS}"', 1
     )[0]
@@ -692,7 +706,7 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert any(event["ready"] == ["False", "False"] for event in pod_events)
     assert pod_events[-1]["ready"] == ["True", "True"]
     assert all(event["uids"] == ["uid-1", "uid-2"] and event["restarts"] == [0, 0] for event in pod_events)
-    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 0 for event in events if event.get("event") == "prometheus")
+    assert any(event["value"] == [1, 1] for event in events if event.get("event") == "prometheus")
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
@@ -700,8 +714,54 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert "observability revision expected=10 observed=10" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
-    assert (harness.evidence / "interruption-metrics.json").exists()
+    observations = [json.loads(line) for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()]
+    assert observations[-1]["readyEndpoints"] == [
+        {"httpStatus": 503, "readyConnections": 0},
+        {"httpStatus": 503, "readyConnections": 0},
+    ]
+    assert observations[-1]["prometheusTargetCount"] == 2
+    assert observations[-1]["haConnections"] == [1, 1]
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+@pytest.mark.parametrize("ready_connections", ([1, 0], [0, 1]))
+def test_nonzero_authoritative_ready_connection_fails(
+    tmp_path: Path, ready_connections: list[int],
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, ready_connections=ready_connections)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "still reports ready connections" in result.stderr
+    assert (harness.evidence / "interruption-observations.jsonl").stat().st_size > 0
+
+
+def test_malformed_ready_response_fails_closed_with_evidence(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, ready_malformed=1)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "unavailable or malformed" in result.stderr
+    observation = json.loads((harness.evidence / "interruption-observations.jsonl").read_text().splitlines()[-1])
+    assert observation["readyEndpoints"][1] == {"httpStatus": None, "readyConnections": None}
+
+
+def test_prometheus_target_loss_fails_closed_with_evidence(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, prom_targets_during=1)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "Prometheus target became unavailable" in result.stderr
+    observation = json.loads((harness.evidence / "interruption-observations.jsonl").read_text().splitlines()[-1])
+    assert observation["prometheusTargetCount"] == 1
+
+
+def test_deployment_resource_version_only_change_passes(tmp_path: Path) -> None:
+    result = StatefulDrillHarness(tmp_path).run()
+    assert result.returncode == 0, result.stderr
+
+
+def test_deployment_desired_or_ownership_change_fails(tmp_path: Path) -> None:
+    result = StatefulDrillHarness(tmp_path, deployment_change=True).run()
+    assert result.returncode != 0
+    assert "Deployment desired or ownership state changed" in result.stderr
 
 
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Correct the drill's incorrect requirement that the aggregate HA gauge equal zero as the authoritative outage signal, replacing it with an authoritative per-connector `/ready` proof that `readyConnections == 0` while preserving same-pod identity and restart-count guarantees.
- Strengthen forensic evidence and make the Deployment invariance comparison robust to status-only `resourceVersion` churn so a status reconciliation does not cause a false failure.
- Model the realistic cloudflared semantics (HA floor of two during WAN loss) in the stateful test harness and add focused, fail-closed regression coverage for malformed readiness output, Prometheus target loss, UID/restart drift, and desired-state changes.

### Description

- Require identity-guarded on-node `/ready` queries inside the validated CRI sandbox/netns using `nsenter` and a preflighted `curl` binary, parse and sanitize the response to only store HTTP status and numeric `readyConnections`, and never emit connector IDs or secret values. (changed `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Replace the zero-HA requirement with these authoritative checks while retaining the HA gauge as supporting evidence (recorded per-poll) and continuing to require pre/post disruption HA >= 4 on recovery. (changed `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Persist deterministic, sanitized JSONL interruption observations on every poll (elapsed time, pod uid/restart/Ready, sanitized `/ready` result, Prometheus target count, and observed HA values) so failed polls leave usable forensic evidence. (changed `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Change the Deployment fingerprint to compare stable desired/ownership fields only (UID, `generation`, labels, annotations, and `spec`) and exclude `metadata.resourceVersion`; separately require `status.observedGeneration` to equal the unchanged `metadata.generation`. (changed `scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Update the offline stateful harness to model: preflight HA total 8, during-disruption both pods Ready=False, `/ready` returning HTTP 503 with `readyConnections: 0` per connector, Prometheus targets remaining up, HA aggregate remaining at a realistic floor (e.g. 2), recovery back to HA total 8, and a Deployment `resourceVersion` advance during the transition. Add focused failing tests for nonzero readyConnections, malformed `/ready`, Prometheus target loss, UID/restart change, and desired/ownership changes. (changed `tests/test_cloudflare_wan_dependency_loss_drill.py`)
- Update documentation to explain why the HA gauge can remain >0 during WAN loss, to document the authoritative zero-ready-connections proof, to record the August 11 safely cleaned-up failed proof, and to explain that `resourceVersion` may advance and is excluded from desired-state equality. (changed `docs/cloudflare_tunnel.md`)
- Preserve all existing safety contracts: offline default plan, staging-only `--execute`, exact-table deletion, cleanup watchdogs, 180s disruption, 240s watchdog, 300s recovery, never reading Secret values, and never mutating production or Helm charts.

Files modified: `scripts/cloudflare_wan_dependency_loss_drill.sh`, `tests/test_cloudflare_wan_dependency_loss_drill.py`, `docs/cloudflare_tunnel.md`.

### Testing

- `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — syntax check succeeded. (passed)
- `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — full suite run in this environment: 107 passed. (passed)
- `bash scripts/cloudflare_wan_dependency_loss_drill.sh` — verified default invocation prints the offline, non-mutating plan only. (passed)
- `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — no whitespace or secret findings. (passed)
- `just cf-tunnel-wan-dependency-loss-drill env=staging` — `just` is not installed in this environment so the `just` invocation could not be executed; the helper's offline plan and behavior were validated directly. (environment limitation)
- `pre-commit run --all-files`, `pyspelling -c .spellcheck.yaml`, `linkchecker --no-warnings README.md docs/` — tooling not available in the runner; these checks were not executed here. (environment limitation)

All automated tests added or updated for the new contract pass locally in the test harness; no live drill, cluster mutation, Helm release, Secret value access, or production changes were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b86f64788832f82f6b49491c71c17)