### PR TITLE
Fix DSPACE production metrics contract and narrow token.place credential detection

### DIFF
--- a/docs/examples/dspace.values.prod.yaml
+++ b/docs/examples/dspace.values.prod.yaml
@@ -15,6 +15,7 @@ env:
 
 metrics:
   enabled: true
+  path: /metrics
   auth:
     existingSecret: dspace-prod-metrics-token
     secretKey: token

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -996,14 +996,8 @@ def contains_inline_credential(value: object) -> bool:
     # Keeping the values explicit prevents an exempt variable from carrying an
     # authenticated URL, query token, or other credential material.
     public_token_place_settings = {
-        "DSPACE_TOKEN_PLACE_URL": {
-            "https://token.place",
-            "https://staging.token.place",
-        },
-        "DSPACE_TOKEN_PLACE_CHAT_MODEL": {
-            "llama-3.1-8b-instruct",
-            "qwen3-8b-instruct",
-        },
+        "DSPACE_TOKEN_PLACE_URL": "https://token.place",
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL": "llama-3.1-8b-instruct",
     }
 
     def is_empty(item: object) -> bool:
@@ -1014,10 +1008,7 @@ def contains_inline_credential(value: object) -> bool:
         approved_public_value = (
             isinstance(name, str)
             and "value" in value
-            and any(
-                value["value"] == approved
-                for approved in public_token_place_settings.get(name, set())
-            )
+            and value["value"] == public_token_place_settings.get(name)
         )
         if (
             isinstance(name, str)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -992,6 +992,12 @@ def contains_inline_credential(value: object) -> bool:
         "secretkeyref",
         "secretname",
     }
+    # These exact DSPACE environment variables configure the public token.place
+    # service and model; despite their names, neither carries credential material.
+    public_token_place_settings = {
+        "DSPACE_TOKEN_PLACE_URL",
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+    }
 
     def is_empty(item: object) -> bool:
         return item is None or item is False or item == "" or item == {} or item == []
@@ -1001,6 +1007,7 @@ def contains_inline_credential(value: object) -> bool:
         if (
             isinstance(name, str)
             and sensitive.search(name)
+            and name not in public_token_place_settings
             and "value" in value
             and not is_empty(value["value"])
         ):

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -992,11 +992,18 @@ def contains_inline_credential(value: object) -> bool:
         "secretkeyref",
         "secretname",
     }
-    # These exact DSPACE environment variables configure the public token.place
-    # service and model; despite their names, neither carries credential material.
+    # Only these reviewed public name/value pairs may bypass the name-based check.
+    # Keeping the values explicit prevents an exempt variable from carrying an
+    # authenticated URL, query token, or other credential material.
     public_token_place_settings = {
-        "DSPACE_TOKEN_PLACE_URL",
-        "DSPACE_TOKEN_PLACE_CHAT_MODEL",
+        "DSPACE_TOKEN_PLACE_URL": {
+            "https://token.place",
+            "https://staging.token.place",
+        },
+        "DSPACE_TOKEN_PLACE_CHAT_MODEL": {
+            "llama-3.1-8b-instruct",
+            "qwen3-8b-instruct",
+        },
     }
 
     def is_empty(item: object) -> bool:
@@ -1004,10 +1011,18 @@ def contains_inline_credential(value: object) -> bool:
 
     if isinstance(value, dict):
         name = value.get("name")
+        approved_public_value = (
+            isinstance(name, str)
+            and "value" in value
+            and any(
+                value["value"] == approved
+                for approved in public_token_place_settings.get(name, set())
+            )
+        )
         if (
             isinstance(name, str)
             and sensitive.search(name)
-            and name not in public_token_place_settings
+            and not approved_public_value
             and "value" in value
             and not is_empty(value["value"])
         ):

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -174,6 +174,7 @@ def test_dspace_prod_values_enable_authenticated_metrics_without_a_credential() 
     values = merged_values_document((str(OVERLAYS["prod"]),))
     assert values["metrics"] == {
         "enabled": True,
+        "path": "/metrics",
         "auth": {"existingSecret": "dspace-prod-metrics-token", "secretKey": "token"},
     }
     assert values["serviceMonitor"] == {

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -812,13 +812,43 @@ def test_helm_stored_values_reject_credential_environment_plain_value(name: str)
     ("name", "plain_value"),
     [
         ("DSPACE_TOKEN_PLACE_URL", "https://token.place"),
+        ("DSPACE_TOKEN_PLACE_URL", "https://staging.token.place"),
         ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "llama-3.1-8b-instruct"),
+        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "qwen3-8b-instruct"),
     ],
 )
 def test_inline_credential_check_accepts_public_token_place_settings(
     name: str, plain_value: str
 ) -> None:
     assert manifest.contains_inline_credential({"name": name, "value": plain_value}) is False
