### PR TITLE
Resolve Helm 3.19 release identity via history fallback for DSPACE reconciliation

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -280,6 +281,56 @@ def helm_status(
     )
 
 
+@dataclass(frozen=True)
+class HelmSnapshot:
+    """A redacted, resolved view of one Helm release observation."""
+
+    status: dict[str, Any]
+    history: object
+    chart_name: str
+    chart_version: str
+    revision: int
+
+
+def helm_snapshot(
+    runner: Runner,
+    kubeconfig: str,
+    release_name: str,
+    namespace: str,
+    expected_chart_version: str | None,
+) -> HelmSnapshot:
+    """Read and resolve Helm identity without exposing Helm's raw documents."""
+    status = helm_status(runner, kubeconfig, release_name, namespace)
+    history = None
+    try:
+        needs_history = release.helm_status_needs_history(status)
+        if not needs_history:
+            expected_chart_version = chart_version(status)
+        if expected_chart_version is None:
+            raise release.ManifestError("status omitted the expected chart version")
+        if needs_history:
+            raw = runner(
+                [
+                    "helm",
+                    "--kubeconfig",
+                    kubeconfig,
+                    "history",
+                    release_name,
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    "json",
+                ]
+            )
+            history = json.loads(raw)
+        name, version, helm_revision = release.resolve_helm_identity(
+            status, history, "dspace", expected_chart_version
+        )
+    except (json.JSONDecodeError, release.ManifestError, OSError) as exc:
+        raise RollbackError("invalid Helm release identity") from exc
+    return HelmSnapshot(status, history, name, version, helm_revision)
+
+
 def cluster_environment(runner: Runner, kubeconfig: str) -> str:
     nodes = json_command(
         runner,
@@ -375,7 +426,7 @@ def revision(status: dict[str, Any]) -> int:
 
 
 def summary(
-    current: dict[str, Any],
+    current: HelmSnapshot | dict[str, Any],
     current_pods: list[dict[str, Any]],
     target: dict[str, Any],
     values: list[dict[str, str]],
@@ -384,15 +435,22 @@ def summary(
     image_ids = sorted(
         {application_image_id(pod) for pod in current_pods if application_image_id(pod)}
     )
-    info = current.get("info", {})
+    if isinstance(current, dict):
+        current = HelmSnapshot(
+            current,
+            None,
+            current.get("chart", {}).get("metadata", {}).get("name") or "unknown",
+            chart_version(current) or "unknown",
+            revision(current),
+        )
+    info = current.status.get("info", {})
     lines = [
         "DSPACE manifest rollback preflight:",
         (
             "  current: release=dspace namespace=dspace "
             f"helmStatus={info.get('status') or 'unknown'} "
-            f"helmRevision={revision(current)} chartName="
-            f"{current.get('chart', {}).get('metadata', {}).get('name') or 'unknown'} "
-            f"chartVersion={chart_version(current) or 'unknown'} chartDigest=unknown"
+            f"helmRevision={current.revision} chartName={current.chart_name} "
+            f"chartVersion={current.chart_version} chartDigest=unknown"
         ),
         (
             f"           images={','.join(images) or 'unknown'} "
@@ -594,12 +652,19 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.tag={image_value}",
         ]
     )
-    before_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+    before = helm_snapshot(
+        runner,
+        args.kubeconfig,
+        "dspace",
+        "dspace",
+        target["chartVersion"] if configuration_reconciliation else None,
+    )
+    before_helm = before.status
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if revision(before_helm) != target["helmRevision"]:
+        if before.revision != target["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -614,7 +679,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if chart_version(before_helm) != target["chartVersion"]:
+        if before.chart_name != "dspace" or before.chart_version != target["chartVersion"]:
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -712,7 +777,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
     except release.ManifestError as exc:
         raise RollbackError("OCI preflight validation failed") from exc
-    print(summary(before_helm, before_pods, target, values_proof))
+    print(summary(before, before_pods, target, values_proof))
     current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
     current_ids: set[str] = set()
     for pod in before_pods:
@@ -776,7 +841,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
-    if revision(helm_status(runner, args.kubeconfig, "dspace", "dspace")) != revision(before_helm):
+    pre_reservation = helm_snapshot(
+        runner, args.kubeconfig, "dspace", "dspace", before.chart_version
+    )
+    if pre_reservation != before:
         raise RollbackError("Helm revision changed during preflight")
 
     invocation = uuid.uuid4().hex
@@ -810,9 +878,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "values": values_proof,
         "before": {
-            "helmRevision": revision(before_helm),
+            "helmRevision": before.revision,
             "helmStatus": before_helm.get("info", {}).get("status"),
-            "chartVersion": chart_version(before_helm),
+            "chartName": before.chart_name,
+            "chartVersion": before.chart_version,
             "pods": before_pods,
         },
         "ociPreflight": oci,
@@ -831,11 +900,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
         if configuration_reconciliation:
-            current_status = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-            if (
-                revision(current_status) != revision(before_helm)
-                or chart_version(current_status) != target["chartVersion"]
-            ):
+            current = helm_snapshot(
+                runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+            )
+            if current != before:
                 raise RollbackError("Helm coordinates changed before mutation")
             current_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
             if current_pods != before_pods:
@@ -923,8 +991,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             if time.monotonic() >= deadline:
                 raise RollbackError("timed out waiting for old terminating pods to disappear")
             time.sleep(POLL_INTERVAL)
-        after_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        after_revision = revision(after_helm)
+        after = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+        )
+        after_helm = after.status
+        after_revision = after.revision
         if (
             after_helm.get("name") != "dspace"
             or after_helm.get("namespace") != "dspace"
@@ -933,15 +1004,14 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= revision(before_helm):
+        if after_revision <= before.revision:
             raise RollbackError("Helm revision did not advance")
         if (
-            after_helm.get("chart", {}).get("metadata", {}).get("name") != "dspace"
-            or chart_version(after_helm) != target["chartVersion"]
+            after.chart_name != "dspace" or after.chart_version != target["chartVersion"]
         ):
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
-            chart_version(before_helm) != target["chartVersion"]
+            before.chart_version != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
             or current_images
             != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
@@ -1031,6 +1101,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             invocation_description=description,
             expected_image_coordinate=f"{release.IMAGE_REF}:{image_value}",
             helm_stored_values_result=helm_stored_values_result,
+            helm_history=after.history,
         )
         verifier_command = [
             str(args.verifier),
@@ -1079,8 +1150,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 ]
             )
         failed_stage = "revision-stability-collection"
-        stable = helm_status(runner, args.kubeconfig, "dspace", "dspace")
-        if revision(stable) != after_revision:
+        stable = helm_snapshot(
+            runner, args.kubeconfig, "dspace", "dspace", target["chartVersion"]
+        )
+        if stable != after:
             raise RollbackError("Helm revision changed concurrently during evidence collection")
         result = {
             **evidence,
@@ -1088,11 +1161,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "completedAt": timestamp(),
             "sugarkubeRevision": sugarkube_revision,
             "helm": {
-                "beforeRevision": revision(before_helm),
+                "beforeRevision": before.revision,
                 "afterRevision": after_revision,
                 "status": "deployed",
                 "chartName": "dspace",
-                "chartVersion": chart_version(after_helm),
+                "chartVersion": after.chart_version,
             },
             "pods": {"before": before_pods, "after": after_pods},
             "verification": {
@@ -1129,16 +1202,22 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         diagnostics: dict[str, Any] = {}
         if production_target_verified:
             try:
-                observed_helm = helm_status(runner, args.kubeconfig, "dspace", "dspace")
+                observed = helm_snapshot(
+                    runner,
+                    args.kubeconfig,
+                    "dspace",
+                    "dspace",
+                    target["chartVersion"] if mutated else before.chart_version,
+                )
+                observed_helm = observed.status
                 observed_info = observed_helm.get("info", {})
-                observed_chart = observed_helm.get("chart", {}).get("metadata", {})
                 diagnostics["helm"] = {
                     "release": observed_helm.get("name"),
                     "namespace": observed_helm.get("namespace"),
-                    "revision": revision(observed_helm),
+                    "revision": observed.revision,
                     "status": observed_info.get("status"),
-                    "chartName": observed_chart.get("name"),
-                    "chartVersion": chart_version(observed_helm),
+                    "chartName": observed.chart_name,
+                    "chartVersion": observed.chart_version,
                     "invocationDescriptionMatches": observed_info.get("description")
                     == description,
                 }

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -374,6 +374,94 @@ def test_summary_never_invents_current_chart_digest() -> None:
     )
 
 
+def helm_319_status(revision: int = 9) -> dict[str, object]:
+    return {
+        "config": {"redacted": "must-not-escape"},
+        "info": {"status": "deployed", "description": "safe"},
+        "manifest": "raw-manifest-must-not-escape",
+        "name": "dspace",
+        "namespace": "dspace",
+        "version": revision,
+    }
+
+
+def helm_history(revision: int = 9, chart: str = "dspace-3.0.2") -> list[dict[str, object]]:
+    return [
+        {"revision": revision - 1, "chart": "dspace-3.0.1", "status": "superseded"},
+        {"revision": revision, "chart": chart, "status": "deployed"},
+    ]
+
+
+def test_helm_319_snapshot_resolves_current_history_without_leaking_raw_documents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: helm_319_status())
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        return json.dumps(helm_history())
+
+    snapshot = rollback.helm_snapshot(runner, "kubeconfig", "dspace", "dspace", "3.0.2")
+
+    assert (snapshot.chart_name, snapshot.chart_version, snapshot.revision) == (
+        "dspace",
+        "3.0.2",
+        9,
+    )
+    assert len(commands) == 1 and "history" in commands[0]
+    text = rollback.summary(snapshot, [], {**target(), "chartVersion": "3.0.2"}, [])
+    assert "chartName=dspace chartVersion=3.0.2" in text
+    assert "raw-manifest" not in text
+    assert "must-not-escape" not in text
+
+
+def test_helm_snapshot_does_not_query_history_when_status_has_chart_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            **helm_319_status(),
+            "chart": {"metadata": {"name": "dspace", "version": "3.0.2"}},
+        },
+    )
+    snapshot = rollback.helm_snapshot(
+        lambda _command: pytest.fail("history must not be queried"),
+        "kubeconfig",
+        "dspace",
+        "dspace",
+        "3.0.2",
+    )
+    assert snapshot.history is None
+
+
+@pytest.mark.parametrize(
+    "history",
+    [
+        None,
+        [],
+        [{"revision": 9, "chart": "dspace-3.0.2"}] * 2,
+        [{"revision": "9", "chart": "dspace-3.0.2"}],
+        [{"revision": 8, "chart": "dspace-3.0.2"}],
+        [{"revision": 9, "chart": "other-3.0.2"}],
+    ],
+)
+def test_helm_319_snapshot_rejects_invalid_current_history(
+    history: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(rollback, "helm_status", lambda *_args: helm_319_status())
+    with pytest.raises(rollback.RollbackError, match="invalid Helm release identity"):
+        rollback.helm_snapshot(
+            lambda _command: json.dumps(history),
+            "kubeconfig",
+            "dspace",
+            "dspace",
+            "3.0.2",
+        )
+
+
 def pre_reservation_case(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -988,7 +1076,6 @@ def test_configuration_reconciliation_completes_all_production_gates(
                 "status": "deployed",
                 "description": state["description"] if state["upgraded"] else "previous",
             },
-            "chart": {"metadata": {"name": "dspace", "version": selected["chartVersion"]}},
         }
 
     monkeypatch.setattr(rollback, "helm_status", status)
@@ -1005,6 +1092,11 @@ def test_configuration_reconciliation_completes_all_production_gates(
 
     def runner(command: list[str]) -> str:
         commands.append(command)
+        if command[0] == "helm" and "history" in command:
+            current_revision = 8 if state["upgraded"] else 7
+            return json.dumps(
+                [{"revision": current_revision, "chart": f"dspace-{selected['chartVersion']}"}]
+            )
         if "current-context" in command:
             return "sugar-prod"
         if command[:3] == ["git", "rev-parse", "HEAD"]:
@@ -1036,6 +1128,7 @@ def test_configuration_reconciliation_completes_all_production_gates(
     assert not any(item in upgrade for item in forbidden)
     assert DIGEST not in next(item for item in upgrade if item.startswith("image.tag="))
     assert finalized["helm_stored_values_result"] is stored_proof
+    assert finalized["helm_history"] == [{"revision": 8, "chart": "dspace-3.2.0"}]
     assert finalized["expected_image_coordinate"] == (
         f"{manifest.IMAGE_REF}:{selected['imageTag']}"
     )


### PR DESCRIPTION
### Motivation

- Helm v3.19 omits `chart.metadata` from `helm status -o json`, causing DSPACE production reconciliation to treat the live release as unknown and abort before applying metrics changes.  The goal is to safely resolve the installed chart identity using the established `helm history` fallback and reuse the existing identity resolver.

### Description

- Add a small, redacted Helm snapshot helper (`HelmSnapshot` + `helm_snapshot`) that reads `helm status` and only queries `helm history` when `helm_status_needs_history` indicates the status document lacks chart metadata.  The helper delegates exact identity validation to the existing `resolve_helm_identity` in `dspace_release_manifest.py` and never exposes or persists raw Helm JSON. (modified: `scripts/dspace_manifest_rollback.py`)
- Apply the resolved chart name/version/revision everywhere the rollback flow needs a canonical identity: preflight summary, configuration-reconciliation checks, reserved evidence, pre-mutation revalidation, post-upgrade verification, stability collection, failure diagnostics, and finalization; when history was required to resolve the identity, pass that history object to `release.finalize(..., helm_history=...)`. (modified: `scripts/dspace_manifest_rollback.py`)
- Add tests and fixtures covering the observed Helm 3.19 schema (status without `chart` + matching `helm history`), asserting resolution to `dspace` `3.0.2` revision 9, that history is only queried when necessary, that malformed/ambiguous/mismatched histories are rejected, and that finalization receives the history when required. (modified: `tests/test_manifest_rollback.py`)
- Keep the change surface minimal and reuse existing `helm_status_needs_history` / `resolve_helm_identity` logic from `dspace_release_manifest.py` to preserve existing validation contracts and redaction behavior.

### Testing

- Compiled the modified modules with `python3 -m py_compile scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py` (succeeded).
- Ran the focused test suites: `pytest -q tests/test_manifest_rollback.py` (66 passed), `pytest -q tests/test_release_manifest.py` (222 passed), and `pytest -q tests/test_generic_app_just_recipes.py` (422 passed, 1 pre-existing warning). All targeted tests covering rollback/release behavior passed.
- Ran repository checks: `pre-commit run --all-files` was executed but failed on unrelated, pre-existing repo-wide YAML/lint issues; those pre-existing fixes were not included in this change and unrelated files were reverted before committing the two modified files.

Residual notes and risks

- The new helper intentionally avoids emitting raw Helm `status`, `manifest`, or `history` text in logs/evidence; diagnostics continue to surface only the resolved chart identity and redacted diagnostics as before.
- `pre-commit run --all-files` cannot be guaranteed green in this environment because the repository contains unrelated lint/YAML issues; the functional tests validating the Helm-3.19 behavior are green.

Files changed:
- scripts/dspace_manifest_rollback.py
- tests/test_manifest_rollback.py

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b8c3abfa8832f816f220fa2443dfa)