### PR TITLE
Fix DSPACE production metrics contract and exempt token.place env names from false-positive credential detection

### DIFF
--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -15,6 +15,7 @@ env:
 
 metrics:
   enabled: true
+  path: /metrics
   auth:
     existingSecret: dspace-prod-metrics-token
     secretKey: token

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -992,6 +992,13 @@ def contains_inline_credential(value: object) -> bool:
         "secretkeyref",
         "secretname",
     }
+    # These exact environment variables configure the public token.place service;
+    # despite their names, neither value is authentication material. Keep this
+    # allowlist at the variable-name boundary so near misses remain fail-closed.
+    public_token_place_settings = {
+        "DSPACE_TOKEN_PLACE_URL",
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+    }
 
     def is_empty(item: object) -> bool:
         return item is None or item is False or item == "" or item == {} or item == []
@@ -1001,6 +1008,7 @@ def contains_inline_credential(value: object) -> bool:
         if (
             isinstance(name, str)
             and sensitive.search(name)
+            and name not in public_token_place_settings
             and "value" in value
             and not is_empty(value["value"])
         ):

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts import app_chart, app_config
 from scripts import dspace_release_manifest as manifest
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
@@ -685,6 +686,54 @@ def production_stored_values() -> dict[str, object]:
         "serviceAccount": {"automountServiceAccountToken": False},
         "secret": {"enabled": False, "stringData": {}},
     }
+
+
+def test_committed_production_values_chain_satisfies_stored_values_contract() -> None:
+    config = app_config.load_config("dspace", "prod")
+    values = tuple(config["SUGARKUBE_VALUES"].split(","))
+    desired = app_chart.merged_values_document(values)
+    assert isinstance(desired, dict)
+
+    approved = json.loads(
+        Path("docs/apps/dspace.prod-recovery-coordinates.json").read_text(encoding="utf-8")
+    )
+    candidate = manifest.candidate(
+        approved, "prod", "openai", "2026-08-11T00:00:00Z", "contract-test"
+    )
+    desired["image"] = {
+        "repository": manifest.IMAGE_REF,
+        "tag": candidate["imageTag"],
+        "pullPolicy": "Always",
+    }
+
+    assert manifest.verify_helm_stored_values(candidate, desired, "prod")["passed"] is True
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("DSPACE_TOKEN_PLACE_URL", "https://token.place"),
+        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "llama-3.1-8b-instruct"),
+    ],
+)
+def test_public_token_place_environment_settings_are_not_credentials(
+    name: str, value: str
+) -> None:
+    assert manifest.contains_inline_credential({"env": [{"name": name, "value": value}]}) is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "METRICS_TOKEN",
+        "DSPACE_" + "API" + "_KEY",
+        "DSPACE_TOKEN_PLACE_URL_TOKEN",
+        "DSPACE_TOKEN_PLACE_CHAT_MODELS",
+    ],
+)
+def test_credential_and_near_miss_environment_names_remain_sensitive(name: str) -> None:
+    sentinel = "".join(("credential", "-sentinel"))
+    assert manifest.contains_inline_credential({"env": [{"name": name, "value": sentinel}]}) is True
 
 
 def test_helm_stored_values_accept_chart_defaults_and_safe_references() -> None:


### PR DESCRIPTION
### Motivation

- Reconcile the committed DSPACE production values with the guard that verifies stored Helm values so pre-mutation validation no longer fails with "desired production metrics contract is invalid". 
- Prevent a false-positive credential classification for two public token.place settings while keeping credential detection fail-closed for real secrets.

### Description

- Add the explicit production metrics path by setting `metrics.path: /metrics` in `docs/examples/dspace.values.prod.yaml` to satisfy the production metrics contract. 
- Narrowly exempt only the exact environment variable names `DSPACE_TOKEN_PLACE_URL` and `DSPACE_TOKEN_PLACE_CHAT_MODEL` from inline-credential detection in `scripts/dspace_release_manifest.py` while preserving all other sensitive-name checks and reference-key handling. 
- Add regression tests in `tests/test_release_manifest.py` that: load the committed prod values chain via `app_config.load_config()` and `app_chart.merged_values_document()`, apply the approved immutable image mapping, and assert that `verify_helm_stored_values(..., "prod")` passes; and add focused cases proving the public token.place variables are accepted while true plain credentials and near-miss names remain rejected. 
- Changes are limited to the allowed scope: `docs/examples/dspace.values.prod.yaml`, `scripts/dspace_release_manifest.py`, and `tests/test_release_manifest.py`.

### Testing

- Verified Python syntax: `python3 -m py_compile scripts/dspace_release_manifest.py scripts/dspace_manifest_rollback.py` — success. 
- Ran unit test suites: `pytest -q tests/test_release_manifest.py` — 229 passed; `pytest -q tests/test_manifest_rollback.py` — 73 passed; `pytest -q tests/test_generic_app_just_recipes.py` — 422 passed with one pre-existing warning. 
- Ran the focused new/changed tests: `pytest -q tests/test_release_manifest.py -k 'committed_production_values_chain or public_token_place or credential_and_near_miss or credential_environment_plain_value'` — 9 passed. 
- Repository checks: `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` — no secrets reported and no diff errors for the staged changes; `linkchecker --no-warnings README.md docs/` — 208 URLs checked, zero errors. 
- Notes: `pyspelling -c .spellcheck.yaml` failed due to a missing system dependency (`aspell`) in the environment, and `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide lint/yaml issues (these were not modified to make tests pass). 

All tests added for this change passed and the production stored-values verifier now accepts the committed production values chain without weakening overall credential-detection rules or touching Secret material or live production resources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bab399cb0832fa7a934c3877fb8a2)