### PR TITLE
Fix Cloudflare WAN drill proof: require per-pod /ready==503 zero-readyConnections, drop resourceVersion from fingerprint, persist JSONL evidence

### DIFF
--- a/docs/cloudflare_tunnel.md
+++ b/docs/cloudflare_tunnel.md
@@ -567,8 +567,15 @@ part of this rollout.
    privileged namespace operation, and rejects an ambiguous sandbox or pre-existing owner table. Each
    transient watchdog enters and holds the validated namespace before disruption, avoiding delayed PID
    reuse, and all watchdog binary paths are preflighted on both affected nodes. It then proves the
-   original UIDs become NotReady with zero HA connections and
-   unchanged restart counts. Cleanup deletes only the exact owner table, including after signals and
+   original UIDs become NotReady with unchanged restart counts. For each original process it enters
+   the already validated network namespace and queries `/ready`, retaining only the HTTP status and
+   `readyConnections`; a pass requires HTTP 503 with zero ready connections from both processes while
+   both Prometheus scrape targets remain up. The HA gauge is still recorded as supporting evidence,
+   but is not the authoritative interruption check: cloudflared 2026.7.3 increments that gauge when a
+   `Serve` attempt starts and decrements it only when the attempt returns, so one retrying attempt per
+   connector can leave an aggregate value of two after connected edge sessions have fallen to zero.
+   Every poll is appended to sanitized JSONL evidence even when the drill fails. Cleanup deletes only
+   the exact owner table, including after signals and
    partial or ambiguously reported setup. A node remains cleanup-eligible until both exact deletion and
    table absence are proven; normal-cleanup failure leaves it available to the EXIT retry. Failure to
    prove automatic cleanup fails closed and prints exact UID/inode-guarded, node-specific manual cleanup
@@ -576,10 +583,28 @@ part of this rollout.
 6. Recovery must use the same UIDs with unchanged restart counts. Within five minutes both pods must be
    Ready with at least four HA connections apiece; all approved public endpoints must return HTTP 200;
    Helm histories, including the single deployed observability release at the explicitly approved
-   revision, Secret metadata, and Deployment state must be unchanged; and
+   revision, Secret metadata, and Deployment desired/ownership state must be unchanged; and
    `just cf-tunnel-verify env=staging` must pass. The helper never requests the Secret value. Finally,
    `unset CF_TUNNEL_TOKEN CF_TUNNEL_NAME CF_TUNNEL_ID`; retain the two healthy pods, Service,
    ServiceMonitor, and PDB.
+
+   Deployment `metadata.resourceVersion` is not desired state and may advance when Kubernetes
+   reconciles status during the readiness transition. The helper therefore compares the Deployment
+   UID, generation, labels, annotations, and spec, excludes dynamic status and resource version from
+   that fingerprint, and separately requires final `status.observedGeneration` to equal the unchanged
+   generation.
+
+   The first authorized execution of the namespace-local helper on August 11, 2026 was a **safely
+   cleaned-up failed proof**, not a passing drill and not evidence for #2407. Both original pods became
+   NotReady without UID or restart-count changes, both metrics targets remained up, and readiness
+   telemetry reached zero connected sessions; however, the old contract incorrectly required the HA
+   gauge to reach zero. It remained at two retrying `Serve` attempts. EXIT cleanup removed both exact
+   tables and watchdog units, and subsequent reconciliation proved the same pods healthy, all 16
+   staging endpoints HTTP 200, unchanged Helm histories and Secret metadata, and no residual drill
+   objects. The Deployment resource version also advanced due to the status transition, exposing the
+   second invalid fingerprint assumption. A new live retry requires this fix to be merged, a fresh
+   read-only gate, newly approved exact main and observability revisions, and separate explicit staging
+   authorization. Production remains explicitly out of scope.
 
 Rollback immediately if no connector stays Ready, a public endpoint fails for two consecutive
 one-minute checks, a replacement does not reach four HA connections within five minutes, metrics

--- a/scripts/cloudflare_wan_dependency_loss_drill.sh
+++ b/scripts/cloudflare_wan_dependency_loss_drill.sh
@@ -9,6 +9,7 @@ readonly EXPECTED_HELM_REVISION=2
 readonly CONFIRMATION='DISRUPT STAGING CLOUDFLARE WAN FOR SAME-PROCESS RECOVERY'
 readonly SELECTOR='app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance=cloudflare-tunnel'
 readonly CRICTL='/usr/local/bin/crictl'