+
+
+@pytest.mark.parametrize(
+    ("name", "plain_value"),
+    [
+        (
+            "DSPACE_TOKEN_PLACE_URL",
+            "".join(("https://user:", "pass", "word@token.place")),
+        ),
+        (
+            "DSPACE_TOKEN_PLACE_URL",
+            "".join(("https://token.place?", "token", "=credential-sentinel")),
+        ),
+        ("DSPACE_TOKEN_PLACE_URL", "https://other.example"),
+        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "".join(("credential", "-sentinel"))),
+    ],
+)
+def test_inline_credential_check_rejects_unapproved_token_place_values(
+    name: str, plain_value: str
+) -> None:
+    value = {"name": name, "value": plain_value}
+    assert manifest.contains_inline_credential(value) is True
+
+    stored = production_stored_values()
+    stored["env"] = [value]
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+    assert plain_value not in str(raised.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -812,9 +812,7 @@ def test_helm_stored_values_reject_credential_environment_plain_value(name: str)
     ("name", "plain_value"),
     [
         ("DSPACE_TOKEN_PLACE_URL", "https://token.place"),
-        ("DSPACE_TOKEN_PLACE_URL", "https://staging.token.place"),
         ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "llama-3.1-8b-instruct"),
-        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "qwen3-8b-instruct"),
     ],
 )
 def test_inline_credential_check_accepts_public_token_place_settings(
@@ -834,7 +832,9 @@ def test_inline_credential_check_accepts_public_token_place_settings(
             "DSPACE_TOKEN_PLACE_URL",
             "".join(("https://token.place?", "token", "=credential-sentinel")),
         ),
+        ("DSPACE_TOKEN_PLACE_URL", "https://staging.token.place"),
         ("DSPACE_TOKEN_PLACE_URL", "https://other.example"),
+        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "qwen3-8b-instruct"),
         ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "".join(("credential", "-sentinel"))),
     ],
 )

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts import app_chart, app_config
 from scripts import dspace_release_manifest as manifest
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
@@ -687,6 +688,26 @@ def production_stored_values() -> dict[str, object]:
     }
 
 
+def test_committed_production_values_pass_stored_values_contract() -> None:
+    config = app_config.load_config("dspace", "prod")
+    values = app_chart.merged_values_document(tuple(config["SUGARKUBE_VALUES"].split(",")))
+    assert isinstance(values, dict)
+
+    recovery = json.loads(
+        Path("docs/apps/dspace.prod-recovery-coordinates.json").read_text(encoding="utf-8")
+    )
+    approved = manifest.candidate(
+        recovery, "prod", "openai", "2026-07-31T12:00:00Z", "operator"
+    )
+    values["image"] = {
+        "repository": manifest.IMAGE_REF,
+        "tag": approved["imageTag"],
+        "pullPolicy": "Always",
+    }
+
+    assert manifest.verify_helm_stored_values(approved, values, "prod")["passed"] is True
+
+
 def test_helm_stored_values_accept_chart_defaults_and_safe_references() -> None:
     value = split_candidate("prod")
     stored = production_stored_values()
@@ -782,6 +803,39 @@ def test_helm_stored_values_reject_credential_environment_plain_value(name: str)
     sentinel = "".join(("credential", "-sentinel"))
     stored = production_stored_values()
     stored["env"] = [{"name": name, "value": sentinel}]
