### PR TITLE
Add read-only production resilience parity audit (just recipe, collector, tests, docs)

### DIFF
--- a/config/production-resilience-audit-targets.json
+++ b/config/production-resilience-audit-targets.json
@@ -1,0 +1,13 @@
+{
+  "targets": [
+    "https://danielsmith.io/",
+    "https://danielsmith.io/health",
+    "https://democratized.space/",
+    "https://democratized.space/health",
+    "https://democratized.space/live",
+    "https://token.place/",
+    "https://token.place/health",
+    "https://token.place/live",
+    "https://token.place/meta"
+  ]
+}

--- a/docs/production-resilience-audit.md
+++ b/docs/production-resilience-audit.md
@@ -1,0 +1,28 @@
+# Production resilience parity audit
+
+This audit inventories production against the DNS, ingress, and Cloudflare Tunnel HA contracts
+proven in staging. It is evidence collection, not a production rollout or an authorization to
+change production.
+
+Run it from `sugarkube0` or another authorized operator host after explicitly selecting the
+`sugar-prod` kubeconfig:
+
+```bash
+KUBECONFIG="$HOME/.kube/config" just prod-resilience-audit env=prod \
+  --evidence-dir="evidence/prod-resilience-$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+The command fails closed unless the context, repository cluster-identity result, and exact
+three-node production inventory all agree. It uses only read operations and never reads Secret
+values, pod logs, connector IDs, credentials, or user data. It probes only the narrowly scoped
+targets in `config/production-resilience-audit-targets.json`; each request has independent bounded
+timeouts. Evidence consists of deterministic sanitized JSON, a Markdown summary, endpoint TSV,
+and SHA-256 manifest. A completed collection returns success even when it reports `PARITY_GAPS`;
+add `--require-parity` when gaps should produce a nonzero exit status.
+
+Review the captured evidence before designing a separate, separately reviewed production
+lifecycle and rollout PR. Do **not** use the existing non-staging `cf-tunnel-install` behavior as
+a promotion mechanism. Dormant `platform/cloudflared` and `clusters/*/patches/cloudflared-values.yaml`
+resources are not treated as live ownership; the audit discovers the live Helm-owned Deployment.
+No production WAN-loss or node-loss drill is authorized. Issue #2407 remains closed, while
+#2408 remains open and separate application-replica work and is untouched by this workflow.

--- a/justfile
+++ b/justfile
@@ -728,6 +728,10 @@ cf-tunnel-install env='dev' token='':
 cf-tunnel-verify env='staging':
     scripts/verify_cloudflare_tunnel.sh {{ quote(env) }}
 
+# Strictly read-only production DNS/ingress and Cloudflare Tunnel parity evidence collection.
+prod-resilience-audit *args:
+    python3 "{{ justfile_directory() }}/scripts/production_resilience_audit.py" "${@}"
+
 # Plan (default) or execute the staging-only, same-process Cloudflare WAN dependency-loss drill.
 cf-tunnel-wan-dependency-loss-drill *args:
     scripts/cloudflare_wan_dependency_loss_drill.sh "$@"

--- a/scripts/production_resilience_audit.py
+++ b/scripts/production_resilience_audit.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Collect a sanitized, strictly read-only production resilience audit."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NODES = {"sugarkube0", "sugarkube1", "sugarkube2"}
+EXPECTED_IMAGE = (
+    "cloudflare/cloudflared:2026.7.3@sha256:"
+    "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+)
+FORBIDDEN = {
+    "apply",
+    "create",
+    "patch",
+    "replace",
+    "delete",
+    "edit",
+    "run",
+    "exec",
+    "port-forward",
+    "install",
+    "upgrade",
+    "rollback",
+    "uninstall",
+    "reconcile",
+    "repo",
+}
+
+
+class CollectionError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, required: bool = True) -> str:
+    """Run only commands admitted by the audit's read-only allow-list."""
+    if command[0] not in {"kubectl", "helm", "curl", "git", sys.executable}:
+        raise CollectionError(f"command is not allow-listed: {command[0]}")
+    if command[0] in {"kubectl", "helm"} and FORBIDDEN.intersection(command[1:]):
+        raise CollectionError("mutation command rejected by audit allow-list")
+    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    if proc.returncode and required:
+        raise CollectionError(f"read-only command failed: {command[0]} {' '.join(command[1:3])}")
+    return proc.stdout
+
+
+def load_json(command: list[str], *, optional: bool = False) -> dict[str, Any]:
+    text = run(command, required=not optional)
+    if optional and not text.strip():
+        return {}
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        if optional:
+            return {}
+        raise CollectionError(f"invalid JSON from {command[0]}") from exc
+    if not isinstance(value, dict) and command[0] == "kubectl":
+        raise CollectionError(f"unexpected JSON from {command[0]}")
+    return value
+
+
+def metadata(obj: dict[str, Any]) -> dict[str, Any]:
+    m = obj.get("metadata", {})
+    result = {
+        key: m.get(key)
+        for key in ("name", "namespace", "uid", "generation")
+        if m.get(key) is not None
+    }
+    for field in ("labels", "annotations"):
+        values = m.get(field, {})
+        if isinstance(values, dict):
+            result[field] = {
+                key: value
+                for key, value in sorted(values.items())
+                if not re.search(
+                    r"connector|tunnel.?id|token|secret|credential", f"{key} {value}", re.I
+                )
+            }
+    return result
+
+
+def lifecycle_spec(resource: str, obj: dict[str, Any]) -> dict[str, Any] | None:
+    """Retain structural desired state without arbitrary embedded configuration text."""
+    if not obj:
+        return None
+    if resource.startswith("deployment/"):
+        return deployment_snapshot(obj)
+    spec = obj.get("spec", {})
+    if not isinstance(spec, dict):
+        return {}
+    result = {key: value for key, value in spec.items() if key != "valuesContent"}
+    if isinstance(spec.get("valuesContent"), str):
+        result["valuesContentSha256"] = hashlib.sha256(spec["valuesContent"].encode()).hexdigest()
+    return result
+
+
+def pod_snapshot(pod: dict[str, Any]) -> dict[str, Any]:
+    status = pod.get("status", {})
+    containers = status.get("containerStatuses", []) or []
+    return {
+        "name": pod.get("metadata", {}).get("name"),
+        "uid": pod.get("metadata", {}).get("uid"),
+        "node": pod.get("spec", {}).get("nodeName"),
+        "ready": any(
+            c.get("type") == "Ready" and c.get("status") == "True"
+            for c in status.get("conditions", [])
+        ),
+        "restarts": sum(int(c.get("restartCount", 0)) for c in containers),
+        "terminating": bool(pod.get("metadata", {}).get("deletionTimestamp")),
+    }
+
+
+def deployment_snapshot(dep: dict[str, Any]) -> dict[str, Any]:
+    spec, status = dep.get("spec", {}), dep.get("status", {})
+    template = spec.get("template", {}).get("spec", {})
+    containers = template.get("containers", [])
+    return {
+        "metadata": metadata(dep),
+        "replicas": {
+            "desired": spec.get("replicas", 1),
+            "ready": status.get("readyReplicas", 0),
+            "available": status.get("availableReplicas", 0),
+        },
+        "strategy": spec.get("strategy", {}),
+        "affinity": template.get("affinity"),
+        "topologySpreadConstraints": template.get("topologySpreadConstraints"),
+        "containers": [
+            {
+                "name": c.get("name"),
+                "image": c.get("image"),
+                "readinessProbe": c.get("readinessProbe"),
+                "livenessProbe": c.get("livenessProbe"),
+                "secretReferences": sorted(
+                    {
+                        e.get("valueFrom", {}).get("secretKeyRef", {}).get("name")
+                        for e in c.get("env", [])
+                        if e.get("valueFrom", {}).get("secretKeyRef", {}).get("name")
+                    }
+                ),
+            }
+            for c in containers
+        ],
+    }
+
+
+def endpoint_snapshot(doc: dict[str, Any], service: str) -> dict[str, Any]:
+    grouped: dict[tuple[str, tuple[str, ...], str], list[tuple[bool, bool, bool]]] = {}
+    for item in doc.get("items", []):
+        if item.get("metadata", {}).get("labels", {}).get("kubernetes.io/service-name") != service:
+            raise CollectionError(f"unexpected EndpointSlice ownership for {service}")
+        for endpoint in item.get("endpoints", []):
+            conditions = endpoint.get("conditions", {})
+            ready = conditions.get("ready", True)
+            serving = conditions.get("serving", ready)
+            terminating = conditions.get("terminating", False)
+            target = endpoint.get("targetRef", {})
+            key = (
+                endpoint.get("nodeName") or "",
+                tuple(sorted(endpoint.get("addresses", []))),
+                "/".join(str(target.get(k, "")) for k in ("kind", "namespace", "name", "uid")),
+            )
+            grouped.setdefault(key, []).append(
+                (ready is True, serving is True, terminating is True)
+            )
+    healthy = [
+        key for key, states in grouped.items() if all(r and s and not t for r, s, t in states)
+    ]
+    unhealthy = [key for key in grouped if key not in healthy]
+    return {
+        "service": service,
+        "sliceCount": len(doc.get("items", [])),
+        "uniqueEndpoints": len(grouped),
+        "healthyEndpoints": len(healthy),
+        "unhealthyEndpoints": len(unhealthy),
+        "healthyNodes": sorted({key[0] for key in healthy if key[0]}),
+    }
+
+
+def gap(gaps: list[dict[str, str]], code: str, detail: str) -> None:
+    gaps.append({"code": code, "detail": detail})
+
+
+def prom_value(path: str) -> int:
+    doc = load_json(["kubectl", "get", "--raw", path])
+    try:
+        return int(float(doc["data"]["result"][0]["value"][1]))
+    except (KeyError, IndexError, TypeError, ValueError):
+        return 0
+
+
+def probe(url: str) -> dict[str, Any]:
+    proc = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--output",
+            "/dev/null",
+            "--max-time",
+            "10",
+            "--connect-timeout",
+            "4",
+            "--write-out",
+            "%{http_code}\t%{time_connect}\t%{time_starttransfer}\t%{time_total}",
+            url,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    fields = proc.stdout.strip().split("\t")
+    error = (
+        "none" if proc.returncode == 0 else ("timeout" if proc.returncode == 28 else "transport")
+    )
+    return {
+        "url": url,
+        "status": int(fields[0]) if len(fields) == 4 and fields[0].isdigit() else 0,
+        "connectSeconds": fields[1] if len(fields) == 4 else None,
+        "startTransferSeconds": fields[2] if len(fields) == 4 else None,
+        "totalSeconds": fields[3] if len(fields) == 4 else None,
+        "error": error,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("env", help="must be env=prod or prod")
+    parser.add_argument("--evidence-dir", required=True, type=Path)
+    parser.add_argument("--require-parity", action="store_true")
+    args = parser.parse_args()
+    env_name = args.env
+    while env_name.startswith("env="):
+        env_name = env_name[4:]
+    if env_name != "prod":
+        raise CollectionError("env must normalize exactly to prod")
+    for tool in ("kubectl", "helm", "curl", "git"):
+        if shutil.which(tool) is None:
+            raise CollectionError(f"required read-only tool not found: {tool}")
+    context = run(["kubectl", "config", "current-context"]).strip()
+    if context != "sugar-prod":
+        raise CollectionError("current kubectl context must be exactly sugar-prod")
+    kubeconfig = os.environ.get("KUBECONFIG", str(Path.home() / ".kube/config"))
+    detected = run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/cluster_identity.py"),
+            "assert",
+            "--kubeconfig",
+            kubeconfig,
+            "--env",
+            "prod",
+        ]
+    ).strip()
+    if detected != "prod":
+        raise CollectionError("repository cluster-identity detection did not report prod")
+    nodes_doc = load_json(["kubectl", "get", "nodes", "-o", "json"])
+    node_names = {x.get("metadata", {}).get("name") for x in nodes_doc.get("items", [])}
+    if node_names != EXPECTED_NODES:
+        raise CollectionError(
+            "observed node set must be exactly sugarkube0, sugarkube1, and sugarkube2"
+        )
+
+    gaps: list[dict[str, str]] = []
+    node_state = [
+        {
+            "name": n.get("metadata", {}).get("name"),
+            "ready": next(
+                (
+                    c.get("status") == "True"
+                    for c in n.get("status", {}).get("conditions", [])
+                    if c.get("type") == "Ready"
+                ),
+                False,
+            ),
+        }
+        for n in nodes_doc.get("items", [])
+    ]
+    if not all(n["ready"] for n in node_state):
+        gap(gaps, "NODE_NOT_READY", "not every production node is Ready")
+    readyz = run(["kubectl", "get", "--raw", "/readyz?verbose"])
+    readyz_lines = sorted(line.strip() for line in readyz.splitlines() if line.strip())
+    if "etcd" not in readyz.lower() or "failed" in readyz.lower():
+        gap(gaps, "API_READINESS_GAP", "API verbose readiness or etcd readiness is unhealthy")
+
+    components: dict[str, Any] = {}
+    for name in ("coredns", "traefik"):
+        dep = load_json(["kubectl", "-n", "kube-system", "get", "deployment", name, "-o", "json"])
+        pods = load_json(
+            [
+                "kubectl",
+                "-n",
+                "kube-system",
+                "get",
+                "pods",
+                "-l",
+                f"app.kubernetes.io/name={name}" if name == "traefik" else "k8s-app=kube-dns",
+                "-o",
+                "json",
+            ]
+        )
+        snap = deployment_snapshot(dep)
+        snap["pods"] = sorted(
+            (pod_snapshot(p) for p in pods.get("items", [])), key=lambda p: p["name"] or ""
+        )
+        components[name] = snap
+        ready_nodes = {p["node"] for p in snap["pods"] if p["ready"] and not p["terminating"]}
+        if snap["replicas"]["ready"] < 2:
+            gap(gaps, f"{name.upper()}_SINGLETON", f"{name} has fewer than two Ready replicas")
+        if len(ready_nodes) < 2:
+            gap(
+                gaps,
+                f"{name.upper()}_UNSPREAD",
+                f"{name} Ready pods are not spread across two nodes",
+            )
+    endpoints = []
+    for service in ("kube-dns", "traefik"):
+        doc = load_json(
+            [
+                "kubectl",
+                "-n",
+                "kube-system",
+                "get",
+                "endpointslices.discovery.k8s.io",
+                "-l",
+                f"kubernetes.io/service-name={service}",
+                "-o",
+                "json",
+            ]
+        )
+        snap = endpoint_snapshot(doc, service)
+        endpoints.append(snap)
+        if snap["healthyEndpoints"] < 2:
+            gap(
+                gaps,
+                f"{service.upper().replace('-', '_')}_ENDPOINTS_INSUFFICIENT",
+                f"{service} has fewer than two effective healthy endpoints",
+            )
+        if len(snap["healthyNodes"]) < 2:
+            gap(
+                gaps,
+                f"{service.upper().replace('-', '_')}_ENDPOINTS_UNSPREAD",
+                f"{service} endpoints are insufficiently spread",
+            )
+    traefik_service = load_json(
+        ["kubectl", "-n", "kube-system", "get", "service", "traefik", "-o", "json"]
+    )
+    components["traefik"]["internalTrafficPolicy"] = traefik_service.get("spec", {}).get(
+        "internalTrafficPolicy", "Cluster"
+    )
+    components["pdbs"] = load_json(
+        ["kubectl", "-n", "kube-system", "get", "pdb", "-o", "json"], optional=True
+    ).get("items", [])
+    lifecycle = {}
+    for resource in ("helmchartconfig/traefik", "deployment/coredns-ha"):
+        obj = load_json(
+            ["kubectl", "-n", "kube-system", "get", resource, "-o", "json"], optional=True
+        )
+        lifecycle[resource] = (
+            {
+                "present": bool(obj),
+                "metadata": metadata(obj),
+                "desiredSpec": lifecycle_spec(resource, obj),
+            }
+            if obj
+            else {"present": False}
+        )
+
+    deployments = load_json(
+        [
+            "kubectl",
+            "get",
+            "deployments",
+            "-A",
+            "-l",
+            "app.kubernetes.io/name=cloudflare-tunnel",
+            "-o",
+            "json",
+        ]
+    )
+    candidates = sorted(
+        deployments.get("items", []),
+        key=lambda d: (
+            d.get("metadata", {}).get("namespace", ""),
+            d.get("metadata", {}).get("name", ""),
+        ),
+    )
+    if len(candidates) != 1:
+        raise CollectionError(
+            f"expected exactly one live Cloudflare Tunnel Deployment; found {len(candidates)}"
+        )
+    tunnel_dep = candidates[0]
+    tm = tunnel_dep.get("metadata", {})
+    annotations = tm.get("annotations", {})
+    namespace = tm.get("namespace")
+    release = annotations.get("meta.helm.sh/release-name") or tm.get("labels", {}).get(
+        "app.kubernetes.io/instance"
+    )
+    release_ns = annotations.get("meta.helm.sh/release-namespace") or namespace
+    if (
+        not release
+        or release_ns != namespace
+        or tm.get("labels", {}).get("app.kubernetes.io/managed-by") != "Helm"
+    ):
+        raise CollectionError("live Cloudflare Deployment does not have unambiguous Helm ownership")
+    releases = json.loads(run(["helm", "list", "-A", "-o", "json"]) or "[]")
+    matches = [r for r in releases if r.get("name") == release and r.get("namespace") == namespace]
+    if len(matches) != 1:
+        raise CollectionError("live Deployment did not resolve to exactly one Helm release")
+    helm_status = json.loads(
+        run(["helm", "-n", namespace, "status", release, "-o", "json"]) or "{}"
+    )
+    helm_history = json.loads(
+        run(["helm", "-n", namespace, "history", release, "-o", "json"]) or "[]"
+    )
+    tunnel = deployment_snapshot(tunnel_dep)
+    tunnel["release"] = {
+        "namespace": namespace,
+        "name": release,
+        "chart": matches[0].get("chart"),
+        "appVersion": matches[0].get("app_version"),
+        "status": matches[0].get("status"),
+        "revision": matches[0].get("revision"),
+        "history": [
+            {k: h.get(k) for k in ("revision", "status", "chart", "app_version")}
+            for h in helm_history
+        ],
+        "helmStatus": helm_status.get("info", {}).get("status"),
+    }
+    selector = f"app.kubernetes.io/name=cloudflare-tunnel,app.kubernetes.io/instance={release}"
+    tunnel_pods = load_json(
+        ["kubectl", "-n", namespace, "get", "pods", "-l", selector, "-o", "json"]
+    )
+    tunnel["pods"] = sorted(
+        (pod_snapshot(p) for p in tunnel_pods.get("items", [])), key=lambda p: p["name"] or ""
+    )
+    pdb = load_json(
+        ["kubectl", "-n", namespace, "get", "pdb", "-l", selector, "-o", "json"], optional=True
+    )
+    metrics_service = load_json(
+        ["kubectl", "-n", namespace, "get", "service", "-l", selector, "-o", "json"], optional=True
+    )
+    monitor = load_json(
+        ["kubectl", "-n", namespace, "get", "servicemonitor", "-l", selector, "-o", "json"],
+        optional=True,
+    )
+    tunnel["pdbCount"] = len(pdb.get("items", []))
+    tunnel["metricsServiceCount"] = len(metrics_service.get("items", []))
+    tunnel["serviceMonitorCount"] = len(monitor.get("items", []))
+    container = (tunnel.get("containers") or [{}])[0]
+    ready_pods = [p for p in tunnel["pods"] if p["ready"] and not p["terminating"]]
+    strategy = tunnel.get("strategy") or {}
+    rolling = strategy.get("rollingUpdate", {})
+    anti_affinity = (tunnel.get("affinity") or {}).get("podAntiAffinity", {})
+    required_spread = anti_affinity.get("requiredDuringSchedulingIgnoredDuringExecution", [])
+    pdb_items = pdb.get("items", [])
+    service_items = metrics_service.get("items", [])
+    checks = {
+        "TUNNEL_CHART_VERSION_MISMATCH": matches[0].get("chart") != "cloudflare-tunnel-0.3.2",
+        "IMAGE_NOT_IMMUTABLE": container.get("image") != EXPECTED_IMAGE,
+        "TUNNEL_READY_REPLICAS_INSUFFICIENT": len(ready_pods) < 2,
+        "TUNNEL_UNSPREAD": len({p["node"] for p in ready_pods}) < 2,
+        "TUNNEL_ANTI_AFFINITY_MISSING": not any(
+            term.get("topologyKey") == "kubernetes.io/hostname" for term in required_spread
+        ),
+        "TUNNEL_UNSAFE_ROLLOUT": strategy.get("type", "RollingUpdate") != "RollingUpdate"
+        or str(rolling.get("maxUnavailable")) != "0"
+        or str(rolling.get("maxSurge")) != "1",
+        "TUNNEL_PROBE_CONTRACT": container.get("readinessProbe", {}).get("httpGet", {}).get("path")
+        != "/ready"
+        or container.get("livenessProbe") is not None,
+        "TUNNEL_PDB_MISSING": len(pdb_items) != 1
+        or pdb_items[0].get("spec", {}).get("minAvailable") != 1,
+        "TUNNEL_METRICS_DISCOVERY_MISSING": len(service_items) != 1
+        or service_items[0].get("spec", {}).get("type", "ClusterIP") != "ClusterIP"
+        or service_items[0].get("spec", {}).get("clusterIP") == "None"
+        or tunnel["serviceMonitorCount"] != 1,
+    }
+    for code, failed in checks.items():
+        if failed:
+            gap(gaps, code, code.lower().replace("_", " "))
+    metrics = {
+        "healthyTargetCount": prom_value(
+            "/api/v1/namespaces/monitoring/services/"
+            "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
+            "count(up%7Bservice%3D%22cloudflare-tunnel-metrics%22%7D%20%3D%3D%201)"
+        ),
+        "connectorsWithFourHAConnections": prom_value(
+            "/api/v1/namespaces/monitoring/services/"
+            "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
+            "count(cloudflared_tunnel_ha_connections%7Bservice%3D%22"
+            "cloudflare-tunnel-metrics%22%7D%20%3E%3D%204)"
+        ),
+        "firingRelevantAlerts": prom_value(
+            "/api/v1/namespaces/monitoring/services/"
+            "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
+            "count(ALERTS%7Balertname%3D~%22CloudflareTunnel.%2A%22%2C"
+            "alertstate%3D%22firing%22%7D)"
+        ),
+    }
+    if metrics["healthyTargetCount"] < len(ready_pods):
+        gap(
+            gaps,
+            "TUNNEL_METRICS_TARGETS_UNHEALTHY",
+            "fewer healthy metrics targets than Ready connectors",
+        )
+    if metrics["connectorsWithFourHAConnections"] < len(ready_pods):
+        gap(
+            gaps,
+            "TUNNEL_HA_CONNECTIONS_INSUFFICIENT",
+            "fewer than four HA connections per Ready connector",
+        )
+    if metrics["firingRelevantAlerts"]:
+        gap(gaps, "TUNNEL_ALERT_FIRING", "a relevant Cloudflare Tunnel alert is firing")
+
+    targets = json.loads((ROOT / "config/production-resilience-audit-targets.json").read_text())[
+        "targets"
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(targets)) as pool:
+        probes = sorted(pool.map(probe, targets), key=lambda p: p["url"])
+    for p in probes:
+        if p["error"] != "none" or not 200 <= p["status"] < 400:
+            gap(gaps, "ENDPOINT_PROBE_FAILED", f"approved endpoint failed: {p['url']}")
+    gaps.sort(key=lambda x: (x["code"], x["detail"]))
+    timestamp = os.environ.get("SUGARKUBE_AUDIT_TIMESTAMP") or dt.datetime.now(
+        dt.timezone.utc
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    audit = {
+        "schemaVersion": 1,
+        "timestamp": timestamp,
+        "gitRevision": run(["git", "rev-parse", "HEAD"]).strip(),
+        "environment": "prod",
+        "context": context,
+        "result": "PARITY_OK" if not gaps else "PARITY_GAPS",
+        "gapCount": len(gaps),
+        "gaps": gaps,
+        "observed": {
+            "nodes": sorted(node_state, key=lambda n: n["name"]),
+            "apiReadyz": readyz_lines,
+            "components": components,
+            "endpointSlices": endpoints,
+            "lifecycle": lifecycle,
+            "cloudflareTunnel": tunnel,
+            "prometheus": metrics,
+            "probes": probes,
+        },
+    }
+    out = args.evidence_dir
+    out.mkdir(parents=True, exist_ok=False)
+    (out / "audit.json").write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n")
+    (out / "endpoints.tsv").write_text(
+        "url\tstatus\tconnect_seconds\tstart_transfer_seconds\ttotal_seconds\terror\n"
+        + "".join(
+            "\t".join(
+                str(value or "")
+                for value in (
+                    p["url"],
+                    p["status"],
+                    p["connectSeconds"],
+                    p["startTransferSeconds"],
+                    p["totalSeconds"],
+                    p["error"],
+                )
+            )
+            + "\n"
+            for p in probes
+        )
+    )
+    rows = (
+        "\n".join(f"| `{g['code']}` | {g['detail']} |" for g in gaps)
+        or "| — | No parity gaps observed. |"
+    )
+    (out / "summary.md").write_text(
+        "# Production resilience parity audit\n\n"
+        f"**Result:** `{audit['result']}` — {len(gaps)} gap(s).\n\n"
+        f"| Gap code | Detail |\n|---|---|\n{rows}\n"
+    )
+    files = sorted(p for p in out.iterdir() if p.name != "sha256sums.txt")
+    (out / "sha256sums.txt").write_text(
+        "".join(f"{hashlib.sha256(p.read_bytes()).hexdigest()}  {p.name}\n" for p in files)
+    )
+    print(
+        f"{audit['result']}: collection completed with {len(gaps)} parity gap(s); evidence: {out}"
+    )
+    return 1 if args.require_parity and gaps else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except CollectionError as exc:
+        print(f"COLLECTION_FAILED: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/tests/test_production_resilience_audit.py
+++ b/tests/test_production_resilience_audit.py
@@ -1,0 +1,106 @@
+"""Focused offline checks for the production resilience audit's safety primitives."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from scripts import production_resilience_audit as audit
+
+ROOT = pathlib.Path(__file__).parents[1]
+
+
+def test_endpoint_slices_aggregate_duplicates_and_effective_conditions() -> None:
+    endpoint = {"addresses": ["10.0.0.1"], "nodeName": "sugarkube0"}
+    doc = {
+        "items": [
+            {
+                "metadata": {"labels": {"kubernetes.io/service-name": "traefik"}},
+                "endpoints": [endpoint],
+            },
+            {
+                "metadata": {"labels": {"kubernetes.io/service-name": "traefik"}},
+                "endpoints": [endpoint | {"conditions": {"serving": False}}],
+            },
+            {
+                "metadata": {"labels": {"kubernetes.io/service-name": "traefik"}},
+                "endpoints": [
+                    {
+                        "addresses": ["10.0.0.2"],
+                        "nodeName": "sugarkube1",
+                        "conditions": {"ready": True, "serving": True, "terminating": False},
+                    }
+                ],
+            },
+        ]
+    }
+    result = audit.endpoint_snapshot(doc, "traefik")
+    assert result == {
+        "service": "traefik",
+        "sliceCount": 3,
+        "uniqueEndpoints": 2,
+        "healthyEndpoints": 1,
+        "unhealthyEndpoints": 1,
+        "healthyNodes": ["sugarkube1"],
+    }
+
+
+def test_metadata_and_lifecycle_never_retain_sensitive_values() -> None:
+    obj = {
+        "metadata": {
+            "name": "tunnel",
+            "labels": {"safe": "Helm", "connector-id": "DO_NOT_RETAIN"},
+            "annotations": {"token": "DO_NOT_RETAIN", "safe": "value"},
+        },
+        "spec": {"valuesContent": "replicas: 2", "safe": 2},
+    }
+    evidence = {
+        "metadata": audit.metadata(obj),
+        "spec": audit.lifecycle_spec("helmchartconfig/x", obj),
+    }
+    encoded = json.dumps(evidence)
+    assert "DO_NOT_RETAIN" not in encoded
+    assert evidence["metadata"]["labels"] == {"safe": "Helm"}
+    assert evidence["spec"]["safe"] == 2
+    assert len(evidence["spec"]["valuesContentSha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["kubectl", "apply", "-f", "x"],
+        ["kubectl", "exec", "pod", "--", "sh"],
+        ["helm", "upgrade", "release", "chart"],
+        ["helm", "repo", "update"],
+    ],
+)
+def test_mutation_commands_are_rejected_before_execution(monkeypatch, command) -> None:
+    called = False
+
+    def forbidden(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(audit.subprocess, "run", forbidden)
+    with pytest.raises(audit.CollectionError, match="mutation command"):
+        audit.run(command)
+    assert not called
+
+
+def test_repository_recipe_does_not_call_install_or_drill_lifecycles() -> None:
+    recipe = (
+        (ROOT / "justfile").read_text().split("prod-resilience-audit", 1)[1].split("\n\n", 1)[0]
+    )
+    assert "production_resilience_audit.py" in recipe
+    assert "cf-tunnel-install" not in recipe
+    assert "wan-dependency-loss-drill" not in recipe
+
+
+def test_gap_order_is_stable() -> None:
+    gaps = []
+    audit.gap(gaps, "Z_GAP", "second")
+    audit.gap(gaps, "A_GAP", "first")
+    gaps.sort(key=lambda item: (item["code"], item["detail"]))
+    assert [item["code"] for item in gaps] == ["A_GAP", "Z_GAP"]


### PR DESCRIPTION
### Motivation

- Provide a strictly read-only, evidence-producing audit that inventories production DNS/ingress and the live Cloudflare Tunnel release against the staging-proven HA contracts before any production rollout is designed or authorized. 
- Require fail-closed guards so the audit only runs when `env` normalizes to `prod`, the current `kubectl` context is `sugar-prod`, repository cluster-identity reports `prod`, and the node set is exactly `sugarkube0/1/2`.

### Description

- Add a `just` recipe `prod-resilience-audit` that invokes a new read-only collector script; the recipe does not call `cf-tunnel-install`, the WAN-loss drill, or any mutating lifecycles. (`justfile`)
- Implement `scripts/production_resilience_audit.py`, a read-only collector that allow-lists safe commands, rejects mutation verbs, sanitizes metadata (redacts connector/token-like keys), hashes embedded values, and assembles deterministic evidence including `audit.json`, `summary.md`, `endpoints.tsv`, and `sha256sums.txt`.
- Discover and validate the live Cloudflare Tunnel Deployment via live `kubectl` + `helm` discovery (require exactly one candidate), capture sanitized Deployment/Pod/PDB/Service/ServiceMonitor snapshots, and run Prometheus queries to aggregate target and HA-connection health without retaining raw connector IDs or secrets.
- Add a narrow production probe manifest (`config/production-resilience-audit-targets.json`) and operator documentation (`docs/production-resilience-audit.md`).
- Add focused offline tests `tests/test_production_resilience_audit.py` covering EndpointSlice aggregation semantics, metadata redaction, mutation-command rejection, recipe isolation, and stable gap ordering.

### Testing

- Unit and integration-like test runs: `python3 -m pytest -q tests/test_production_resilience_audit.py tests/test_cloudflare_tunnel_hardening.py tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_token_mode.py tests/test_staging_ingress_ha.py` — all tests passed (58 passed).
- Formatter/lint checks run: `python3 -m black`, `python3 -m flake8` targeted at the new files passed; `just --unstable --fmt --check` rendered the recipe successfully; `just --dry-run prod-resilience-audit env=prod --evidence-dir=/tmp/evidence` produced the expected invocation string.
- Repository standard checks: `pre-commit run --all-files` was executed; the new files passed focused hooks, while the repository-wide `run-checks` hook surfaced pre-existing Flake8/style failures in unrelated files (these are existing repository issues and did not originate from this PR).
- Docs/links/spelling: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were executed successfully (spelling passed; linkcheck found 0 errors).

Notes and safety boundary: the collector enforces read-only execution, never reads Secret `.data` values, never runs any mutating `kubectl`/`helm`/`flux`/system commands, and never performs any Cloudflare WAN or node-loss drill; review captured evidence before designing any separate production rollout PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bb3dbf0d8832fa06ab567b561fde0)