+readonly CURL='/usr/bin/curl'
 readonly DISRUPTION_SECONDS=180
 readonly RECOVERY_SECONDS=300
 
@@ -186,7 +187,8 @@ jq -e --arg image "${EXPECTED_IMAGE}" '
  and .spec.template.spec.containers[0].readinessProbe.httpGet.path=="/ready"
  and .spec.template.spec.containers[0].readinessProbe.httpGet.port==2000
 ' <<<"${deployment}" >/dev/null || die 'Deployment ownership, replicas, immutable image is not approved, or probe lifecycle is unsafe'
-deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
+deployment_generation="$(jq -r '.metadata.generation' <<<"${deployment}")"
+deployment_fingerprint="$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${deployment}" | sha256sum | cut -d' ' -f1)"
 
 # Reuse the repository verifier's complete strategy/topology/probe contract before mutation.
 just cf-tunnel-verify env=staging
@@ -236,7 +238,7 @@ fi
 
 table="$(table_for)"
 for i in 0 1; do
-  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
+  node_exec "${pod_nodes[$i]}" "test -x ${CRICTL} -a -x ${CURL} -a -x /usr/bin/jq -a -x /usr/bin/readlink -a -x /usr/bin/nsenter -a -x /usr/bin/systemd-run -a -x /usr/bin/systemctl -a -x /bin/sh -a -x /bin/sleep -a -x /usr/sbin/nft" >/dev/null || die "required remote binary path missing on ${pod_nodes[$i]}"
   resolve="sudo ${CRICTL} pods --name '^${pod_names[$i]}$' -q"
   sandbox="$(node_exec "${pod_nodes[$i]}" "${resolve}")"
   [[ "${sandbox}" != *$'\n'* && "${sandbox}" =~ ^[a-f0-9]{12,64}$ ]] || die "cannot resolve one exact sandbox for ${pod_names[$i]}"
@@ -290,20 +292,51 @@ done
 
 disruption_started="${SECONDS}"
 deadline=$((SECONDS+90)); interrupted=0
+: >"${evidence_dir}/interruption-observations.jsonl"
 while ((SECONDS < deadline)); do
   current="$(kubectl -n cloudflare get pods -l "${SELECTOR}" -o json)"
   unchanged="$(jq --arg u0 "${pod_uids[0]}" --arg u1 "${pod_uids[1]}" --argjson r0 "${pod_restarts[0]}" --argjson r1 "${pod_restarts[1]}" '
     [.items[]|select(.metadata.deletionTimestamp==null)] as $p | ($p|length)==2 and
     ([$p[].metadata.uid]|sort)==([$u0,$u1]|sort) and
     all($p[];([.status.containerStatuses[].restartCount]|add)==(if .metadata.uid==$u0 then $r0 else $r1 end))' <<<"${current}")"