+    with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
+        manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
+    assert sentinel not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ("name", "plain_value"),
+    [
+        ("DSPACE_TOKEN_PLACE_URL", "https://token.place"),
+        ("DSPACE_TOKEN_PLACE_CHAT_MODEL", "llama-3.1-8b-instruct"),
+    ],
+)
+def test_inline_credential_check_accepts_public_token_place_settings(
+    name: str, plain_value: str
+) -> None:
+    assert manifest.contains_inline_credential({"name": name, "value": plain_value}) is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "_".join(("DSPACE_TOKEN_PLACE_URL", "TOKEN")),
+        "_".join(("DSPACE_TOKEN_PLACE_CHAT_MODEL", "SECRET")),
+        "_".join(("DSPACE_TOKEN_PLACE", "".join(("PASS", "WORD")))),
+    ],
+)
+def test_inline_credential_check_does_not_exempt_close_names(name: str) -> None:
+    sentinel = "".join(("credential", "-sentinel"))
+    value = {"name": name, "value": sentinel}
+    assert manifest.contains_inline_credential(value) is True
+
+    stored = production_stored_values()
+    stored["env"] = [value]
     with pytest.raises(manifest.ManifestError, match="approved contract") as raised:
         manifest.verify_helm_stored_values(split_candidate("prod"), stored, "prod")
     assert sentinel not in str(raised.value)


### PR DESCRIPTION
### Motivation

The guarded production DSPACE reconciliation stopped before mutation because the committed desired values did not satisfy the stored-values contract:

- `metrics.path: /metrics` was missing.
- Public token.place URL/model settings were falsely classified as credentials because their names contain `TOKEN`.

### Changes

- Add explicit `metrics.path: /metrics` to `docs/examples/dspace.values.prod.yaml`.
- Restrict `contains_inline_credential()` to exempt only these exact approved public name/value pairs:
  - `DSPACE_TOKEN_PLACE_URL=https://token.place`
  - `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`
- Continue rejecting credential-bearing URLs, query tokens, staging or alternate endpoints, unapproved model values, `METRICS_TOKEN`, `DSPACE_API_KEY`, and close-name variants.
- Add a regression test that loads the committed production values through `app_config.load_config()` and `app_chart.merged_values_document()`, applies the approved immutable image mapping, and verifies the complete production stored-values contract.
- Add focused fail-closed and redaction coverage for approved pairs, unexpected values, genuine credential names, and near misses.
- Update the directly affected assertion in `tests/test_dspace_runtime_values.py` to expect `/metrics`.

### Safety and scope

The diff is limited to four directly affected files. The runtime-values assertion is the sole necessary expansion beyond the original allowed-file list.

This PR does not change chart or image pins, deployment evidence, Kubernetes resources, Secret handling, dashboards, alert rules, staging values, or DSPACE application source. No production commands were run, and no Secret was accessed, rotated, decoded, printed, or deleted.

### Verification

Latest head `c8211472a3cfe676027d3b5a79142c741a6b9840`:

- GitHub Test Suite: 2,853 passed, 63 skipped.
- GitHub `ci`: passed.
- GitHub Docs: spellcheck and linkcheck passed.
- GitHub pi-image: passed.
- Codecov: all modified and coverable lines are covered.

Targeted checks:

- `python3 -m py_compile scripts/dspace_release_manifest.py scripts/dspace_manifest_rollback.py`
- `pytest -q tests/test_release_manifest.py` — 234 passed.
- `pytest -q tests/test_dspace_runtime_values.py` — 10 passed.
- `pytest -q tests/test_manifest_rollback.py` — 73 passed.
- `pytest -q tests/test_generic_app_just_recipes.py` — 422 passed with one existing warning.
- `git diff --check`
- Working-tree and staged-diff secret scans.
- `linkchecker --no-warnings README.md docs/` — 208 links checked successfully.

The follow-up environment lacked the `aspell` binary for a standalone local `pyspelling` run, but the latest-head GitHub Docs spellcheck passed. Local repository-wide pre-commit still reported pre-existing unrelated whitespace, templated/multi-document YAML, and lint findings; no automatic out-of-scope edits were retained, and the latest-head GitHub `ci` workflow passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bab405690832f949ca7dd2838dc25)