### PR TITLE
Fix Helm 3.19 release identity reconciliation

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -280,6 +280,50 @@ def helm_status(
     )
 
 
+def helm_snapshot(
+    runner: Runner,
+    kubeconfig: str,
+    release_name: str,
+    namespace: str,
+    expected_chart_version: str | None,
+) -> tuple[dict[str, Any], object, tuple[str, str, int]]:
+    """Read and validate one redaction-safe Helm release identity snapshot."""
+    status = helm_status(runner, kubeconfig, release_name, namespace)
+    history: object = None
+    try:
+        if release.helm_status_needs_history(status):
+            try:
+                history = json.loads(
+                    runner(
+                        [
+                            "helm",
+                            "--kubeconfig",
+                            kubeconfig,
+                            "history",
+                            release_name,
+                            "--namespace",
+                            namespace,
+                            "-o",
+                            "json",
+                        ]
+                    )
+                )
+            except (json.JSONDecodeError, OSError) as exc:
+                raise RollbackError("Helm history did not return valid JSON") from exc
+        identity = release.resolve_helm_identity(status, history, "dspace", expected_chart_version)
+    except release.ManifestError as exc:
+        raise RollbackError("invalid Helm release identity") from exc
+    info = status.get("info")
+    if (
+        status.get("name") != release_name
+        or status.get("namespace") != namespace
+        or not isinstance(info, dict)
+        or info.get("status") != "deployed"
+    ):
+        raise RollbackError("invalid Helm release identity")
+    return status, history, identity
+
+
 def cluster_environment(runner: Runner, kubeconfig: str) -> str:
     nodes = json_command(
         runner,
@@ -379,7 +423,14 @@ def summary(
     current_pods: list[dict[str, Any]],
     target: dict[str, Any],
     values: list[dict[str, str]],
+    current_identity: tuple[str, str, int] | None = None,
 ) -> str:
+    if current_identity is None:
+        current_identity = (
+            str(current.get("chart", {}).get("metadata", {}).get("name") or "unknown"),
+            chart_version(current) or "unknown",
+            revision(current),
+        )
     images = sorted({application_image(pod) for pod in current_pods if application_image(pod)})
     image_ids = sorted(
         {application_image_id(pod) for pod in current_pods if application_image_id(pod)}
@@ -390,9 +441,8 @@ def summary(
         (
             "  current: release=dspace namespace=dspace "
             f"helmStatus={info.get('status') or 'unknown'} "
-            f"helmRevision={revision(current)} chartName="
-            f"{current.get('chart', {}).get('metadata', {}).get('name') or 'unknown'} "
-            f"chartVersion={chart_version(current) or 'unknown'} chartDigest=unknown"
+            f"helmRevision={current_identity[2]} chartName={current_identity[0]} "
+            f"chartVersion={current_identity[1]} chartDigest=unknown"
         ),
         (
             f"           images={','.join(images) or 'unknown'} "
@@ -484,9 +534,7 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
 
 
 def assert_production_target(kubeconfig: str, runner: Runner) -> None:
-    context = runner(
-        ["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]
-    ).strip()
+    context = runner(["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]).strip()
     if context != "sugar-prod":
         raise RollbackError("metrics configuration reconciliation requires sugar-prod")
     runner(
@@ -594,12 +642,18 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.tag={image_value}",
         ]
     )
-    before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+    before_helm, before_history, before_identity = helm_snapshot(
+        runner,
+        args.kubeconfig,
+        "dspace",
+        "dspace",
+        None,
+    )
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if revision(before_helm) != target["helmRevision"]:
+        if before_identity[2] != target["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -614,7 +668,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if chart_version(before_helm) != target["chartVersion"]:
+        if before_identity[:2] != ("dspace", target["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -712,7 +766,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
     except release.ManifestError as exc:
         raise RollbackError("OCI preflight validation failed") from exc
-    print(summary(before_helm, before_pods, target, values_proof))
+    print(summary(before_helm, before_pods, target, values_proof, before_identity))
     current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
     current_ids: set[str] = set()
     for pod in before_pods:
@@ -776,8 +830,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
-    if revision(helm_status(runner, args.kubeconfig, "dspace", "dspace")) != revision(before_helm):
-        raise RollbackError("Helm revision changed during preflight")
+    pre_reserve_helm, _, pre_reserve_identity = helm_snapshot(
+        runner,
+        args.kubeconfig,
+        "dspace",
+        "dspace",
+        target["chartVersion"] if configuration_reconciliation else None,
+    )
+    if pre_reserve_identity != before_identity:
+        raise RollbackError("Helm identity changed during preflight")
 
     invocation = uuid.uuid4().hex
     target_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
@@ -810,9 +871,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "values": values_proof,
         "before": {
-            "helmRevision": revision(before_helm),
+            "helmRevision": before_identity[2],
             "helmStatus": before_helm.get("info", {}).get("status"),
-            "chartVersion": chart_version(before_helm),
+            "chartName": before_identity[0],
+            "chartVersion": before_identity[1],
             "pods": before_pods,
         },
         "ociPreflight": oci,
@@ -831,11 +893,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
         if configuration_reconciliation:
-            current_status = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-            if (
-                revision(current_status) != revision(before_helm)
-                or chart_version(current_status) != target["chartVersion"]
-            ):
+            current_status, _, current_identity = helm_snapshot(
+                runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+            )
+            if current_identity != before_identity:
                 raise RollbackError("Helm coordinates changed before mutation")
             current_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
             if current_pods != before_pods:
@@ -923,8 +984,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             if time.monotonic() >= deadline:
                 raise RollbackError("timed out waiting for old terminating pods to disappear")
             time.sleep(POLL_INTERVAL)
-        after_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        after_revision = revision(after_helm)
+        after_helm, after_history, after_identity = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+        )
+        after_revision = after_identity[2]
         if (
             after_helm.get("name") != "dspace"
             or after_helm.get("namespace") != "dspace"
@@ -933,15 +996,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= revision(before_helm):
+        if after_revision <= before_identity[2]:
             raise RollbackError("Helm revision did not advance")
-        if (
-            after_helm.get("chart", {}).get("metadata", {}).get("name") != "dspace"
-            or chart_version(after_helm) != target["chartVersion"]
-        ):
-            raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
-            chart_version(before_helm) != target["chartVersion"]
+            before_identity[1] != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
             or current_images
             != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
@@ -1031,6 +1089,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             invocation_description=description,
             expected_image_coordinate=f"{release.IMAGE_REF}:{image_value}",
             helm_stored_values_result=helm_stored_values_result,
+            helm_history=after_history,
         )
         verifier_command = [
             str(args.verifier),
@@ -1079,8 +1138,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 ]
             )
         failed_stage = "revision-stability-collection"
-        stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        if revision(stable) != after_revision:
+        stable, _, stable_identity = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+        )
+        if stable_identity != after_identity:
             raise RollbackError("Helm revision changed concurrently during evidence collection")
         result = {
             **evidence,
@@ -1088,11 +1149,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "completedAt": timestamp(),
             "sugarkubeRevision": sugarkube_revision,
             "helm": {
-                "beforeRevision": revision(before_helm),
+                "beforeRevision": before_identity[2],
                 "afterRevision": after_revision,
                 "status": "deployed",
                 "chartName": "dspace",
-                "chartVersion": chart_version(after_helm),
+                "chartVersion": after_identity[1],
             },
             "pods": {"before": before_pods, "after": after_pods},
             "verification": {
@@ -1129,18 +1190,18 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         diagnostics: dict[str, Any] = {}
         if production_target_verified:
             try:
-                observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+                observed_helm, _, observed_identity = helm_snapshot(
+                    runner, args.kubeconfig, "dspace", "dspace", None
+                )
                 observed_info = observed_helm.get("info", {})
-                observed_chart = observed_helm.get("chart", {}).get("metadata", {})
                 diagnostics["helm"] = {
                     "release": observed_helm.get("name"),
                     "namespace": observed_helm.get("namespace"),
-                    "revision": revision(observed_helm),
+                    "revision": observed_identity[2],
                     "status": observed_info.get("status"),
-                    "chartName": observed_chart.get("name"),
-                    "chartVersion": chart_version(observed_helm),
-                    "invocationDescriptionMatches": observed_info.get("description")
-                    == description,
+                    "chartName": observed_identity[0],
+                    "chartVersion": observed_identity[1],
+                    "invocationDescriptionMatches": observed_info.get("description") == description,
                 }
             except Exception:
                 diagnostics["helm"] = "unavailable"

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -125,7 +125,7 @@ def resolve_helm_identity(
     status: object,
     history: object,
     expected_name: str,
-    expected_version: str,
+    expected_version: str | None,
 ) -> tuple[str, str, int]:
     """Resolve an exact chart identity, using history only when status omits it."""
     metadata_missing = helm_status_needs_history(status)
@@ -136,17 +136,26 @@ def resolve_helm_identity(
         if not isinstance(metadata, dict):
             raise ManifestError("invalid Helm release identity")
         name, version = metadata.get("name"), metadata.get("version")
-        if name != expected_name or version != expected_version:
+        if (
+            name != expected_name
+            or not isinstance(version, str)
+            or not version
+            or (expected_version is not None and version != expected_version)
+        ):
             raise ManifestError("invalid Helm release identity")
         return name, version, revision
 
     if not isinstance(history, list):
         raise ManifestError("invalid Helm release identity")
     matches = []
+    history_revisions = []
     for record in history:
         if not isinstance(record, dict):
             raise ManifestError("invalid Helm release identity")
-        record_revision = record.get("revision")
+        raw_revision = record.get("revision")
+        record_revision = raw_revision
+        if isinstance(raw_revision, str) and re.fullmatch(r"[1-9][0-9]*", raw_revision):
+            record_revision = int(raw_revision)
         coordinate = record.get("chart")
         if (
             type(record_revision) is not int
@@ -155,11 +164,21 @@ def resolve_helm_identity(
             or not coordinate
         ):
             raise ManifestError("invalid Helm release identity")
+        history_revisions.append(record_revision)
         if record_revision == revision:
             matches.append(record)
-    if len(matches) != 1 or matches[0]["chart"] != f"{expected_name}-{expected_version}":
+    coordinate = matches[0]["chart"] if len(matches) == 1 else None
+    prefix = f"{expected_name}-"
+    if (
+        len(matches) != 1
+        or max(history_revisions, default=0) != revision
+        or not isinstance(coordinate, str)
+        or not coordinate.startswith(prefix)
+        or not coordinate[len(prefix) :]
+        or (expected_version is not None and coordinate != f"{expected_name}-{expected_version}")
+    ):
         raise ManifestError("invalid Helm release identity")
-    return expected_name, expected_version, revision
+    return expected_name, coordinate[len(prefix) :], revision
 
 
 def _object(path: Path) -> dict[str, Any]:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -45,9 +45,7 @@ def target(environment: str = "staging", schema_version: int = 1) -> dict[str, o
     }
     if schema_version == 2:
         value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
-    checks = sorted(manifest.required_final_checks(value)) + [
-        "imagePlatformSourceRevision[0]"
-    ]
+    checks = sorted(manifest.required_final_checks(value)) + ["imagePlatformSourceRevision[0]"]
     value["verificationResults"] = [
         {"check": check, "passed": True, "details": "observed"} for check in checks
     ]
@@ -374,6 +372,85 @@ def test_summary_never_invents_current_chart_digest() -> None:
     )
 
 
+def test_helm_319_snapshot_resolves_current_history_record_only() -> None:
+    status = {
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 9,
+        "info": {"status": "deployed"},
+    }
+    calls: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        calls.append(command)
+        if "status" in command:
+            return json.dumps(status)
+        return json.dumps(
+            [
+                {"revision": "8", "chart": "dspace-3.0.1"},
+                {"revision": "9", "chart": "dspace-3.0.2"},
+            ]
+        )
+
+    observed, history, identity = rollback.helm_snapshot(
+        runner, "kubeconfig", "dspace", "dspace", "3.0.2"
+    )
+    assert observed is not history
+    assert identity == ("dspace", "3.0.2", 9)
+    assert sum("history" in command for command in calls) == 1
+
+
+def test_helm_snapshot_does_not_read_history_when_status_has_metadata() -> None:
+    status = {
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 9,
+        "info": {"status": "deployed"},
+        "chart": {"metadata": {"name": "dspace", "version": "3.0.2"}},
+    }
+    calls: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        calls.append(command)
+        return json.dumps(status)
+
+    _, history, identity = rollback.helm_snapshot(runner, "kubeconfig", "dspace", "dspace", "3.0.2")
+    assert history is None
+    assert identity == ("dspace", "3.0.2", 9)
+    assert not any("history" in command for command in calls)
+
+
+@pytest.mark.parametrize(
+    "history",
+    (
+        [],
+        [{"revision": "9", "chart": "dspace-3.0.2"}] * 2,
+        [{"revision": "nine", "chart": "dspace-3.0.2"}],
+        [{"revision": "8", "chart": "dspace-3.0.2"}],
+        [{"revision": "9", "chart": "other-3.0.2"}],
+        [
+            {"revision": "9", "chart": "dspace-3.0.2"},
+            {"revision": "10", "chart": "dspace-3.0.2"},
+        ],
+    ),
+)
+def test_helm_snapshot_rejects_unbound_or_drifting_history(history: object) -> None:
+    status = {
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 9,
+        "info": {"status": "deployed"},
+    }
+    with pytest.raises(rollback.RollbackError, match="invalid Helm release identity"):
+        rollback.helm_snapshot(
+            lambda command: json.dumps(history if "history" in command else status),
+            "kubeconfig",
+            "dspace",
+            "dspace",
+            "3.0.2",
+        )
+
+
 def pre_reservation_case(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -544,6 +621,8 @@ def test_configuration_reconciliation_invalid_render_fails_before_reservation_an
         rollback,
         "helm_status",
         lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
             "version": 7,
             "info": {"status": "deployed"},
             "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
@@ -656,6 +735,8 @@ def test_configuration_reconciliation_preconditions_fail_before_reservation(
         rollback,
         "helm_status",
         lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
             "version": 8 if failure == "revision" else 7,
             "info": {"status": "deployed"},
             "chart": {
@@ -988,7 +1069,6 @@ def test_configuration_reconciliation_completes_all_production_gates(
                 "status": "deployed",
                 "description": state["description"] if state["upgraded"] else "previous",
             },
-            "chart": {"metadata": {"name": "dspace", "version": selected["chartVersion"]}},
         }
 
     monkeypatch.setattr(rollback, "helm_status", status)
@@ -1007,6 +1087,11 @@ def test_configuration_reconciliation_completes_all_production_gates(
         commands.append(command)
         if "current-context" in command:
             return "sugar-prod"
+        if command[0] == "helm" and "history" in command:
+            revision = "8" if state["upgraded"] else "7"
+            return json.dumps(
+                [{"revision": revision, "chart": f"dspace-{selected['chartVersion']}"}]
+            )
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return "f" * 40
         if command[0] == "helm" and "upgrade" in command:
@@ -1036,6 +1121,9 @@ def test_configuration_reconciliation_completes_all_production_gates(
     assert not any(item in upgrade for item in forbidden)
     assert DIGEST not in next(item for item in upgrade if item.startswith("image.tag="))
     assert finalized["helm_stored_values_result"] is stored_proof
+    assert finalized["helm_history"] == [
+        {"revision": "8", "chart": f"dspace-{selected['chartVersion']}"}
+    ]
     assert finalized["expected_image_coordinate"] == (
         f"{manifest.IMAGE_REF}:{selected['imageTag']}"
     )


### PR DESCRIPTION
### Motivation
- Helm v3.19 omits chart metadata from `helm status -o json`, causing the DSPACE production metrics reconciliation to fail to resolve the installed chart identity and abort before any mutation or Secret creation.
- The intent is to reuse the existing history-based fallback contract so status+history resolve the exact deployed chart name, version and revision and to apply that identity consistently across preflight, reservation, mutation, finalization and diagnostics.

### Description
- Add a redaction-safe `helm_snapshot(...)` helper in `scripts/dspace_manifest_rollback.py` that reads `helm status` and conditionally queries `helm history` only when status omits chart metadata, resolves the identity via the shared manifest helpers, and returns `(status, history, (name, version, revision))` for callers to use.
- Harden `resolve_helm_identity(...)` in `scripts/dspace_release_manifest.py` to accept numeric revisions encoded as decimal strings in history records, collect history revisions, require exactly one history record matching the status revision, parse the chart coordinate `name-version` and return the chart version derived from history when status lacks metadata, while still validating status documents that include `chart.metadata`.
- Replace ad-hoc `helm status`/`chart_version`/`revision` checks in the rollback flow with `helm_snapshot` identity comparisons so preflight, pre-reservation revalidation, pre-mutation checks, post-upgrade stability collection, finalization and diagnostics all use the same resolved identity; pass the post-upgrade `helm_history` into `release.finalize(...)` when a history fallback was needed.
- Improve error handling for `helm history` JSON reads to surface a clear `Helm history did not return valid JSON` failure and keep raw Helm documents out of preserved evidence and summary output.
- Add targeted tests in `tests/test_manifest_rollback.py` that exercise Helm 3.19–style status (no `chart` metadata) plus history fixtures and parametrized fail-closed cases for missing/duplicate/malformed/wrong-revision/wrong-chart/drifting history, and a test that verifies no history lookup when status already contains chart metadata.

### Testing
- Ran `python3 -m py_compile scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py` and it completed successfully.
- Ran `pytest -q tests/test_manifest_rollback.py` and `pytest -q tests/test_release_manifest.py` and `pytest -q tests/test_generic_app_just_recipes.py` and the modified test suites passed (the modified `tests/test_manifest_rollback.py` exercises the Helm 3.19 fixtures and the new snapshot behavior).
- Ran `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` with no new issues introduced by this change.
- Ran targeted pre-commit hooks for the changed files (`pre-commit run --files scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py tests/test_manifest_rollback.py`) and whitespace/EOF/yaml checks for those files passed; a full `pre-commit run --all-files` is blocked by unrelated repository-wide legacy lint/YAML issues and was not forced here.
- Ran `pyspelling -c .spellcheck.yaml` and it failed in this environment due to the missing `aspell` executable (environmental limitation), and `gh` push/PR creation was not performed because the current environment is not authenticated to GitHub. 

All changes are confined to the files in scope: `scripts/dspace_manifest_rollback.py`, `scripts/dspace_release_manifest.py`, and `tests/test_manifest_rollback.py`, and preserve the fail-closed, redaction and evidence contracts required by production reconciliation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b8c3508a0832f95273c0666cefa7b)