-  [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
   same="$(jq 'all(.items[]; any(.status.conditions[]?;.type=="Ready" and .status=="False"))' <<<"${current}")"
-  [[ "${same}" == true ]] || { sleep 5; continue; }
-  [[ "$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' | jq -r '.data.result[0].value[1]//"-1"')" == 0 ]] && { interrupted=1; break; }
+  ready_results=()
+  ready_ok=1
+  for i in 0 1; do
+    ready_command="test \"\$(sudo ${CRICTL} inspectp ${pod_sandboxes[$i]} | /usr/bin/jq -r '.status.labels[\"io.kubernetes.pod.uid\"]')\" = '${pod_uids[$i]}' && test \"\$(sudo /usr/bin/readlink /proc/${pod_pids[$i]}/ns/net)\" = '${pod_netns[$i]}' && response=\"\$(sudo /usr/bin/nsenter -t ${pod_pids[$i]} -n ${CURL} -sS --max-time 5 -w '\n%{http_code}' http://127.0.0.1:2000/ready)\" && status=\"\${response##*$'\n'}\" && body=\"\${response%$'\n'*}\" && /usr/bin/jq -ce --argjson status \"\${status}\" '(.readyConnections | numbers) as \$ready | {status:\$status,readyConnections:\$ready}' <<<\"\${body}\""
+    if ready_result="$(node_exec "${pod_nodes[$i]}" "${ready_command}")" &&
+      /usr/bin/jq -e '(.status|type)=="number" and (.readyConnections|type)=="number"' <<<"${ready_result}" >/dev/null; then
+      ready_results+=("${ready_result}")
+    else
+      ready_results+=('{"status":null,"readyConnections":null}')
+      ready_ok=0
+    fi
+  done
+  targets=-1
+  ha=-1
+  targets_response=''
+  ha_response=''
+  if targets_response="$(prom_query 'count(up{namespace="cloudflare",service="cloudflare-tunnel-metrics"} == 1)')"; then
+    targets="$(jq -r '.data.result[0].value[1]//"-1"' <<<"${targets_response}" 2>/dev/null || printf '%s' -1)"
+  fi
+  if ha_response="$(prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})')"; then
+    ha="$(jq -r '.data.result[0].value[1]//"-1"' <<<"${ha_response}" 2>/dev/null || printf '%s' -1)"
+  fi
+  [[ "${targets}" =~ ^-?[0-9]+([.][0-9]+)?$ ]] || targets=-1
+  [[ "${ha}" =~ ^-?[0-9]+([.][0-9]+)?$ ]] || ha=-1
+  jq -cn --argjson elapsed "$((SECONDS-disruption_started))" --argjson pods "$(jq -c '[.items[] | {uid:.metadata.uid,restartCount:([.status.containerStatuses[].restartCount]|add),ready:([.status.conditions[]?|select(.type=="Ready")|.status][0]//null)}]' <<<"${current}")" --argjson ready "$(printf '%s\n' "${ready_results[@]}" | jq -s .)" --argjson targets "${targets}" --argjson ha "${ha}" '{elapsedSeconds:$elapsed,pods:$pods,readiness:$ready,prometheusTargetCount:$targets,haConnections:$ha}' >>"${evidence_dir}/interruption-observations.jsonl"
+  [[ "${unchanged}" == true ]] || die 'connector UID/restart set changed during interruption'
+  ((ready_ok)) || die 'connector readiness endpoint was unavailable or malformed during interruption'
+  [[ "${targets}" == 2 ]] || die 'Prometheus target became unavailable during interruption'
+  if [[ "${same}" == true ]]; then
+    jq -e 'all(.[]; .status == 503 and .readyConnections == 0)' <<<"$(printf '%s\n' "${ready_results[@]}" | jq -s .)" >/dev/null || \
+      die 'did not prove same-process NotReady and zero ready connections'
+    interrupted=1
+    break
+  fi
   sleep 5
 done
-((interrupted)) || die 'did not prove same-process NotReady and zero HA connections'
-prom_query 'sum(cloudflared_tunnel_ha_connections{namespace="cloudflare",service="cloudflare-tunnel-metrics"})' >"${evidence_dir}/interruption-metrics.json"
+((interrupted)) || die 'did not prove same-process NotReady and zero ready connections'
 remaining=$((DISRUPTION_SECONDS-(SECONDS-disruption_started)))
 if ((remaining > 0)); then sleep "${remaining}"; fi
 
@@ -345,6 +378,7 @@ recovery_obs_history="$(helm -n monitoring history kube-prometheus-stack -o json
 validate_observability_history "${recovery_obs_history}" 'post-cleanup'
 [[ "${recovery_obs_history}" == "${obs_history}" ]] || die "observability Helm history changed (expected deployed revision ${expected_observability_revision}; observed ${observed_observability_revision})"
 final_deployment="$(kubectl -n cloudflare get deployment cloudflare-tunnel -o json)"
-[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,resourceVersion:.metadata.resourceVersion,generation:.metadata.generation},spec:.spec,statusObserved:.status.observedGeneration}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment state changed'
+[[ "$(jq -S '{metadata:{labels:.metadata.labels,annotations:.metadata.annotations,uid:.metadata.uid,generation:.metadata.generation},spec:.spec}' <<<"${final_deployment}" | sha256sum | cut -d' ' -f1)" == "${deployment_fingerprint}" ]] || die 'Deployment desired or ownership state changed'
+[[ "$(jq -r '.status.observedGeneration' <<<"${final_deployment}")" == "${deployment_generation}" ]] || die 'Deployment observedGeneration does not match unchanged generation'
 just cf-tunnel-verify env=staging
 printf 'PASS: same cloudflared processes recovered; observability revision expected=%s observed=%s; sanitized evidence: %s\n' "${expected_observability_revision}" "${observed_observability_revision}" "${evidence_dir}"

