### PR TITLE
Fix Helm 3.19 release identity resolution and history fallback

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -280,6 +280,83 @@ def helm_status(
     )
 
 
+def helm_history(
+    runner: Runner, kubeconfig: str, release_name: str, namespace: str
+) -> object:
+    try:
+        return json.loads(
+            runner(
+                [
+                    "helm",
+                    "--kubeconfig",
+                    kubeconfig,
+                    "history",
+                    release_name,
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    "json",
+                ]
+            )
+        )
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RollbackError("Helm history did not return valid JSON") from exc
+
+
+def helm_snapshot(
+    runner: Runner,
+    kubeconfig: str,
+    release_name: str,
+    namespace: str,
+    *,
+    require_deployed: bool = True,
+) -> tuple[dict[str, Any], object, tuple[str, str, int]]:
+    """Read a redaction-safe, revision-bound Helm release identity."""
+    status = helm_status(runner, kubeconfig, release_name, namespace)
+    history = None
+    try:
+        needs_history = release.helm_status_needs_history(status)
+        if needs_history:
+            history = helm_history(runner, kubeconfig, release_name, namespace)
+            revision_value = status["version"]
+            if not isinstance(history, list):
+                raise release.ManifestError("invalid Helm release identity")
+            matches = [
+                item
+                for item in history
+                if isinstance(item, dict) and item.get("revision") == revision_value
+            ]
+            if len(matches) != 1:
+                raise release.ManifestError("invalid Helm release identity")
+            coordinate = matches[0].get("chart")
+            prefix = f"{release_name}-"
+            if not isinstance(coordinate, str) or not coordinate.startswith(prefix):
+                raise release.ManifestError("invalid Helm release identity")
+            expected_version = coordinate[len(prefix) :]
+        else:
+            metadata = status.get("chart", {}).get("metadata", {})
+            expected_version = metadata.get("version")
+        if not isinstance(expected_version, str) or not release.SEMVER_RE.fullmatch(
+            expected_version
+        ):
+            raise release.ManifestError("invalid Helm release identity")
+        identity = release.resolve_helm_identity(
+            status, history, release_name, expected_version
+        )
+    except release.ManifestError as exc:
+        raise RollbackError("Helm release identity is invalid") from exc
+    if status.get("name") != release_name or status.get("namespace") != namespace:
+        raise RollbackError("Helm release identity is invalid")
+    info = status.get("info")
+    if (
+        not isinstance(info, dict)
+        or not isinstance(info.get("status"), str)
+        or (require_deployed and info["status"] != "deployed")
+    ):
+        raise RollbackError("Helm release identity is invalid")
+    return status, history, identity
+
+
 def cluster_environment(runner: Runner, kubeconfig: str) -> str:
     nodes = json_command(
         runner,
@@ -362,11 +439,6 @@ def pods(
     return sorted(result, key=lambda item: str(item["name"]))
 
 
-def chart_version(status: dict[str, Any]) -> str | None:
-    value = status.get("chart", {}).get("metadata", {}).get("version")
-    return value if isinstance(value, str) else None
-
-
 def revision(status: dict[str, Any]) -> int:
     value = status.get("version")
     if not isinstance(value, int) or isinstance(value, bool) or value < 1:
@@ -376,6 +448,7 @@ def revision(status: dict[str, Any]) -> int:
 
 def summary(
     current: dict[str, Any],
+    current_identity: tuple[str, str, int],
     current_pods: list[dict[str, Any]],
     target: dict[str, Any],
     values: list[dict[str, str]],
@@ -390,9 +463,8 @@ def summary(
         (
             "  current: release=dspace namespace=dspace "
             f"helmStatus={info.get('status') or 'unknown'} "
-            f"helmRevision={revision(current)} chartName="
-            f"{current.get('chart', {}).get('metadata', {}).get('name') or 'unknown'} "
-            f"chartVersion={chart_version(current) or 'unknown'} chartDigest=unknown"
+            f"helmRevision={current_identity[2]} chartName={current_identity[0]} "
+            f"chartVersion={current_identity[1]} chartDigest=unknown"
         ),
         (
             f"           images={','.join(images) or 'unknown'} "
@@ -594,12 +666,14 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.tag={image_value}",
         ]
     )
-    before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+    before_helm, _before_history, before_identity = helm_snapshot(
+        runner, args.kubeconfig, "dspace", "dspace"
+    )
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if revision(before_helm) != target["helmRevision"]:
+        if before_identity[2] != target["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -614,7 +688,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if chart_version(before_helm) != target["chartVersion"]:
+        if before_identity[:2] != ("dspace", target["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -712,7 +786,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
     except release.ManifestError as exc:
         raise RollbackError("OCI preflight validation failed") from exc
-    print(summary(before_helm, before_pods, target, values_proof))
+    print(summary(before_helm, before_identity, before_pods, target, values_proof))
     current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
     current_ids: set[str] = set()
     for pod in before_pods:
@@ -776,7 +850,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
-    if revision(helm_status(runner, args.kubeconfig, "dspace", "dspace")) != revision(before_helm):
+    _, _, preflight_identity = helm_snapshot(runner, args.kubeconfig, "dspace", "dspace")
+    if preflight_identity != before_identity:
         raise RollbackError("Helm revision changed during preflight")
 
     invocation = uuid.uuid4().hex
@@ -810,9 +885,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "values": values_proof,
         "before": {
-            "helmRevision": revision(before_helm),
+            "helmRevision": before_identity[2],
             "helmStatus": before_helm.get("info", {}).get("status"),
-            "chartVersion": chart_version(before_helm),
+            "chartName": before_identity[0],
+            "chartVersion": before_identity[1],
             "pods": before_pods,
         },
         "ociPreflight": oci,
@@ -831,11 +907,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
         if configuration_reconciliation:
-            current_status = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-            if (
-                revision(current_status) != revision(before_helm)
-                or chart_version(current_status) != target["chartVersion"]
-            ):
+            _current_status, _current_history, current_identity = helm_snapshot(
+                runner, args.kubeconfig, "dspace", "dspace"
+            )
+            if current_identity != before_identity:
                 raise RollbackError("Helm coordinates changed before mutation")
             current_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
             if current_pods != before_pods:
@@ -923,8 +998,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             if time.monotonic() >= deadline:
                 raise RollbackError("timed out waiting for old terminating pods to disappear")
             time.sleep(POLL_INTERVAL)
-        after_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        after_revision = revision(after_helm)
+        after_helm, after_history, after_identity = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace"
+        )
+        after_revision = after_identity[2]
         if (
             after_helm.get("name") != "dspace"
             or after_helm.get("namespace") != "dspace"
@@ -933,15 +1010,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= revision(before_helm):
+        if after_revision <= before_identity[2]:
             raise RollbackError("Helm revision did not advance")
         if (
-            after_helm.get("chart", {}).get("metadata", {}).get("name") != "dspace"
-            or chart_version(after_helm) != target["chartVersion"]
+            after_identity[0] != "dspace"
+            or after_identity[1] != target["chartVersion"]
         ):
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
-            chart_version(before_helm) != target["chartVersion"]
+            before_identity[1] != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
             or current_images
             != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
@@ -1031,6 +1108,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             invocation_description=description,
             expected_image_coordinate=f"{release.IMAGE_REF}:{image_value}",
             helm_stored_values_result=helm_stored_values_result,
+            helm_history=after_history,
         )
         verifier_command = [
             str(args.verifier),
@@ -1079,8 +1157,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 ]
             )
         failed_stage = "revision-stability-collection"
-        stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        if revision(stable) != after_revision:
+        _stable, _stable_history, stable_identity = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace"
+        )
+        if stable_identity != after_identity:
             raise RollbackError("Helm revision changed concurrently during evidence collection")
         result = {
             **evidence,
@@ -1088,11 +1168,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "completedAt": timestamp(),
             "sugarkubeRevision": sugarkube_revision,
             "helm": {
-                "beforeRevision": revision(before_helm),
+                "beforeRevision": before_identity[2],
                 "afterRevision": after_revision,
                 "status": "deployed",
                 "chartName": "dspace",
-                "chartVersion": chart_version(after_helm),
+                "chartVersion": after_identity[1],
             },
             "pods": {"before": before_pods, "after": after_pods},
             "verification": {
@@ -1129,16 +1209,21 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         diagnostics: dict[str, Any] = {}
         if production_target_verified:
             try:
-                observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+                observed_helm, _observed_history, observed_identity = helm_snapshot(
+                    runner,
+                    args.kubeconfig,
+                    "dspace",
+                    "dspace",
+                    require_deployed=False,
+                )
                 observed_info = observed_helm.get("info", {})
-                observed_chart = observed_helm.get("chart", {}).get("metadata", {})
                 diagnostics["helm"] = {
                     "release": observed_helm.get("name"),
                     "namespace": observed_helm.get("namespace"),
-                    "revision": revision(observed_helm),
+                    "revision": observed_identity[2],
                     "status": observed_info.get("status"),
-                    "chartName": observed_chart.get("name"),
-                    "chartVersion": chart_version(observed_helm),
+                    "chartName": observed_identity[0],
+                    "chartVersion": observed_identity[1],
                     "invocationDescriptionMatches": observed_info.get("description")
                     == description,
                 }

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -310,7 +310,7 @@ def helm_snapshot(
     namespace: str,
     *,
     require_deployed: bool = True,
-) -> tuple[dict[str, Any], object, tuple[str, str, int]]:
+) -> tuple[dict[str, Any], object | None, tuple[str, str, int]]:
     """Read a redaction-safe, revision-bound Helm release identity."""
     status = helm_status(runner, kubeconfig, release_name, namespace)
     history = None
@@ -334,7 +334,10 @@ def helm_snapshot(
                 raise release.ManifestError("invalid Helm release identity")
             expected_version = coordinate[len(prefix) :]
         else:
-            metadata = status.get("chart", {}).get("metadata", {})
+            chart = status.get("chart")
+            metadata = chart.get("metadata") if isinstance(chart, dict) else None
+            if not isinstance(metadata, dict):
+                raise release.ManifestError("invalid Helm release identity")
             expected_version = metadata.get("version")
         if not isinstance(expected_version, str) or not release.SEMVER_RE.fullmatch(
             expected_version

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -310,17 +310,22 @@ def helm_snapshot(
     namespace: str,
     *,
     require_deployed: bool = True,
-) -> tuple[dict[str, Any], object | None, tuple[str, str, int]]:
+) -> tuple[
+    dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]
+]:
     """Read a redaction-safe, revision-bound Helm release identity."""
     status = helm_status(runner, kubeconfig, release_name, namespace)
-    history = None
+    history: list[dict[str, Any]] | None = None
     try:
         needs_history = release.helm_status_needs_history(status)
         if needs_history:
-            history = helm_history(runner, kubeconfig, release_name, namespace)
+            history_payload = helm_history(runner, kubeconfig, release_name, namespace)
             revision_value = status["version"]
-            if not isinstance(history, list):
+            if not isinstance(history_payload, list) or not all(
+                isinstance(item, dict) for item in history_payload
+            ):
                 raise release.ManifestError("invalid Helm release identity")
+            history = history_payload
             matches = [
                 item
                 for item in history

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -157,7 +157,11 @@ def resolve_helm_identity(
             raise ManifestError("invalid Helm release identity")
         if record_revision == revision:
             matches.append(record)
-    if len(matches) != 1 or matches[0]["chart"] != f"{expected_name}-{expected_version}":
+    if (
+        len(matches) != 1
+        or max(record["revision"] for record in history) != revision
+        or matches[0]["chart"] != f"{expected_name}-{expected_version}"
+    ):
         raise ManifestError("invalid Helm release identity")
     return expected_name, expected_version, revision
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -354,7 +354,11 @@ def test_summary_never_invents_current_chart_digest() -> None:
         "chart": {"metadata": {"name": "dspace", "version": "3.1.0"}},
     }
     text = rollback.summary(
-        current, [pod("1")], target(), [{"path": "values.yaml", "sha256": "3" * 64}]
+        current,
+        ("dspace", "3.1.0", 8),
+        [pod("1")],
+        target(),
+        [{"path": "values.yaml", "sha256": "3" * 64}],
     )
     assert text == "\n".join(
         [
@@ -372,6 +376,98 @@ def test_summary_never_invents_current_chart_digest() -> None:
             f"  values:  values.yaml={'3' * 64}",
         ]
     )
+
+
+def helm_319_status(**changes: object) -> dict[str, object]:
+    value = {
+        "config": {},
+        "info": {"status": "deployed"},
+        "manifest": "must-not-be-reported",
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": 9,
+    }
+    value.update(changes)
+    return value
+
+
+def test_helm_319_snapshot_resolves_exact_current_history_without_leaking_raw_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        return json.dumps(
+            [
+                {"revision": 8, "chart": "dspace-3.0.1"},
+                {"revision": 9, "chart": "dspace-3.0.2"},
+            ]
+        )
+
+    status = helm_319_status()
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
+    observed, history, identity = rollback.helm_snapshot(
+        runner, "kubeconfig", "dspace", "dspace"
+    )
+
+    assert identity == ("dspace", "3.0.2", 9)
+    assert observed is status
+    assert history is not None
+    assert len(commands) == 1 and "history" in commands[0]
+    rendered = rollback.summary(
+        observed,
+        identity,
+        [],
+        {**target(), "chartVersion": "3.0.2"},
+        [{"path": "values.yaml", "sha256": "3" * 64}],
+    )
+    assert "chartName=dspace chartVersion=3.0.2" in rendered
+    assert "must-not-be-reported" not in rendered
+
+
+def test_helm_snapshot_uses_status_metadata_without_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = helm_319_status(
+        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}
+    )
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
+    _status, history, identity = rollback.helm_snapshot(
+        lambda _command: pytest.fail("history must not be queried"),
+        "kubeconfig",
+        "dspace",
+        "dspace",
+    )
+    assert history is None
+    assert identity == ("dspace", "3.0.2", 9)
+
+
+@pytest.mark.parametrize(
+    "history",
+    [
+        [],
+        [{"revision": 8, "chart": "dspace-3.0.2"}],
+        [
+            {"revision": 9, "chart": "dspace-3.0.2"},
+            {"revision": 9, "chart": "dspace-3.0.2"},
+        ],
+        [{"revision": "9", "chart": "dspace-3.0.2"}],
+        [{"revision": 9, "chart": "other-3.0.2"}],
+        [
+            {"revision": 9, "chart": "dspace-3.0.2"},
+            {"revision": 10, "chart": "dspace-3.0.2"},
+        ],
+    ],
+)
+def test_helm_snapshot_rejects_missing_malformed_ambiguous_or_drifting_history(
+    monkeypatch: pytest.MonkeyPatch, history: object
+) -> None:
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: helm_319_status())
+    with pytest.raises(rollback.RollbackError, match="identity"):
+        rollback.helm_snapshot(
+            lambda _command: json.dumps(history), "kubeconfig", "dspace", "dspace"
+        )
 
 
 def pre_reservation_case(
@@ -544,6 +640,8 @@ def test_configuration_reconciliation_invalid_render_fails_before_reservation_an
         rollback,
         "helm_status",
         lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
             "version": 7,
             "info": {"status": "deployed"},
             "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
@@ -656,6 +754,8 @@ def test_configuration_reconciliation_preconditions_fail_before_reservation(
         rollback,
         "helm_status",
         lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
             "version": 8 if failure == "revision" else 7,
             "info": {"status": "deployed"},
             "chart": {
@@ -988,7 +1088,6 @@ def test_configuration_reconciliation_completes_all_production_gates(
                 "status": "deployed",
                 "description": state["description"] if state["upgraded"] else "previous",
             },
-            "chart": {"metadata": {"name": "dspace", "version": selected["chartVersion"]}},
         }
 
     monkeypatch.setattr(rollback, "helm_status", status)
@@ -1012,6 +1111,15 @@ def test_configuration_reconciliation_completes_all_production_gates(
         if command[0] == "helm" and "upgrade" in command:
             state["description"] = command[command.index("--description") + 1]
             state["upgraded"] = True
+        elif command[0] == "helm" and "history" in command:
+            return json.dumps(
+                [
+                    {
+                        "revision": 8 if state["upgraded"] else 7,
+                        "chart": f"dspace-{selected['chartVersion']}",
+                    }
+                ]
+            )
         elif command[0] == "helm" and "values" in command and "get" in command:
             return json.dumps(desired if "--all" in command else live)
         elif command[0] == "helm" and "template" in command:
@@ -1036,6 +1144,9 @@ def test_configuration_reconciliation_completes_all_production_gates(
     assert not any(item in upgrade for item in forbidden)
     assert DIGEST not in next(item for item in upgrade if item.startswith("image.tag="))
     assert finalized["helm_stored_values_result"] is stored_proof
+    assert finalized["helm_history"] == [
+        {"revision": 8, "chart": f"dspace-{selected['chartVersion']}"}
+    ]
     assert finalized["expected_image_coordinate"] == (
         f"{manifest.IMAGE_REF}:{selected['imageTag']}"
     )

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -450,13 +450,14 @@ def test_helm_snapshot_rejects_non_object_status_metadata(
     status = helm_319_status(chart={"metadata": metadata})
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
 
-    with pytest.raises(rollback.RollbackError, match="identity"):
+    with pytest.raises(rollback.RollbackError, match="identity") as exc_info:
         rollback.helm_snapshot(
             lambda _command: pytest.fail("history must not be queried"),
             "kubeconfig",
             "dspace",
             "dspace",
         )
+    assert "must-not-be-reported" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -951,13 +952,16 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
     def status(*_args: object) -> dict[str, object]:
         if upgrade_attempted and diagnostic_failure == "helm":
             raise RuntimeError("bounded diagnostic failure")
-        return {
+        observed: dict[str, object] = {
             "name": "dspace",
             "namespace": "dspace",
             "version": 8 if state_drift == "helm" and evidence.exists() else 7,
             "info": {"status": "deployed"},
             "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
         }
+        if state_drift == "helm":
+            observed.pop("chart")
+        return observed
 
     def observed_pods(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
         if upgrade_attempted and diagnostic_failure == "pods":
@@ -989,6 +993,11 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
             if state_drift == "values" and evidence.exists():
                 values["unexpected"] = True
             return json.dumps(values)
+        if command[0] == "helm" and "history" in command:
+            history = [{"revision": 7, "chart": "dspace-3.2.0"}]
+            if evidence.exists():
+                history.append({"revision": 8, "chart": "dspace-3.2.0"})
+            return json.dumps(history)
         if "template" in command:
             template_calls += 1
             return "target render" if template_calls == 1 else "live render"
@@ -1304,13 +1313,19 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
             }
         post_status_calls[0] += 1
         revision = 9 if failure == "revision" and post_status_calls[0] >= 2 else 8
-        return {
+        observed: dict[str, object] = {
             "name": "dspace",
             "namespace": "dspace",
             "version": revision,
-            "info": {"status": "deployed", "description": description[0]},
+            "info": {
+                "status": "failed" if failure == "helm" else "deployed",
+                "description": description[0],
+            },
             "chart": {"metadata": {"name": "dspace", "version": "3.2.0"}},
         }
+        if failure == "helm":
+            observed.pop("chart")
+        return observed
 
     description = [""]
     monkeypatch.setattr(rollback, "helm_status", status)
@@ -1336,6 +1351,8 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
             description[0] = command[command.index("--description") + 1]
             if failure == "helm":
                 raise rollback.RollbackError(sentinel)
+        if command[0] == "helm" and "history" in command:
+            return json.dumps([{"revision": 8, "chart": "dspace-3.2.0"}])
         if command[0] == "kubectl" and "rollout" in command and failure == "rollout":
             raise rollback.RollbackError(sentinel)
         if command[:2] == [str(verifier), "verify"]:
@@ -1381,7 +1398,7 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
             "release": "dspace",
             "namespace": "dspace",
             "revision": 7 if failure == "pre-mutation" else (9 if failure == "revision" else 8),
-            "status": "deployed",
+            "status": "failed" if failure == "helm" else "deployed",
             "chartName": "dspace",
             "chartVersion": "3.1.0" if failure == "pre-mutation" else "3.2.0",
             "invocationDescriptionMatches": failure != "pre-mutation",

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -443,6 +443,22 @@ def test_helm_snapshot_uses_status_metadata_without_history(
     assert identity == ("dspace", "3.0.2", 9)
 
 
+@pytest.mark.parametrize("metadata", ["dspace-3.0.2", ["dspace", "3.0.2"]])
+def test_helm_snapshot_rejects_non_object_status_metadata(
+    monkeypatch: pytest.MonkeyPatch, metadata: object
+) -> None:
+    status = helm_319_status(chart={"metadata": metadata})
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
+
+    with pytest.raises(rollback.RollbackError, match="identity"):
+        rollback.helm_snapshot(
+            lambda _command: pytest.fail("history must not be queried"),
+            "kubeconfig",
+            "dspace",
+            "dspace",
+        )
+
+
 @pytest.mark.parametrize(
     "history",
     [

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -460,10 +460,42 @@ def test_helm_snapshot_rejects_non_object_status_metadata(
     assert "must-not-be-reported" not in str(exc_info.value)
 
 
+def test_helm_history_rejects_invalid_json() -> None:
+    with pytest.raises(rollback.RollbackError, match="valid JSON"):
+        rollback.helm_history(
+            lambda _command: "not-json", "kubeconfig", "dspace", "dspace"
+        )
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"name": "other"},
+        {"info": {"status": "failed"}},
+    ],
+)
+def test_helm_snapshot_rejects_status_identity_or_state(
+    monkeypatch: pytest.MonkeyPatch, changes: dict[str, object]
+) -> None:
+    status = helm_319_status(
+        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}, **changes
+    )
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
+
+    with pytest.raises(rollback.RollbackError, match="identity"):
+        rollback.helm_snapshot(
+            lambda _command: pytest.fail("history must not be queried"),
+            "kubeconfig",
+            "dspace",
+            "dspace",
+        )
+
+
 @pytest.mark.parametrize(
     "history",
     [
         [],
+        ["not-an-object"],
         [{"revision": 8, "chart": "dspace-3.0.2"}],
         [
             {"revision": 9, "chart": "dspace-3.0.2"},
@@ -471,6 +503,7 @@ def test_helm_snapshot_rejects_non_object_status_metadata(
         ],
         [{"revision": "9", "chart": "dspace-3.0.2"}],
         [{"revision": 9, "chart": "other-3.0.2"}],
+        [{"revision": 9, "chart": "dspace-not-semver"}],
         [
             {"revision": 9, "chart": "dspace-3.0.2"},
             {"revision": 10, "chart": "dspace-3.0.2"},


### PR DESCRIPTION
### Motivation
- Helm v3.19 `helm status -o json` can omit `chart` metadata, which caused unknown chart identity and blocked guarded production metrics reconciliation.
- The code must resolve the exact installed chart name/version/revision without leaking raw Helm documents, and only query `helm history` when `status` lacks chart metadata.

### Description
- Add `helm_history` and a single redaction-safe `helm_snapshot` helper in `scripts/dspace_manifest_rollback.py` that reads `helm status`, conditionally calls `helm history`, and returns `(status, history, (chartName, chartVersion, revision))` after validation. The helper uses the existing `dspace_release_manifest` helpers and preserves failure/redaction contracts. 
- Replace ad-hoc uses of `helm_status`/`chart_version`/`revision` with the resolved identity tuple so preflight, evidence reservation, pre-mutation revalidation, post-upgrade checks, stability collection, and sanitized diagnostics consistently use the resolved chart identity. 
- Pass the matching post-upgrade `helm history` into `release.finalize(..., helm_history=...)` when status omits chart metadata. 
- Harden `resolve_helm_identity` in `scripts/dspace_release_manifest.py` to reject status/history drift by ensuring the live status revision is the latest history revision and that the history record matches the expected chart coordinate. 
- Add tests and fixtures in `tests/test_manifest_rollback.py` for Helm 3.19 schema (status without `chart`), including: resolution of `dspace-3.0.2`@revision 9 from history, conditional history lookup only when metadata is omitted, acceptance of metadata-containing status without history, and rejection of missing/ambiguous/malformed/drifting history; and adapt a few existing tests to the new identity contract.

### Testing
- Ran Python compilation: `python3 -m py_compile scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py` — succeeded. 
- Ran unit tests: `pytest -q tests/test_manifest_rollback.py` — all tests passed (66 passed); `pytest -q tests/test_release_manifest.py` — all tests passed (222 passed); `pytest -q tests/test_generic_app_just_recipes.py` — passed; aggregate test runs show the full test-suite passing (all tests passed locally). 
- Per-repo checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` were run and showed no new issues from these changes; `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide hook failures (YAML/lint/format issues) that are out-of-scope for this focused fix. 

Residual risks and notes: production reconciliation was not executed and no production cluster commands were run; the change preserves the fail-closed identity contract and avoids persisting or printing raw `helm status`/`history` payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b8c3769bc832fa3f62e83700a174e)