--- a/tests/test_cloudflare_wan_dependency_loss_drill.py
+++ b/tests/test_cloudflare_wan_dependency_loss_drill.py
@@ -37,6 +37,8 @@ class StatefulDrillHarness:
             "sandbox_fail": False, "collision": False, "install_fail": -1,
             "crictl_paths": ["/usr/local/bin/crictl"],
             "restart": [0, 0], "tables": [False, False], "watchdogs": [False, False],
+            "ready_connections": [0, 0], "ready_malformed": -1, "targets_during": 2,
+            "deployment_change": False, "uid_change_during": False,
             "block_long_sleep": False, "secret": "SENTINEL-SECRET-MUST-NOT-LEAK",
         }
         state.update(overrides)
@@ -151,14 +153,18 @@ elif name == "kubectl":
     joined = " ".join(args)
     if "current-context" in joined: out(state["context"])
     elif "get deployment" in joined:
+        state["deployment_calls"] = state.get("deployment_calls", 0) + 1
         used = image if state["image_ok"] else "cloudflare/cloudflared:wrong"
-        out(json.dumps({"metadata":{"labels":{"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}}))
+        labels={"app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}
+        if state["deployment_change"] and state["deployment_calls"] > 1: labels["changed"]="true"
+        out(json.dumps({"metadata":{"uid":"deployment-uid","generation":1,"resourceVersion":"12" if state["deployment_calls"] == 1 else "13","labels":labels,"annotations":{"meta.helm.sh/release-name":"cloudflare-tunnel"}},"spec":{"replicas":2,"template":{"spec":{"containers":[{"image":used,"readinessProbe":{"httpGet":{"path":"/ready","port":2000}}}]}}},"status":{"observedGeneration":1}})); save()
     elif "get pods" in joined:
         items=[]
         for i in range(state["pod_count"]):
             disrupted = i < 2 and state["tables"][i]
             restart = state["restart"][i] if i < 2 else 0
-            items.append({"metadata":{"name":f"connector-{i+1}","uid":f"uid-{i+1}","labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
+            uid = f"replacement-{i+1}" if disrupted and state["uid_change_during"] else f"uid-{i+1}"
+            items.append({"metadata":{"name":f"connector-{i+1}","uid":uid,"labels":{"app.kubernetes.io/name":"cloudflare-tunnel","app.kubernetes.io/instance":"cloudflare-tunnel"}},"spec":{"nodeName":"node-1" if state["same_node"] else f"node-{i+1}","containers":[{"image":image}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False" if disrupted else "True"}],"containerStatuses":[{"restartCount":restart}]}})
         out(json.dumps({"items":items}))
         event("pods", uids=[p["metadata"]["uid"] for p in items], restarts=[p["status"]["containerStatuses"][0]["restartCount"] for p in items], ready=[p["status"]["conditions"][0]["status"] for p in items])
     elif "get secret" in joined:
@@ -168,7 +174,8 @@ elif name == "kubectl":
     elif "get --raw" in joined:
         query=urllib.parse.unquote(joined)
         if "ALERTS" in query: value=state["alerts"]
-        elif "sum(cloudflared" in query: value=0 if all(state["tables"]) else 8
+        elif "sum(cloudflared" in query: value=2 if all(state["tables"]) else 8
+        elif "count(up" in query: value=state["targets_during"] if all(state["tables"]) else 2
         else: value=2
         event("prometheus", query=query, value=value)
         out(json.dumps({"data":{"result":[{"value":[0,str(value)]}]}}))
@@ -190,6 +197,9 @@ elif name == "node-executor":
         out(json.dumps({"status":{"labels":{"io.kubernetes.pod.uid":f"uid-{idx+1}"}},"info":{"pid":101+idx}}))
     elif command.startswith("sudo /usr/bin/readlink /proc/"):
         out(f"net:[{1001+idx}]")
+    elif "http://127.0.0.1:2000/ready" in command:
+        if state["ready_malformed"] == idx: out("not-json")
+        else: out(json.dumps({"status":503,"readyConnections":state["ready_connections"][idx]}))
     elif "systemd-run" in command:
         state["watchdogs"][idx]=True; save(); event("watchdog", node=node, verified=False)
     elif "systemctl is-active" in command:
@@ -343,6 +353,8 @@ def test_only_approved_crictl_path_is_encoded_in_the_helper() -> None:
     assert "command -v crictl" not in TEXT
     assert "sudo crictl" not in TEXT
     assert 'test -x ${CRICTL}' in TEXT
+    assert "readonly CURL='/usr/bin/curl'" in TEXT
+    assert 'test -x ${CRICTL} -a -x ${CURL}' in TEXT
 
 
 def test_manual_commands_expand_the_immutable_crictl_path(tmp_path: Path) -> None:
@@ -628,7 +640,7 @@ def test_lifecycle_contract_is_checked_before_disruption() -> None:
 
 
 def test_interruption_requires_same_uids_and_restart_counts() -> None:
-    assert "did not prove same-process NotReady and zero HA connections" in TEXT
+    assert "did not prove same-process NotReady and zero ready connections" in TEXT
     interruption = TEXT.split("deadline=$((SECONDS+90))", 1)[1].split(
         'sleep "${DISRUPTION_SECONDS}"', 1
     )[0]
@@ -692,7 +704,7 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert any(event["ready"] == ["False", "False"] for event in pod_events)
     assert pod_events[-1]["ready"] == ["True", "True"]
     assert all(event["uids"] == ["uid-1", "uid-2"] and event["restarts"] == [0, 0] for event in pod_events)
-    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 0 for event in events if event.get("event") == "prometheus")
+    assert any("sum(cloudflared" in str(event["query"]) and event["value"] == 2 for event in events if event.get("event") == "prometheus")
     assert sum(entry["tool"] == "just" for entry in commands) == 2
     assert len([event for event in events if event.get("event") == "endpoint"]) == 32
     preflight = json.loads((harness.evidence / "preflight.json").read_text())
@@ -700,8 +712,38 @@ def test_actual_helper_completes_stateful_interruption_and_recovery(tmp_path: Pa
     assert "observability revision expected=10 observed=10" in result.stdout
     assert [pod["restartCount"] for pod in preflight["pods"]] == [0, 0]
     assert all(pod["image"].startswith("cloudflare/cloudflared:") for pod in preflight["pods"])
-    assert (harness.evidence / "interruption-metrics.json").exists()
+    observations = [json.loads(line) for line in (harness.evidence / "interruption-observations.jsonl").read_text().splitlines()]
+    assert observations[-1]["readiness"] == [{"status": 503, "readyConnections": 0}] * 2
+    assert observations[-1]["prometheusTargetCount"] == 2
+    assert observations[-1]["haConnections"] == 2
     assert (harness.evidence / "recovery-metrics.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"ready_connections": [1, 0]}, "did not prove same-process NotReady and zero ready connections"),
+        ({"ready_malformed": 1}, "readiness endpoint was unavailable or malformed"),
+        ({"targets_during": 1}, "Prometheus target became unavailable"),
+        ({"deployment_change": True}, "Deployment desired or ownership state changed"),
+    ],
+)
+def test_interruption_and_deployment_failures_leave_sanitized_evidence(
+    tmp_path: Path, override: dict[str, object], message: str,
+) -> None:
+    harness = StatefulDrillHarness(tmp_path, **override)
+    result = harness.run(timeout=120)
+    assert result.returncode != 0
+    assert message in result.stderr
+    observations = harness.evidence / "interruption-observations.jsonl"
+    assert observations.exists() and observations.read_text().strip()
+    assert "connectorId" not in observations.read_text()
+
+
+def test_deployment_resource_version_only_change_passes(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path)
+    result = harness.run()
+    assert result.returncode == 0, result.stderr
 
 
 def test_execution_commands_use_only_the_approved_crictl_path(tmp_path: Path) -> None:
@@ -924,6 +966,16 @@ def test_actual_helper_rejects_accidental_restart(tmp_path: Path) -> None:
     assert changed, "helper never installed both disruption tables"
     assert process.returncode != 0, stdout
     assert "UID/restart set changed" in stderr
+    assert harness.current()["tables"] == [False, False]
+
+
+def test_actual_helper_rejects_uid_change_and_keeps_observation(tmp_path: Path) -> None:
+    harness = StatefulDrillHarness(tmp_path, uid_change_during=True)
+    result = harness.run()
+    assert result.returncode != 0
+    assert "UID/restart set changed" in result.stderr
+    evidence = harness.evidence / "interruption-observations.jsonl"
+    assert evidence.exists() and "replacement-1" in evidence.read_text()
     assert harness.current()["tables"] == [False, False]
 
 


### PR DESCRIPTION
### Motivation

- A staged run showed the previous proof contract was invalid because the HA gauge can remain >0 during WAN loss (retrying Serve attempts), so insisting HA==0 produced false failures.  The drill must instead prove each original process reports zero ready connections from its `/ready` endpoint while remaining the same pod/process.
- `metadata.resourceVersion` advanced during a status-only transition and caused an unwarranted Deployment mismatch; resourceVersion and dynamic status must not be part of the desired-state fingerprint.
- The operator needs deterministic, sanitized interruption evidence for every poll (including failed attempts) to diagnose failures without leaking secrets or connector identifiers.

### Description

- Replace the invalid HA==0 interruption requirement with authoritative per-connector `/ready` checks executed inside the validated CRI sandbox network namespace via the node executor and `nsenter`, preflighting the exact `curl` path; parse only sanitized fields (`HTTP status` and `readyConnections`) and never record `connectorId` or Secret values. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Persist a deterministic JSONL file `interruption-observations.jsonl` with every poll containing elapsed time, pod UID/restart/Ready state, sanitized `/ready` result and `readyConnections`, Prometheus target count, and observed HA gauge; fail closed on unreadable/malformed `/ready`, identity changes, restart, or metrics-target loss. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Keep HA gauge recording as supporting evidence (not authoritative) and continue preflight/recovery requirements of >=4 HA connections per connector. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Change Deployment fingerprint to exclude `metadata.resourceVersion` and other dynamic status; fingerprint now covers Deployment UID, generation, labels, annotations, and `spec`, and the final `status.observedGeneration` is required to equal the unchanged `metadata.generation`. (`scripts/cloudflare_wan_dependency_loss_drill.sh`)
- Update the stateful offline test harness to model a realistic HA floor of 2 during the interruption, require both `/ready` responses to be HTTP 503 with `readyConnections: 0`, keep Prometheus targets reachable, and simulate resourceVersion-only churn; add focused failure tests for non-zero readyConnections, malformed `/ready` output, metrics-target loss, UID/restart changes, and a real desired-state/ownership change; remove tests that required HA==0. (`tests/test_cloudflare_wan_dependency_loss_drill.py`)
- Update documentation to explain cloudflared 2026.7.3 gauge semantics, the authoritative zero-ready-connections proof, Deployment `resourceVersion` guidance, and to record the August 11 safely cleaned-up failed proof and required authorization for any future live attempt. (`docs/cloudflare_tunnel.md`)

### Testing

- Ran `bash -n scripts/cloudflare_wan_dependency_loss_drill.sh` — syntax check passed.  No live cluster commands were executed during testing.
- Ran full unit/behavioral tests: `python -m pytest -q tests/test_cloudflare_wan_dependency_loss_drill.py` — all tests passed (106 passed).  Focused subset run for targeted changes (`-k 'uid_change or approved_crictl_path or actual_helper_completes or interruption_and_deployment or resource_version'`) also passed (9 passed).
- Verified the offline plan printing: `just cf-tunnel-wan-dependency-loss-drill env=staging` — printed the non-mutating plan only.
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — passed (no secrets or diff-check issues discovered).
- CI-local tools missing: `pre-commit`, `pyspelling`, and `linkchecker` were not available in this environment so those steps were not executed here; they should run in CI or by maintainers before merging.

Notes and residual risk

- No live drill, cluster mutations, Helm releases, Secret values, or production changes were performed as part of this work; tests use an offline shim to model behavior.
- A future, authorized live retry still requires explicit, separate approvals (approved main revision and observability revision, node executor, and the typed confirmation) before `--execute` is permitted.
- Follow-up: ensure CI runs `pre-commit`, `pyspelling`, and `linkchecker` as part of the merge validation and that the node executor in environments used for live runs has `curl` at the preflighted path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b86f94514832fb8dc8ec7c34f8769)