### PR TITLE
Add read-only production resilience parity audit (prod-resilience-audit)

### DIFF
--- a/config/prod-resilience-audit-targets.json
+++ b/config/prod-resilience-audit-targets.json
@@ -1,0 +1,5 @@
+{
+  "democratized.space": ["/", "/healthz", "/livez", "/config.json", "/build-meta.json"],
+  "token.place": ["/", "/healthz", "/livez", "/api/v1/meta"],
+  "danielsmith.io": ["/", "/healthz", "/livez", "/build-meta.json"]
+}

--- a/config/prod-resilience-audit-targets.json
+++ b/config/prod-resilience-audit-targets.json
@@ -1,5 +1,5 @@
 {
   "democratized.space": ["/", "/healthz", "/livez", "/config.json", "/build-meta.json"],
   "token.place": ["/", "/healthz", "/livez", "/api/v1/meta"],
-  "danielsmith.io": ["/", "/healthz", "/livez", "/build-meta.json"]
+  "danielsmith.io": ["/", "/healthz", "/livez"]
 }

--- a/docs/production-resilience-audit.md
+++ b/docs/production-resilience-audit.md
@@ -1,0 +1,40 @@
+# Production resilience parity audit
+
+This audit is the read-only prerequisite to any production DNS, ingress, or Cloudflare Tunnel
+high-availability proposal. It inventories the live cluster and compares observations with the
+contract proven by the staging WAN drill. It does **not** deploy, patch, restart, delete, reconcile,
+or render changes, and it does not invoke `cf-tunnel-install`. The current non-staging behavior of
+that recipe is materially different from the staging lifecycle and is not an approved production
+promotion mechanism. Dormant `platform/cloudflared` and `clusters/*/patches/cloudflared-values.yaml`
+resources are not treated as live ownership.
+
+Run from `sugarkube0` or another authorized operator host. Explicitly select the production
+kubeconfig first; its current context must be exactly `sugar-prod`, the repository identity check
+must report `prod`, and the observed nodes must be exactly `sugarkube0`, `sugarkube1`, and
+`sugarkube2`.
+
+```bash
+export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
+test "$(kubectl config current-context)" = sugar-prod
+just prod-resilience-audit env=prod --evidence-dir="$PWD/prod-audit-evidence"
+```
+
+The default exit status is successful when collection completes, even when the report contains
+expected parity gaps. Use `--require-parity` in a gate that should fail when any stable gap code is
+present:
+
+```bash
+just prod-resilience-audit env=prod --evidence-dir="$PWD/prod-audit-gate" --require-parity
+```
+
+The evidence directory contains deterministic, sanitized `audit.json`, `summary.md`,
+`endpoints.tsv`, and `SHA256SUMS`. Kubernetes Secret resources and values, Helm values, pod logs,
+raw Prometheus label sets, and tunnel connector identifiers are never queried or retained. Public
+requests are bounded and run independently; evidence records only URLs, status codes, bounded
+timings, and sanitized error classes. The committed target list is narrowly scoped in
+`config/prod-resilience-audit-targets.json`, based on each application's production runbook.
+
+Review all evidence before designing a separate, explicitly reviewed production lifecycle and
+rollout PR. This audit does not select a replica count. No production WAN-loss or node-loss drill is
+authorized. The staging work in issue #2407 remains closed; issue #2408 remains open, separate
+application-replica work and is not changed by this audit.

--- a/justfile
+++ b/justfile
@@ -3674,3 +3674,7 @@ staging-ingress-ha-verify env='staging':
 
 staging-ingress-ha-rollback env='staging':
     scripts/staging_ingress_ha.sh rollback "{{ env }}"
+
+# Collect sanitized, read-only production DNS/ingress and tunnel parity evidence.
+prod-resilience-audit env *args:
+    scripts/prod_resilience_audit.sh "{{ env }}" {{ args }}

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -9,6 +9,7 @@ import datetime as dt
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -46,8 +47,11 @@ def run(argv: list[str], *, ok=(0,), timeout=30) -> subprocess.CompletedProcess[
         raise HardFailure("internal safety policy rejected a mutating helm command")
     proc = subprocess.run(argv, text=True, capture_output=True, timeout=timeout, check=False)
     if proc.returncode not in ok:
-        operation = argv[1] if len(argv) > 1 else ""
-        raise HardFailure(f"read-only command failed: {argv[0]} {operation}")
+        stderr = " ".join(proc.stderr.split())[:500] or "<empty>"
+        raise HardFailure(
+            f"read-only command failed (exit {proc.returncode}): {shlex.join(argv)}; "
+            f"stderr: {stderr}"
+        )
     return proc
 
 
@@ -69,6 +73,30 @@ def kubectl(*args: str, allow_missing=False) -> dict[str, Any]:
 def add_gap(gaps: set[str], code: str, condition: bool) -> None:
     if condition:
         gaps.add(code)
+
+
+def int_or_string_equals(value: Any, expected: int) -> bool:
+    """Compare a Kubernetes IntOrString value with an expected integer."""
+    return not isinstance(value, bool) and str(value) == str(expected)
+
+
+def probe_urls(target_map: Any) -> list[str]:
+    """Expand the public target manifest, failing closed when it has no URLs."""
+    if not isinstance(target_map, dict):
+        raise HardFailure("production probe target manifest must be an object")
+    urls = sorted(
+        f"https://{host}{path}"
+        for host, paths in target_map.items()
+        if isinstance(paths, list)
+        for path in paths
+    )
+    if not urls:
+        raise HardFailure("production probe target manifest contains no URLs")
+    return urls
+
+
+def probes_unhealthy(rows: list[dict[str, Any]]) -> bool:
+    return any(row.get("error") or not 200 <= row["status"] < 400 for row in rows)
 
 
 def ready(pod: dict[str, Any]) -> bool:
@@ -421,18 +449,22 @@ def main() -> int:
     strategy = tunnel["strategy"].get("rollingUpdate", {})
     add_gap(gaps, "CF_IMAGE_NOT_IMMUTABLE_PIN", container.get("image") != EXPECTED_IMAGE)
     add_gap(gaps, "CF_CHART_VERSION_MISMATCH", release.get("chart") != "cloudflare-tunnel-0.3.2")
+    add_gap(gaps, "CF_HELM_RELEASE_NOT_DEPLOYED", tunnel["helmStatus"] != "deployed")
     add_gap(gaps, "CF_CONNECTORS_INSUFFICIENT", len(ready_tunnel) < 2)
     add_gap(gaps, "CF_CONNECTORS_UNSPREAD", len({p["node"] for p in ready_tunnel}) < 2)
     add_gap(
         gaps,
         "CF_UNSAFE_ROLLOUT",
-        strategy.get("maxUnavailable") != 0 or strategy.get("maxSurge") != 1,
+        not int_or_string_equals(strategy.get("maxUnavailable"), 0)
+        or not int_or_string_equals(strategy.get("maxSurge"), 1),
     )
     probe_spec = (container.get("readinessProbe") or {}).get("httpGet", {})
     add_gap(
         gaps,
         "CF_PROBE_CONTRACT",
-        probe_spec.get("path") != "/ready" or bool(container.get("livenessProbe")),
+        probe_spec.get("path") != "/ready"
+        or not int_or_string_equals(probe_spec.get("port"), 2000)
+        or bool(container.get("livenessProbe")),
     )
     pdbs = list_items(
         "-n", ns, "get", "pdb", "-l", f"app.kubernetes.io/instance={release_name}", "-o", "json"
@@ -499,11 +531,13 @@ def main() -> int:
     add_gap(gaps, "CF_ALERTS_FIRING", metrics["firingRelevantAlerts"] != 0)
 
     target_map = json.loads(TARGETS.read_text())
-    urls = sorted(f"https://{host}{path}" for host, paths in target_map.items() for path in paths)
+    urls = probe_urls(target_map)
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(urls)) as pool:
         probe_rows = sorted(pool.map(probe, urls), key=lambda row: row["url"])
     add_gap(
-        gaps, "PUBLIC_ENDPOINT_UNHEALTHY", any(not 200 <= row["status"] < 400 for row in probe_rows)
+        gaps,
+        "PUBLIC_ENDPOINT_UNHEALTHY",
+        probes_unhealthy(probe_rows),
     )
     revision = run(["git", "rev-parse", "HEAD"]).stdout.strip()
     timestamp = os.environ.get("SUGARKUBE_AUDIT_TIMESTAMP") or dt.datetime.now(

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -783,21 +783,45 @@ def main(argv: list[str] | None = None) -> int:
         annotations = object_shape(
             meta.get("annotations", {}), "malformed Kubernetes Deployment metadata"
         )
-        release_name = labels.get("app.kubernetes.io/instance") or annotations.get(
-            "meta.helm.sh/release-name"
-        )
+        managed_by = labels.get("app.kubernetes.io/managed-by")
+        release_name = annotations.get("meta.helm.sh/release-name")
+        release_namespace = annotations.get("meta.helm.sh/release-namespace")
+        instance = labels.get("app.kubernetes.io/instance")
+        namespace = meta.get("namespace")
+        if not (
+            managed_by == "Helm"
+            and isinstance(release_name, str)
+            and isinstance(release_namespace, str)
+            and release_namespace == namespace
+            and (instance is None or instance == release_name)
+        ):
+            continue
         match = [
             r
             for r in releases
-            if r.get("name") == release_name and r.get("namespace") == meta.get("namespace")
+            if r.get("name") == release_name and r.get("namespace") == release_namespace
         ]
         if len(match) == 1:
-            candidates.append((dep, match[0]))
+            candidates.append(
+                (
+                    dep,
+                    match[0],
+                    {
+                        "managedBy": managed_by,
+                        "releaseName": release_name,
+                        "releaseNamespace": release_namespace,
+                        "managedByHelm": True,
+                        "instanceMatchesRelease": instance is None or instance == release_name,
+                        "namespaceMatchesDeployment": release_namespace == namespace,
+                        "matchesUniqueHelmRelease": True,
+                    },
+                )
+            )
     if len(candidates) != 1:
         raise HardFailure(
             f"expected exactly one live Cloudflare release candidate; found {len(candidates)}"
         )
-    tunnel_dep, release = candidates[0]
+    tunnel_dep, release, helm_ownership = candidates[0]
     tunnel_meta = object_shape(
         tunnel_dep.get("metadata"), "malformed Kubernetes Deployment metadata"
     )
@@ -838,6 +862,7 @@ def main(argv: list[str] | None = None) -> int:
             "revision": release.get("revision"),
             "helmListStatus": list_status,
             "helmCurrentHistoryStatus": current_history_status,
+            "helmOwnership": helm_ownership,
             "history": history,
         }
     )
@@ -896,43 +921,71 @@ def main(argv: list[str] | None = None) -> int:
             "name": x["metadata"]["name"],
             "minAvailable": x.get("spec", {}).get("minAvailable"),
             "maxUnavailable": x.get("spec", {}).get("maxUnavailable"),
+            "selectorTargetsWorkload": True,
         }
         for x in pdbs
         if selector_matches(x.get("spec", {}).get("selector"), workload_labels)
     ]
     matching_services = []
+    service_snapshots = []
     for service in services:
         spec = service.get("spec", {})
         ports = spec.get("ports", [])
-        if (
-            spec.get("type", "ClusterIP") == "ClusterIP"
-            and selector_matches({"matchLabels": spec.get("selector", {})}, workload_labels)
-            and any(
-                p.get("name") == "metrics"
-                and int_or_string_equals(p.get("port"), 2000)
-                and int_or_string_equals(p.get("targetPort"), 2000)
-                for p in ports
-            )
-        ):
+        selector_targets = selector_matches(
+            {"matchLabels": spec.get("selector", {})}, workload_labels
+        )
+        metrics_ports = [p for p in ports if p.get("name") == "metrics"]
+        valid_port = any(
+            int_or_string_equals(p.get("port"), 2000)
+            and int_or_string_equals(p.get("targetPort"), 2000)
+            for p in metrics_ports
+        )
+        service_snapshots.extend(
+            {
+                "name": service["metadata"]["name"],
+                "type": spec.get("type", "ClusterIP"),
+                "selectorTargetsWorkload": selector_targets,
+                "metricsPortName": port.get("name"),
+                "port": port.get("port"),
+                "targetPort": port.get("targetPort"),
+            }
+            for port in (metrics_ports or [{}])
+        )
+        if spec.get("type", "ClusterIP") == "ClusterIP" and selector_targets and valid_port:
             matching_services.append(service)
     service_labels = (
         matching_services[0].get("metadata", {}).get("labels", {})
         if len(matching_services) == 1
         else {}
     )
-    matching_monitors = [
-        monitor
-        for monitor in monitors
-        if selector_matches(monitor.get("spec", {}).get("selector"), service_labels)
-        and ns in monitor.get("spec", {}).get("namespaceSelector", {}).get("matchNames", [])
-        and any(
-            endpoint.get("port") == "metrics" and endpoint.get("path") == "/metrics"
-            for endpoint in monitor.get("spec", {}).get("endpoints", [])
+    matching_monitors = []
+    monitor_snapshots = []
+    for monitor in monitors:
+        spec = monitor.get("spec", {})
+        selector_targets = bool(service_labels) and selector_matches(
+            spec.get("selector"), service_labels
         )
-    ]
+        namespace_targets = ns in spec.get("namespaceSelector", {}).get("matchNames", [])
+        valid_endpoint = False
+        for endpoint in spec.get("endpoints", []) or [{}]:
+            endpoint_matches = (
+                endpoint.get("port") == "metrics" and endpoint.get("path") == "/metrics"
+            )
+            valid_endpoint = valid_endpoint or endpoint_matches
+            monitor_snapshots.append(
+                {
+                    "name": monitor["metadata"]["name"],
+                    "selectorTargetsService": selector_targets,
+                    "namespaceTargetsRelease": namespace_targets,
+                    "endpointPort": endpoint.get("port"),
+                    "endpointPath": endpoint.get("path"),
+                }
+            )
+        if selector_targets and namespace_targets and valid_endpoint:
+            matching_monitors.append(monitor)
     tunnel["metrics"] = {
-        "services": [x["metadata"]["name"] for x in matching_services],
-        "serviceMonitors": [x["metadata"]["name"] for x in matching_monitors],
+        "services": service_snapshots,
+        "serviceMonitors": monitor_snapshots,
     }
     add_gap(
         gaps,
@@ -944,7 +997,9 @@ def main(argv: list[str] | None = None) -> int:
         "CF_METRICS_DISCOVERY_MISSING",
         len(matching_services) != 1 or len(matching_monitors) != 1,
     )
-    metrics_service = tunnel["metrics"]["services"][0] if tunnel["metrics"]["services"] else ""
+    metrics_service = (
+        matching_services[0]["metadata"]["name"] if len(matching_services) == 1 else ""
+    )
     metrics = {
         "healthyTargets": prom_count(
             f'count(up{{namespace="{ns}",service="{metrics_service}"}} == 1)'

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -40,6 +40,18 @@ class HardFailure(RuntimeError):
     pass
 
 
+def object_shape(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HardFailure(message)
+    return value
+
+
+def list_shape(value: Any, message: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise HardFailure(message)
+    return value
+
+
 def operation(argv: list[str]) -> str:
     """Return a safe operation identifier or reject before process execution."""
     if not argv:
@@ -268,24 +280,34 @@ def ready(pod: dict[str, Any]) -> bool:
 
 def pods_snapshot(document: dict[str, Any]) -> list[dict[str, Any]]:
     result = []
-    for pod in document.get("items", []):
+    for value in list_shape(document.get("items"), "malformed Kubernetes pod list"):
+        pod = object_shape(value, "malformed Kubernetes pod record")
+        metadata = object_shape(pod.get("metadata"), "malformed Kubernetes pod record")
+        spec = object_shape(pod.get("spec"), "malformed Kubernetes pod record")
+        status = object_shape(pod.get("status"), "malformed Kubernetes pod record")
+        list_shape(status.get("conditions", []), "malformed Kubernetes pod record")
+        statuses = list_shape(
+            status.get("containerStatuses", []), "malformed Kubernetes pod record"
+        )
+        if not all(isinstance(item, dict) for item in statuses):
+            raise HardFailure("malformed Kubernetes pod record")
         result.append(
             {
-                "uid": pod.get("metadata", {}).get("uid"),
-                "node": pod.get("spec", {}).get("nodeName"),
+                "uid": metadata.get("uid"),
+                "node": spec.get("nodeName"),
                 "ready": ready(pod),
-                "restarts": sum(
-                    int(c.get("restartCount", 0))
-                    for c in pod.get("status", {}).get("containerStatuses", [])
-                ),
+                "restarts": sum(int(c.get("restartCount", 0)) for c in statuses),
             }
         )
     return sorted(result, key=lambda p: (p["node"] or "", p["uid"] or ""))
 
 
 def deployment_snapshot(dep: dict[str, Any]) -> dict[str, Any]:
-    meta, spec, status = dep.get("metadata", {}), dep.get("spec", {}), dep.get("status", {})
-    pod_spec = spec.get("template", {}).get("spec", {})
+    meta = object_shape(dep.get("metadata"), "malformed Kubernetes Deployment")
+    spec = object_shape(dep.get("spec"), "malformed Kubernetes Deployment")
+    status = object_shape(dep.get("status", {}), "malformed Kubernetes Deployment")
+    template = object_shape(spec.get("template"), "malformed Kubernetes Deployment")
+    pod_spec = object_shape(template.get("spec"), "malformed Kubernetes Deployment")
     containers = []
 
     def safe_probe(value: Any) -> dict[str, Any] | None:
@@ -304,9 +326,15 @@ def deployment_snapshot(dep: dict[str, Any]) -> dict[str, Any]:
             "failureThreshold": value.get("failureThreshold"),
         }
 
-    for c in pod_spec.get("containers", []):
+    for value in list_shape(
+        pod_spec.get("containers"), "malformed Kubernetes Deployment containers"
+    ):
+        c = object_shape(value, "malformed Kubernetes Deployment container")
         refs = []
-        for env in c.get("env", []):
+        for env_value in list_shape(
+            c.get("env", []), "malformed Kubernetes Deployment environment"
+        ):
+            env = object_shape(env_value, "malformed Kubernetes Deployment environment")
             ref = env.get("valueFrom", {}).get("secretKeyRef")
             if ref:
                 refs.append(
@@ -343,17 +371,24 @@ def endpoints(document: dict[str, Any], service: str) -> dict[str, Any]:
     if not isinstance(items, list):
         raise HardFailure("malformed EndpointSlice list")
     for item in items:
-        if item.get("metadata", {}).get("labels", {}).get("kubernetes.io/service-name") != service:
+        item = object_shape(item, "malformed EndpointSlice entry")
+        metadata = object_shape(item.get("metadata"), "malformed EndpointSlice entry")
+        labels = object_shape(metadata.get("labels"), "malformed EndpointSlice entry")
+        if labels.get("kubernetes.io/service-name") != service:
             raise HardFailure("EndpointSlice selector returned an unrelated Service")
-        for endpoint in item.get("endpoints", []):
-            cond = endpoint.get("conditions", {})
+        for value in list_shape(item.get("endpoints"), "malformed EndpointSlice entry"):
+            endpoint = object_shape(value, "malformed EndpointSlice entry")
+            cond = object_shape(endpoint.get("conditions", {}), "malformed EndpointSlice entry")
             effective_ready = cond.get("ready", True)
             serving = cond.get("serving", effective_ready)
             terminating = cond.get("terminating", False)
-            target = endpoint.get("targetRef", {})
+            addresses = list_shape(endpoint.get("addresses"), "malformed EndpointSlice entry")
+            if not all(isinstance(address, str) for address in addresses):
+                raise HardFailure("malformed EndpointSlice entry")
+            target = object_shape(endpoint.get("targetRef", {}), "malformed EndpointSlice entry")
             key = (
                 endpoint.get("nodeName") or "",
-                tuple(sorted(set(endpoint.get("addresses", [])))),
+                tuple(sorted(set(addresses))),
                 tuple(str(target.get(k, "")) for k in ("kind", "namespace", "name", "uid")),
             )
             grouped.setdefault(key, []).append((effective_ready, serving, terminating))
@@ -373,6 +408,8 @@ def list_items(*args: str) -> list[dict[str, Any]]:
     items = value.get("items", [])
     if not isinstance(items, list):
         raise HardFailure("Kubernetes list response is malformed")
+    if not all(isinstance(item, dict) for item in items):
+        raise HardFailure("Kubernetes list contains a malformed record")
     return items
 
 
@@ -463,12 +500,12 @@ def probe(url: str) -> dict[str, Any]:
     return row
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("env")
     parser.add_argument("--evidence-dir", required=True, type=Path)
     parser.add_argument("--require-parity", action="store_true")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.env.removeprefix("env=") != "prod":
         raise HardFailure("env must normalize exactly to prod")
     for tool in ("kubectl", "helm", "curl", "git"):
@@ -494,15 +531,25 @@ def main() -> int:
 
     gaps: set[str] = set()
     nodes_doc = kubectl("get", "nodes", "-o", "json")
-    names = {n.get("metadata", {}).get("name") for n in nodes_doc.get("items", [])}
+    node_items = list_shape(nodes_doc.get("items"), "malformed Kubernetes node list")
+    nodes_by_name = []
+    for value in node_items:
+        node = object_shape(value, "malformed Kubernetes node record")
+        metadata = object_shape(node.get("metadata"), "malformed Kubernetes node record")
+        status = object_shape(node.get("status"), "malformed Kubernetes node record")
+        conditions = list_shape(status.get("conditions"), "malformed Kubernetes node conditions")
+        if not isinstance(metadata.get("name"), str) or not all(
+            isinstance(condition, dict) for condition in conditions
+        ):
+            raise HardFailure("malformed Kubernetes node record")
+        nodes_by_name.append((node, metadata, conditions))
+    names = {metadata["name"] for _, metadata, _ in nodes_by_name}
     if names != EXPECTED_NODES:
         raise HardFailure("observed node set is not exactly sugarkube0, sugarkube1, sugarkube2")
     nodes = []
-    for node in nodes_doc["items"]:
-        conditions = {
-            c.get("type"): c.get("status") for c in node.get("status", {}).get("conditions", [])
-        }
-        nodes.append({"name": node["metadata"]["name"], "ready": conditions.get("Ready") == "True"})
+    for node, metadata, node_conditions in nodes_by_name:
+        conditions = {c.get("type"): c.get("status") for c in node_conditions}
+        nodes.append({"name": metadata["name"], "ready": conditions.get("Ready") == "True"})
     add_gap(gaps, "NODE_NOT_READY", not all(n["ready"] for n in nodes))
     readyz = run(["kubectl", "get", "--raw", "/readyz?verbose"]).stdout
     readyz_summary = {
@@ -617,12 +664,20 @@ def main() -> int:
     deployments = list_items(
         "get", "deployment", "-A", "-l", "app.kubernetes.io/name=cloudflare-tunnel", "-o", "json"
     )
-    releases = json.loads(run(["helm", "list", "-A", "-o", "json"]).stdout)
+    releases = list_shape(
+        json.loads(run(["helm", "list", "-A", "-o", "json"]).stdout),
+        "malformed Helm release list",
+    )
+    if not all(isinstance(item, dict) for item in releases):
+        raise HardFailure("malformed Helm release record")
     candidates = []
     for dep in deployments:
-        meta = dep.get("metadata", {})
-        labels = meta.get("labels", {})
-        release_name = labels.get("app.kubernetes.io/instance") or meta.get("annotations", {}).get(
+        meta = object_shape(dep.get("metadata"), "malformed Kubernetes Deployment metadata")
+        labels = object_shape(meta.get("labels", {}), "malformed Kubernetes Deployment metadata")
+        annotations = object_shape(
+            meta.get("annotations", {}), "malformed Kubernetes Deployment metadata"
+        )
+        release_name = labels.get("app.kubernetes.io/instance") or annotations.get(
             "meta.helm.sh/release-name"
         )
         match = [
@@ -637,13 +692,26 @@ def main() -> int:
             f"expected exactly one live Cloudflare release candidate; found {len(candidates)}"
         )
     tunnel_dep, release = candidates[0]
-    ns, release_name = tunnel_dep["metadata"]["namespace"], release["name"]
-    history_raw = json.loads(run(["helm", "-n", ns, "history", release_name, "-o", "json"]).stdout)
+    tunnel_meta = object_shape(
+        tunnel_dep.get("metadata"), "malformed Kubernetes Deployment metadata"
+    )
+    ns, release_name = tunnel_meta.get("namespace"), release.get("name")
+    if not isinstance(ns, str) or not isinstance(release_name, str):
+        raise HardFailure("malformed Cloudflare release identity")
+    history_raw = list_shape(
+        json.loads(run(["helm", "-n", ns, "history", release_name, "-o", "json"]).stdout),
+        "malformed Helm release history",
+    )
+    if not all(isinstance(item, dict) for item in history_raw):
+        raise HardFailure("malformed Helm history record")
     history = [
         {k: h.get(k) for k in ("revision", "updated", "status", "chart", "app_version")}
         for h in history_raw
     ]
-    status_raw = json.loads(run(["helm", "-n", ns, "status", release_name, "-o", "json"]).stdout)
+    status_raw = object_shape(
+        json.loads(run(["helm", "-n", ns, "status", release_name, "-o", "json"]).stdout),
+        "malformed Helm release status",
+    )
     tunnel = deployment_snapshot(tunnel_dep)
     tunnel.update(
         {
@@ -655,9 +723,18 @@ def main() -> int:
             "history": history,
         }
     )
-    selector = ",".join(
-        f"{k}={v}" for k, v in sorted(tunnel_dep["spec"]["selector"]["matchLabels"].items())
+    tunnel_spec = object_shape(tunnel_dep.get("spec"), "malformed Kubernetes Deployment selector")
+    tunnel_selector = object_shape(
+        tunnel_spec.get("selector"), "malformed Kubernetes Deployment selector"
     )
+    match_labels = object_shape(
+        tunnel_selector.get("matchLabels"), "malformed Kubernetes Deployment selector"
+    )
+    if not match_labels or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in match_labels.items()
+    ):
+        raise HardFailure("malformed Kubernetes Deployment selector")
+    selector = ",".join(f"{k}={v}" for k, v in sorted(match_labels.items()))
     workload_labels = (
         tunnel_dep.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {})
     )
@@ -869,9 +946,17 @@ def main() -> int:
     return 1 if args.require_parity and gaps else 0
 
 
-if __name__ == "__main__":
+def cli(argv: list[str] | None = None) -> int:
+    """Run the CLI with a sanitized hard-failure boundary."""
     try:
-        raise SystemExit(main())
-    except (HardFailure, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        return main(argv)
+    except HardFailure as error:
         print(f"HARD_FAILURE: {error}", file=sys.stderr)
-        raise SystemExit(2)
+        return 2
+    except Exception:
+        print("HARD_FAILURE: unexpected collection failure", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Collect a sanitized, strictly read-only production resilience inventory."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NODES = {"sugarkube0", "sugarkube1", "sugarkube2"}
+EXPECTED_IMAGE = (
+    "cloudflare/cloudflared:2026.7.3@sha256:"
+    "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
+)
+TARGETS = ROOT / "config/prod-resilience-audit-targets.json"
+FORBIDDEN = {"apply", "create", "patch", "replace", "delete", "edit", "run", "exec", "port-forward"}
+
+
+class HardFailure(RuntimeError):
+    pass
+
+
+def run(argv: list[str], *, ok=(0,), timeout=30) -> subprocess.CompletedProcess[str]:
+    if argv[0] == "kubectl":
+        words = set(argv[1:])
+        if words & FORBIDDEN or ("rollout" in words and "restart" in words):
+            raise HardFailure("internal safety policy rejected a mutating kubectl command")
+    if argv[0] == "helm" and set(argv[1:]) & {
+        "install",
+        "upgrade",
+        "rollback",
+        "uninstall",
+        "repo",
+        "push",
+    }:
+        raise HardFailure("internal safety policy rejected a mutating helm command")
+    proc = subprocess.run(argv, text=True, capture_output=True, timeout=timeout, check=False)
+    if proc.returncode not in ok:
+        operation = argv[1] if len(argv) > 1 else ""
+        raise HardFailure(f"read-only command failed: {argv[0]} {operation}")
+    return proc
+
+
+def kubectl(*args: str, allow_missing=False) -> dict[str, Any]:
+    proc = run(["kubectl", *args], ok=(0, 1) if allow_missing else (0,))
+    if proc.returncode:
+        if allow_missing and ("NotFound" in proc.stderr or "not found" in proc.stderr.lower()):
+            return {}
+        raise HardFailure("unable to collect an expected Kubernetes resource")
+    try:
+        value = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise HardFailure("kubectl returned malformed JSON") from exc
+    if not isinstance(value, dict):
+        raise HardFailure("kubectl JSON must be an object")
+    return value
+
+
+def add_gap(gaps: set[str], code: str, condition: bool) -> None:
+    if condition:
+        gaps.add(code)
+
+
+def ready(pod: dict[str, Any]) -> bool:
+    return pod.get("metadata", {}).get("deletionTimestamp") is None and any(
+        c.get("type") == "Ready" and c.get("status") == "True"
+        for c in pod.get("status", {}).get("conditions", [])
+    )
+
+
+def pods_snapshot(document: dict[str, Any]) -> list[dict[str, Any]]:
+    result = []
+    for pod in document.get("items", []):
+        result.append(
+            {
+                "uid": pod.get("metadata", {}).get("uid"),
+                "node": pod.get("spec", {}).get("nodeName"),
+                "ready": ready(pod),
+                "restarts": sum(
+                    int(c.get("restartCount", 0))
+                    for c in pod.get("status", {}).get("containerStatuses", [])
+                ),
+            }
+        )
+    return sorted(result, key=lambda p: (p["node"] or "", p["uid"] or ""))
+
+
+def deployment_snapshot(dep: dict[str, Any]) -> dict[str, Any]:
+    meta, spec, status = dep.get("metadata", {}), dep.get("spec", {}), dep.get("status", {})
+    pod_spec = spec.get("template", {}).get("spec", {})
+    containers = []
+
+    def safe_probe(value: Any) -> dict[str, Any] | None:
+        if not isinstance(value, dict):
+            return None
+        http = value.get("httpGet", {})
+        return {
+            "httpGet": {
+                "path": http.get("path"),
+                "port": http.get("port"),
+                "scheme": http.get("scheme"),
+            },
+            "initialDelaySeconds": value.get("initialDelaySeconds"),
+            "periodSeconds": value.get("periodSeconds"),
+            "timeoutSeconds": value.get("timeoutSeconds"),
+            "failureThreshold": value.get("failureThreshold"),
+        }
+
+    for c in pod_spec.get("containers", []):
+        refs = []
+        for env in c.get("env", []):
+            ref = env.get("valueFrom", {}).get("secretKeyRef")
+            if ref:
+                refs.append(
+                    {"env": env.get("name"), "secret": ref.get("name"), "key": ref.get("key")}
+                )
+        containers.append(
+            {
+                "name": c.get("name"),
+                "image": c.get("image"),
+                "readinessProbe": safe_probe(c.get("readinessProbe")),
+                "livenessProbe": safe_probe(c.get("livenessProbe")),
+                "secretReferences": refs,
+            }
+        )
+    return {
+        "namespace": meta.get("namespace"),
+        "name": meta.get("name"),
+        "uid": meta.get("uid"),
+        "generation": meta.get("generation"),
+        "ownerReferences": meta.get("ownerReferences", []),
+        "replicas": spec.get("replicas", 1),
+        "readyReplicas": status.get("readyReplicas", 0),
+        "availableReplicas": status.get("availableReplicas", 0),
+        "strategy": spec.get("strategy", {}),
+        "affinity": pod_spec.get("affinity", {}),
+        "topologySpreadConstraints": pod_spec.get("topologySpreadConstraints", []),
+        "containers": containers,
+    }
+
+
+def endpoints(document: dict[str, Any], service: str) -> dict[str, Any]:
+    grouped: dict[tuple[str, tuple[str, ...], tuple[str, ...]], list[tuple[bool, bool, bool]]] = {}
+    items = document.get("items")
+    if not isinstance(items, list):
+        raise HardFailure("malformed EndpointSlice list")
+    for item in items:
+        if item.get("metadata", {}).get("labels", {}).get("kubernetes.io/service-name") != service:
+            raise HardFailure("EndpointSlice selector returned an unrelated Service")
+        for endpoint in item.get("endpoints", []):
+            cond = endpoint.get("conditions", {})
+            effective_ready = cond.get("ready", True)
+            serving = cond.get("serving", effective_ready)
+            terminating = cond.get("terminating", False)
+            target = endpoint.get("targetRef", {})
+            key = (
+                endpoint.get("nodeName") or "",
+                tuple(sorted(set(endpoint.get("addresses", [])))),
+                tuple(str(target.get(k, "")) for k in ("kind", "namespace", "name", "uid")),
+            )
+            grouped.setdefault(key, []).append((effective_ready, serving, terminating))
+    healthy = [k for k, states in grouped.items() if all(r and s and not t for r, s, t in states)]
+    return {
+        "service": service,
+        "slices": len(items),
+        "uniqueEndpoints": len(grouped),
+        "healthyEndpoints": len(healthy),
+        "unhealthyEndpoints": len(grouped) - len(healthy),
+        "healthyNodes": sorted({key[0] for key in healthy if key[0]}),
+    }
+
+
+def list_items(*args: str) -> list[dict[str, Any]]:
+    value = kubectl(*args)
+    items = value.get("items", [])
+    if not isinstance(items, list):
+        raise HardFailure("Kubernetes list response is malformed")
+    return items
+
+
+def prom_count(query: str) -> int:
+    from urllib.parse import quote
+
+    path = (
+        "/api/v1/namespaces/monitoring/services/"
+        "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
+        + quote(query, safe="")
+    )
+    result = kubectl("get", "--raw", path).get("data", {}).get("result", [])
+    try:
+        return int(float(result[0]["value"][1])) if result else 0
+    except (KeyError, TypeError, ValueError, IndexError) as exc:
+        raise HardFailure("Prometheus returned an invalid aggregate") from exc
+
+
+def probe(url: str) -> dict[str, Any]:
+    try:
+        proc = run(
+            [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--output",
+                "/dev/null",
+                "--max-time",
+                "8",
+                "--connect-timeout",
+                "3",
+                "--write-out",
+                "%{http_code}\t%{time_connect}\t%{time_starttransfer}\t%{time_total}",
+                url,
+            ],
+            ok=tuple(range(0, 100)),
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return {"url": url, "status": 0, "error": "timeout"}
+    fields = proc.stdout.strip().split("\t")
+    status = int(fields[0]) if fields and fields[0].isdigit() else 0
+    row: dict[str, Any] = {"url": url, "status": status}
+    if len(fields) == 4:
+        row.update(zip(("connectSeconds", "startTransferSeconds", "totalSeconds"), fields[1:]))
+    if proc.returncode:
+        row["error"] = "timeout" if proc.returncode == 28 else "transport"
+    return row
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("env")
+    parser.add_argument("--evidence-dir", required=True, type=Path)
+    parser.add_argument("--require-parity", action="store_true")
+    args = parser.parse_args()
+    if args.env.removeprefix("env=") != "prod":
+        raise HardFailure("env must normalize exactly to prod")
+    for tool in ("kubectl", "helm", "curl", "git"):
+        if not shutil.which(tool):
+            raise HardFailure(f"required read-only tool not found: {tool}")
+    context = run(["kubectl", "config", "current-context"]).stdout.strip()
+    if context != "sugar-prod":
+        raise HardFailure("current kubectl context must be exactly sugar-prod")
+    kubeconfig = os.environ.get("KUBECONFIG", str(Path.home() / ".kube/config"))
+    identity = run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/cluster_identity.py"),
+            "assert",
+            "--kubeconfig",
+            kubeconfig,
+            "--env",
+            "prod",
+        ]
+    )
+    if identity.stdout.strip() != "prod":
+        raise HardFailure("repository cluster identity did not report prod")
+
+    gaps: set[str] = set()
+    nodes_doc = kubectl("get", "nodes", "-o", "json")
+    names = {n.get("metadata", {}).get("name") for n in nodes_doc.get("items", [])}
+    if names != EXPECTED_NODES:
+        raise HardFailure("observed node set is not exactly sugarkube0, sugarkube1, sugarkube2")
+    nodes = []
+    for node in nodes_doc["items"]:
+        conditions = {
+            c.get("type"): c.get("status") for c in node.get("status", {}).get("conditions", [])
+        }
+        nodes.append({"name": node["metadata"]["name"], "ready": conditions.get("Ready") == "True"})
+    add_gap(gaps, "NODE_NOT_READY", not all(n["ready"] for n in nodes))
+    readyz = run(["kubectl", "get", "--raw", "/readyz?verbose"]).stdout
+    readyz_summary = {
+        "ready": "readyz check passed" in readyz,
+        "etcdReady": any(
+            line.startswith("[+]etcd ") or line == "[+]etcd ok" for line in readyz.splitlines()
+        ),
+    }
+    add_gap(gaps, "API_OR_ETCD_NOT_READY", not all(readyz_summary.values()))
+
+    components: dict[str, Any] = {}
+    for name in ("coredns", "coredns-ha", "traefik"):
+        dep = kubectl(
+            "-n", "kube-system", "get", "deployment", name, "-o", "json", allow_missing=True
+        )
+        if not dep:
+            if name != "coredns-ha":
+                gaps.add(f"{name.upper()}_MISSING")
+            continue
+        snap = deployment_snapshot(dep)
+        selector = ",".join(
+            f"{k}={v}"
+            for k, v in sorted(
+                dep.get("spec", {}).get("selector", {}).get("matchLabels", {}).items()
+            )
+        )
+        pod_doc = kubectl("-n", "kube-system", "get", "pods", "-l", selector, "-o", "json")
+        snap["pods"] = pods_snapshot(pod_doc)
+        components[name] = snap
+    for name in ("coredns", "traefik"):
+        relevant = [
+            v
+            for k, v in components.items()
+            if k == name or (name == "coredns" and k == "coredns-ha")
+        ]
+        ready_pods = [p for d in relevant for p in d.get("pods", []) if p["ready"]]
+        add_gap(gaps, f"{name.upper()}_SINGLETON", len(ready_pods) < 2)
+        add_gap(gaps, f"{name.upper()}_UNSPREAD", len({p["node"] for p in ready_pods}) < 2)
+    kube_system_pdbs = [
+        {
+            "name": item.get("metadata", {}).get("name"),
+            "selector": item.get("spec", {}).get("selector", {}),
+            "minAvailable": item.get("spec", {}).get("minAvailable"),
+            "maxUnavailable": item.get("spec", {}).get("maxUnavailable"),
+        }
+        for item in list_items("-n", "kube-system", "get", "pdb", "-o", "json")
+    ]
+    endpoint_data = {}
+    for service in ("kube-dns", "traefik"):
+        doc = kubectl(
+            "-n",
+            "kube-system",
+            "get",
+            "endpointslices.discovery.k8s.io",
+            "-l",
+            f"kubernetes.io/service-name={service}",
+            "-o",
+            "json",
+        )
+        endpoint_data[service] = endpoints(doc, service)
+        add_gap(
+            gaps,
+            f"{service.upper().replace('-', '_')}_ENDPOINTS_INSUFFICIENT",
+            len(endpoint_data[service]["healthyNodes"]) < 2,
+        )
+    traefik_service = kubectl("-n", "kube-system", "get", "service", "traefik", "-o", "json")
+    ingress_service = {
+        "internalTrafficPolicy": traefik_service.get("spec", {}).get(
+            "internalTrafficPolicy", "Cluster"
+        )
+    }
+    lifecycle = {}
+    for kind, name in (("helmchartconfig", "traefik"), ("deployment", "coredns-ha")):
+        obj = kubectl("-n", "kube-system", "get", kind, name, "-o", "json", allow_missing=True)
+        lifecycle[f"{kind}/{name}"] = {
+            "present": bool(obj),
+            "uid": obj.get("metadata", {}).get("uid"),
+            "ownerReferences": obj.get("metadata", {}).get("ownerReferences", []),
+            "managedBy": obj.get("metadata", {}).get("labels", {}).get("sugarkube.dev/managed-by"),
+            "desired": (
+                {
+                    "replicas": obj.get("spec", {}).get("replicas"),
+                    "affinity": obj.get("spec", {})
+                    .get("template", {})
+                    .get("spec", {})
+                    .get("affinity", {}),
+                }
+                if kind == "deployment"
+                else {
+                    "valuesContentSha256": hashlib.sha256(
+                        str(obj.get("spec", {}).get("valuesContent", "")).encode()
+                    ).hexdigest()
+                }
+            ),
+        }
+
+    deployments = list_items(
+        "get", "deployment", "-A", "-l", "app.kubernetes.io/name=cloudflare-tunnel", "-o", "json"
+    )
+    releases = json.loads(run(["helm", "list", "-A", "-o", "json"]).stdout)
+    candidates = []
+    for dep in deployments:
+        meta = dep.get("metadata", {})
+        labels = meta.get("labels", {})
+        release_name = labels.get("app.kubernetes.io/instance") or meta.get("annotations", {}).get(
+            "meta.helm.sh/release-name"
+        )
+        match = [
+            r
+            for r in releases
+            if r.get("name") == release_name and r.get("namespace") == meta.get("namespace")
+        ]
+        if len(match) == 1:
+            candidates.append((dep, match[0]))
+    if len(candidates) != 1:
+        raise HardFailure(
+            f"expected exactly one live Cloudflare release candidate; found {len(candidates)}"
+        )
+    tunnel_dep, release = candidates[0]
+    ns, release_name = tunnel_dep["metadata"]["namespace"], release["name"]
+    history_raw = json.loads(run(["helm", "-n", ns, "history", release_name, "-o", "json"]).stdout)
+    history = [
+        {k: h.get(k) for k in ("revision", "updated", "status", "chart", "app_version")}
+        for h in history_raw
+    ]
+    status_raw = json.loads(run(["helm", "-n", ns, "status", release_name, "-o", "json"]).stdout)
+    tunnel = deployment_snapshot(tunnel_dep)
+    tunnel.update(
+        {
+            "release": release_name,
+            "chart": release.get("chart"),
+            "appVersion": release.get("app_version"),
+            "revision": release.get("revision"),
+            "helmStatus": status_raw.get("info", {}).get("status"),
+            "history": history,
+        }
+    )
+    selector = ",".join(
+        f"{k}={v}" for k, v in sorted(tunnel_dep["spec"]["selector"]["matchLabels"].items())
+    )
+    tunnel["pods"] = pods_snapshot(kubectl("-n", ns, "get", "pods", "-l", selector, "-o", "json"))
+    ready_tunnel = [p for p in tunnel["pods"] if p["ready"]]
+    container = tunnel["containers"][0] if tunnel["containers"] else {}
+    strategy = tunnel["strategy"].get("rollingUpdate", {})
+    add_gap(gaps, "CF_IMAGE_NOT_IMMUTABLE_PIN", container.get("image") != EXPECTED_IMAGE)
+    add_gap(gaps, "CF_CHART_VERSION_MISMATCH", release.get("chart") != "cloudflare-tunnel-0.3.2")
+    add_gap(gaps, "CF_CONNECTORS_INSUFFICIENT", len(ready_tunnel) < 2)
+    add_gap(gaps, "CF_CONNECTORS_UNSPREAD", len({p["node"] for p in ready_tunnel}) < 2)
+    add_gap(
+        gaps,
+        "CF_UNSAFE_ROLLOUT",
+        strategy.get("maxUnavailable") != 0 or strategy.get("maxSurge") != 1,
+    )
+    probe_spec = (container.get("readinessProbe") or {}).get("httpGet", {})
+    add_gap(
+        gaps,
+        "CF_PROBE_CONTRACT",
+        probe_spec.get("path") != "/ready" or bool(container.get("livenessProbe")),
+    )
+    pdbs = list_items(
+        "-n", ns, "get", "pdb", "-l", f"app.kubernetes.io/instance={release_name}", "-o", "json"
+    )
+    services = list_items(
+        "-n", ns, "get", "service", "-l", f"app.kubernetes.io/instance={release_name}", "-o", "json"
+    )
+    monitors = list_items(
+        "-n",
+        ns,
+        "get",
+        "servicemonitor",
+        "-l",
+        f"app.kubernetes.io/instance={release_name}",
+        "-o",
+        "json",
+    )
+    tunnel["pdb"] = [
+        {
+            "name": x["metadata"]["name"],
+            "minAvailable": x.get("spec", {}).get("minAvailable"),
+            "maxUnavailable": x.get("spec", {}).get("maxUnavailable"),
+        }
+        for x in pdbs
+    ]
+    tunnel["metrics"] = {
+        "services": [
+            x["metadata"]["name"]
+            for x in services
+            if x.get("spec", {}).get("type", "ClusterIP") == "ClusterIP"
+        ],
+        "serviceMonitors": [x["metadata"]["name"] for x in monitors],
+    }
+    add_gap(
+        gaps,
+        "CF_PDB_MISSING",
+        not any(
+            p.get("spec", {}).get("minAvailable") == 1
+            or p.get("spec", {}).get("maxUnavailable") == 1
+            for p in pdbs
+        ),
+    )
+    add_gap(gaps, "CF_METRICS_DISCOVERY_MISSING", not tunnel["metrics"]["services"] or not monitors)
+    metrics_service = tunnel["metrics"]["services"][0] if tunnel["metrics"]["services"] else ""
+    metrics = {
+        "healthyTargets": prom_count(
+            f'count(up{{namespace="{ns}",service="{metrics_service}"}} == 1)'
+        ),
+        "connectorsWithFourHAConnections": prom_count(
+            "count(cloudflared_tunnel_ha_connections"
+            f'{{namespace="{ns}",service="{metrics_service}"}} >= 4)'
+        ),
+        "firingRelevantAlerts": prom_count(
+            'count(ALERTS{alertname=~"CloudflareTunnel(NoHealthyConnections|'
+            'ConnectionsDegraded|MetricsTargetsDown)",alertstate="firing"})'
+        ),
+    }
+    add_gap(gaps, "CF_METRICS_TARGETS_UNHEALTHY", metrics["healthyTargets"] < len(ready_tunnel))
+    add_gap(
+        gaps,
+        "CF_HA_CONNECTIONS_INSUFFICIENT",
+        metrics["connectorsWithFourHAConnections"] < len(ready_tunnel),
+    )
+    add_gap(gaps, "CF_ALERTS_FIRING", metrics["firingRelevantAlerts"] != 0)
+
+    target_map = json.loads(TARGETS.read_text())
+    urls = sorted(f"https://{host}{path}" for host, paths in target_map.items() for path in paths)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(urls)) as pool:
+        probe_rows = sorted(pool.map(probe, urls), key=lambda row: row["url"])
+    add_gap(
+        gaps, "PUBLIC_ENDPOINT_UNHEALTHY", any(not 200 <= row["status"] < 400 for row in probe_rows)
+    )
+    revision = run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    timestamp = os.environ.get("SUGARKUBE_AUDIT_TIMESTAMP") or dt.datetime.now(
+        dt.timezone.utc
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    audit = {
+        "schemaVersion": 1,
+        "timestamp": timestamp,
+        "gitRevision": revision,
+        "environment": "prod",
+        "context": context,
+        "result": "PARITY_OK" if not gaps else "PARITY_GAPS",
+        "gapCount": len(gaps),
+        "gaps": sorted(gaps),
+        "observed": {
+            "nodes": sorted(nodes, key=lambda x: x["name"]),
+            "apiReadyz": readyz_summary,
+            "components": components,
+            "kubeSystemPDBs": sorted(kube_system_pdbs, key=lambda item: item["name"] or ""),
+            "endpointSlices": endpoint_data,
+            "traefikService": ingress_service,
+            "lifecycleResources": lifecycle,
+            "cloudflareTunnel": tunnel,
+            "prometheus": metrics,
+        },
+    }
+    parent = args.evidence_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix=".prod-audit-", dir=parent))
+    try:
+        (tmp / "audit.json").write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n")
+        with (tmp / "endpoints.tsv").open("w") as stream:
+            stream.write(
+                "url\tstatus\tconnect_seconds\tstart_transfer_seconds\ttotal_seconds\terror\n"
+            )
+            for row in probe_rows:
+                stream.write(
+                    "\t".join(
+                        str(row.get(k, ""))
+                        for k in (
+                            "url",
+                            "status",
+                            "connectSeconds",
+                            "startTransferSeconds",
+                            "totalSeconds",
+                            "error",
+                        )
+                    )
+                    + "\n"
+                )
+        lines = [
+            "# Production resilience parity audit",
+            "",
+            f"**Result:** `{audit['result']}` ({len(gaps)} gaps)",
+            "",
+            "| Gap code |",
+            "|---|",
+        ] + [f"| `{gap}` |" for gap in sorted(gaps)]
+        (tmp / "summary.md").write_text("\n".join(lines) + "\n")
+        files = sorted(p for p in tmp.iterdir() if p.name != "SHA256SUMS")
+        (tmp / "SHA256SUMS").write_text(
+            "".join(f"{hashlib.sha256(p.read_bytes()).hexdigest()}  {p.name}\n" for p in files)
+        )
+        if args.evidence_dir.exists():
+            raise HardFailure("evidence directory already exists")
+        tmp.rename(args.evidence_dir)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+    print(
+        f"{audit['result']}: collection complete; {len(gaps)} parity gap(s); "
+        f"evidence: {args.evidence_dir}"
+    )
+    return 1 if args.require_parity and gaps else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (HardFailure, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        print(f"HARD_FAILURE: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -246,6 +246,11 @@ def helm_status(value: Any) -> str:
     return value
 
 
+def canonical_json(value: Any) -> str:
+    """Return a stable key for an already-sanitized set-like evidence record."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 def probe_urls(target_map: Any) -> list[str]:
     """Expand the public target manifest, failing closed when it has no URLs."""
     if not isinstance(target_map, dict):
@@ -885,7 +890,7 @@ def main(argv: list[str] | None = None) -> int:
         raise HardFailure("malformed Helm history record")
     history = [
         {
-            "revision": h.get("revision"),
+            "revision": helm_revision(h.get("revision")),
             "updated": h.get("updated"),
             "status": helm_status(h.get("status")),
             "chart": h.get("chart"),
@@ -893,6 +898,7 @@ def main(argv: list[str] | None = None) -> int:
         }
         for h in history_raw
     ]
+    history.sort(key=lambda item: (item["revision"], canonical_json(item)))
     current_revision = helm_revision(release.get("revision"))
     current_history = [
         h for h in history_raw if helm_revision(h.get("revision")) == current_revision
@@ -908,7 +914,7 @@ def main(argv: list[str] | None = None) -> int:
             "release": release_name,
             "chart": release.get("chart"),
             "appVersion": release.get("app_version"),
-            "revision": release.get("revision"),
+            "revision": current_revision,
             "helmListStatus": list_status,
             "helmCurrentHistoryStatus": current_history_status,
             "helmOwnership": helm_ownership,
@@ -975,6 +981,7 @@ def main(argv: list[str] | None = None) -> int:
         for x in pdbs
         if selector_matches(x.get("spec", {}).get("selector"), workload_labels)
     ]
+    tunnel["pdb"].sort(key=canonical_json)
     matching_services = []
     service_snapshots = []
     for service in services:
@@ -1033,8 +1040,8 @@ def main(argv: list[str] | None = None) -> int:
         if selector_targets and namespace_targets and valid_endpoint:
             matching_monitors.append(monitor)
     tunnel["metrics"] = {
-        "services": service_snapshots,
-        "serviceMonitors": monitor_snapshots,
+        "services": sorted(service_snapshots, key=canonical_json),
+        "serviceMonitors": sorted(monitor_snapshots, key=canonical_json),
     }
     add_gap(
         gaps,

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -294,6 +294,11 @@ def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
     required_lists = 0
     terms: list[dict[str, str]] = []
     current_term: dict[str, str] | None = None
+    required_path = (
+        "affinity",
+        "podAntiAffinity",
+        "requiredDuringSchedulingIgnoredDuringExecution",
+    )
     parents: dict[int, str] = {}
     malformed = False
     for raw_line in content.splitlines():
@@ -317,6 +322,13 @@ def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
         parents = {level: name for level, name in parents.items() if level < indent}
         path = tuple(parents[level] for level in sorted(parents))
 
+        # A required-list term ends before a sibling or any dedent outside its
+        # anchored path; later YAML must not be allowed to complete that term.
+        if current_term is not None and (
+            indent <= 6 or path[: len(required_path)] != required_path
+        ):
+            current_term = None
+
         if path == ("deployment",) and indent == 2 and key == "replicas":
             if not value.isdecimal():
                 malformed = True
@@ -328,16 +340,7 @@ def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
             and key == "requiredDuringSchedulingIgnoredDuringExecution"
         ):
             required_lists += 1
-        if (
-            path
-            == (
-                "affinity",
-                "podAntiAffinity",
-                "requiredDuringSchedulingIgnoredDuringExecution",
-            )
-            and indent == 6
-            and is_list_item
-        ):
+        if path == required_path and indent == 6 and is_list_item:
             current_term = {}
             terms.append(current_term)
         elif is_list_item:
@@ -345,7 +348,7 @@ def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
 
         if current_term is not None:
             if (
-                path[-2:] == ("labelSelector", "matchLabels")
+                path == required_path + ("labelSelector", "matchLabels")
                 and indent == 12
                 and key == "app.kubernetes.io/name"
             ):

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -25,6 +25,15 @@ EXPECTED_IMAGE = (
 )
 TARGETS = ROOT / "config/prod-resilience-audit-targets.json"
 MAX_PROBE_WORKERS = 8
+PROMETHEUS_ALERT_RULES_PATH = (
+    "/api/v1/namespaces/monitoring/services/"
+    "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/rules?type=alert"
+)
+EXPECTED_CLOUDFLARE_ALERT_RULES = (
+    "CloudflareTunnelConnectionsDegraded",
+    "CloudflareTunnelMetricsTargetsDown",
+    "CloudflareTunnelNoHealthyConnections",
+)
 
 
 class HardFailure(RuntimeError):
@@ -60,6 +69,8 @@ def operation(argv: list[str]) -> str:
             path = args[2]
             if namespace is None and path == "/readyz?verbose":
                 return "kubectl/get-raw-readyz"
+            if namespace is None and path == PROMETHEUS_ALERT_RULES_PATH:
+                return "kubectl/get-raw-prometheus-alert-rules"
             prom_prefix = (
                 "/api/v1/namespaces/monitoring/services/"
                 "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
@@ -378,6 +389,43 @@ def prom_count(query: str) -> int:
         return int(float(result[0]["value"][1])) if result else 0
     except (KeyError, TypeError, ValueError, IndexError) as exc:
         raise HardFailure("Prometheus returned an invalid aggregate") from exc
+
+
+def prometheus_alert_rules() -> dict[str, Any]:
+    """Return only repository-owned aggregate alert-rule health state."""
+    document = kubectl("get", "--raw", PROMETHEUS_ALERT_RULES_PATH)
+    data = document.get("data")
+    if document.get("status") != "success" or not isinstance(data, dict):
+        raise HardFailure("Prometheus returned malformed alert rules")
+    groups = data.get("groups")
+    if not isinstance(groups, list):
+        raise HardFailure("Prometheus returned malformed alert rules")
+
+    expected = set(EXPECTED_CLOUDFLARE_ALERT_RULES)
+    matches: list[tuple[str, str]] = []
+    for group in groups:
+        if not isinstance(group, dict) or not isinstance(group.get("rules"), list):
+            raise HardFailure("Prometheus returned malformed alert rules")
+        for rule in group["rules"]:
+            if (
+                not isinstance(rule, dict)
+                or not isinstance(rule.get("name"), str)
+                or not isinstance(rule.get("health"), str)
+            ):
+                raise HardFailure("Prometheus returned malformed alert rules")
+            if rule["name"] in expected:
+                matches.append((rule["name"], rule["health"]))
+
+    return {
+        "expectedNames": list(EXPECTED_CLOUDFLARE_ALERT_RULES),
+        "expectedCount": len(EXPECTED_CLOUDFLARE_ALERT_RULES),
+        "presentNames": sorted({name for name, _ in matches}),
+        "presentCount": len(matches),
+        "healthyCount": sum(health == "ok" for _, health in matches),
+        "ruleSetMatches": sorted(name for name, _ in matches)
+        == list(EXPECTED_CLOUDFLARE_ALERT_RULES),
+        "allPresentRulesHealthy": all(health == "ok" for _, health in matches),
+    }
 
 
 def probe(url: str) -> dict[str, Any]:
@@ -716,6 +764,7 @@ def main() -> int:
             'ConnectionsDegraded|MetricsTargetsDown)",alertstate="firing"})'
         ),
     }
+    metrics["alertRules"] = prometheus_alert_rules()
     add_gap(gaps, "CF_METRICS_TARGETS_UNHEALTHY", metrics["healthyTargets"] < len(ready_tunnel))
     add_gap(
         gaps,
@@ -723,6 +772,16 @@ def main() -> int:
         metrics["connectorsWithFourHAConnections"] < len(ready_tunnel),
     )
     add_gap(gaps, "CF_ALERTS_FIRING", metrics["firingRelevantAlerts"] != 0)
+    add_gap(
+        gaps,
+        "CF_ALERT_RULE_SET_MISMATCH",
+        not metrics["alertRules"]["ruleSetMatches"],
+    )
+    add_gap(
+        gaps,
+        "CF_ALERT_RULES_UNHEALTHY",
+        not metrics["alertRules"]["allPresentRulesHealthy"],
+    )
 
     target_map = json.loads(TARGETS.read_text())
     urls = probe_urls(target_map)

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -141,7 +141,7 @@ def operation(argv: list[str]) -> str:
         if len(args) == 6 and args[0] in ("-n", "--namespace"):
             namespace, verb, release = args[1:4]
             if (
-                verb in ("status", "history")
+                verb == "history"
                 and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", namespace)
                 and re.fullmatch(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?", release)
                 and args[4:] == ["-o", "json"]
@@ -215,6 +215,34 @@ def add_gap(gaps: set[str], code: str, condition: bool) -> None:
 def int_or_string_equals(value: Any, expected: int) -> bool:
     """Compare a Kubernetes IntOrString value with an expected integer."""
     return not isinstance(value, bool) and str(value) == str(expected)
+
+
+def helm_revision(value: Any) -> int:
+    """Normalize Helm's integer/string revision encoding without coercing other values."""
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise HardFailure("malformed Helm release revision")
+    text = str(value)
+    if not text.isdigit() or int(text) < 1:
+        raise HardFailure("malformed Helm release revision")
+    return int(text)
+
+
+def helm_status(value: Any) -> str:
+    """Retain only Helm's documented, non-sensitive release status values."""
+    allowed = {
+        "deployed",
+        "failed",
+        "pending-install",
+        "pending-rollback",
+        "pending-upgrade",
+        "superseded",
+        "uninstalled",
+        "uninstalling",
+        "unknown",
+    }
+    if value not in allowed:
+        raise HardFailure("malformed Helm release status")
+    return value
 
 
 def probe_urls(target_map: Any) -> list[str]:
@@ -705,13 +733,24 @@ def main(argv: list[str] | None = None) -> int:
     if not all(isinstance(item, dict) for item in history_raw):
         raise HardFailure("malformed Helm history record")
     history = [
-        {k: h.get(k) for k in ("revision", "updated", "status", "chart", "app_version")}
+        {
+            "revision": h.get("revision"),
+            "updated": h.get("updated"),
+            "status": helm_status(h.get("status")),
+            "chart": h.get("chart"),
+            "app_version": h.get("app_version"),
+        }
         for h in history_raw
     ]
-    status_raw = object_shape(
-        json.loads(run(["helm", "-n", ns, "status", release_name, "-o", "json"]).stdout),
-        "malformed Helm release status",
-    )
+    current_revision = helm_revision(release.get("revision"))
+    current_history = [
+        h for h in history_raw if helm_revision(h.get("revision")) == current_revision
+    ]
+    if len(current_history) != 1:
+        raise HardFailure("unable to identify unique current Helm history revision")
+    # Never use `helm status -o json`: it can expose release config, manifests, and hooks.
+    current_history_status = helm_status(current_history[0].get("status"))
+    list_status = helm_status(release.get("status"))
     tunnel = deployment_snapshot(tunnel_dep)
     tunnel.update(
         {
@@ -719,7 +758,8 @@ def main(argv: list[str] | None = None) -> int:
             "chart": release.get("chart"),
             "appVersion": release.get("app_version"),
             "revision": release.get("revision"),
-            "helmStatus": status_raw.get("info", {}).get("status"),
+            "helmListStatus": list_status,
+            "helmCurrentHistoryStatus": current_history_status,
             "history": history,
         }
     )
@@ -744,11 +784,10 @@ def main(argv: list[str] | None = None) -> int:
     strategy = tunnel["strategy"].get("rollingUpdate", {})
     add_gap(gaps, "CF_IMAGE_NOT_IMMUTABLE_PIN", container.get("image") != EXPECTED_IMAGE)
     add_gap(gaps, "CF_CHART_VERSION_MISMATCH", release.get("chart") != "cloudflare-tunnel-0.3.2")
-    tunnel["helmListStatus"] = release.get("status")
     add_gap(
         gaps,
         "CF_HELM_RELEASE_NOT_DEPLOYED",
-        tunnel["helmStatus"] != "deployed" or tunnel["helmListStatus"] != "deployed",
+        tunnel["helmListStatus"] != "deployed" or tunnel["helmCurrentHistoryStatus"] != "deployed",
     )
     add_gap(gaps, "CF_CONNECTORS_INSUFFICIENT", len(ready_tunnel) < 2)
     add_gap(gaps, "CF_CONNECTORS_UNSPREAD", len({p["node"] for p in ready_tunnel}) < 2)

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -287,14 +287,91 @@ def required_hostname_anti_affinity(affinity: Any, labels: dict[str, Any]) -> bo
 
 def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
     """Extract only the two approved fields from K3s Helm values (never raw values)."""
-    text = content if isinstance(content, str) else ""
-    replica = re.search(r"(?m)^\s{2}replicas:\s*([0-9]+)\s*$", text)
+    if not isinstance(content, str) or "\t" in content:
+        return {"replicas": None, "requiredHostnameAntiAffinity": False}
+
+    replicas: list[int] = []
+    required_lists = 0
+    terms: list[dict[str, str]] = []
+    current_term: dict[str, str] | None = None
+    parents: dict[int, str] = {}
+    malformed = False
+    for raw_line in content.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent % 2:
+            malformed = True
+            break
+        line = raw_line[indent:]
+        is_list_item = line.startswith("- ")
+        if is_list_item:
+            line = line[2:]
+        if ":" not in line:
+            malformed = True
+            break
+        key, value = (part.strip() for part in line.split(":", 1))
+        if not key:
+            malformed = True
+            break
+        parents = {level: name for level, name in parents.items() if level < indent}
+        path = tuple(parents[level] for level in sorted(parents))
+
+        if path == ("deployment",) and indent == 2 and key == "replicas":
+            if not value.isdecimal():
+                malformed = True
+                break
+            replicas.append(int(value))
+        if (
+            path == ("affinity", "podAntiAffinity")
+            and indent == 4
+            and key == "requiredDuringSchedulingIgnoredDuringExecution"
+        ):
+            required_lists += 1
+        if (
+            path
+            == (
+                "affinity",
+                "podAntiAffinity",
+                "requiredDuringSchedulingIgnoredDuringExecution",
+            )
+            and indent == 6
+            and is_list_item
+        ):
+            current_term = {}
+            terms.append(current_term)
+        elif is_list_item:
+            current_term = None
+
+        if current_term is not None:
+            if (
+                path[-2:] == ("labelSelector", "matchLabels")
+                and indent == 12
+                and key == "app.kubernetes.io/name"
+            ):
+                if "label" in current_term:
+                    malformed = True
+                current_term["label"] = value
+            elif indent == 8 and key == "topologyKey":
+                if "topology" in current_term:
+                    malformed = True
+                current_term["topology"] = value
+
+        if not value:
+            parents[indent] = key
+
+    approved_term = any(
+        term
+        == {
+            "label": "traefik",
+            "topology": "kubernetes.io/hostname",
+        }
+        for term in terms
+    )
     return {
-        "replicas": int(replica.group(1)) if replica else None,
+        "replicas": replicas[0] if not malformed and len(replicas) == 1 else None,
         "requiredHostnameAntiAffinity": bool(
-            re.search(r"(?m)^\s*requiredDuringSchedulingIgnoredDuringExecution:\s*$", text)
-            and re.search(r"(?m)^\s*topologyKey:\s*kubernetes\.io/hostname\s*$", text)
-            and re.search(r"(?m)^\s*app\.kubernetes\.io/name:\s*traefik\s*$", text)
+            not malformed and required_lists == 1 and approved_term
         ),
     }
 
@@ -649,9 +726,7 @@ def main(argv: list[str] | None = None) -> int:
             "internalTrafficPolicy", "Cluster"
         )
     }
-    add_gap(
-        gaps, "TRAEFIK_TRAFFIC_POLICY_MISMATCH", ingress_service["internalTrafficPolicy"] != "Local"
-    )
+    # The staging-proven contract does not select Local; retain the observation only.
     traefik = components.get("traefik", {})
     add_gap(
         gaps,

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -9,7 +9,7 @@ import datetime as dt
 import hashlib
 import json
 import os
-import shlex
+import re
 import shutil
 import subprocess
 import sys
@@ -24,34 +24,72 @@ EXPECTED_IMAGE = (
     "e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf"
 )
 TARGETS = ROOT / "config/prod-resilience-audit-targets.json"
-FORBIDDEN = {"apply", "create", "patch", "replace", "delete", "edit", "run", "exec", "port-forward"}
+MAX_PROBE_WORKERS = 8
 
 
 class HardFailure(RuntimeError):
     pass
 
 
-def run(argv: list[str], *, ok=(0,), timeout=30) -> subprocess.CompletedProcess[str]:
+def operation(argv: list[str]) -> str:
+    """Return a safe operation identifier or reject before process execution."""
+    if not argv:
+        raise HardFailure("internal safety policy rejected an empty command")
+    args = argv[1:]
     if argv[0] == "kubectl":
-        words = set(argv[1:])
-        if words & FORBIDDEN or ("rollout" in words and "restart" in words):
-            raise HardFailure("internal safety policy rejected a mutating kubectl command")
-    if argv[0] == "helm" and set(argv[1:]) & {
-        "install",
-        "upgrade",
-        "rollback",
-        "uninstall",
-        "repo",
-        "push",
-    }:
-        raise HardFailure("internal safety policy rejected a mutating helm command")
+        if args == ["config", "current-context"]:
+            return "kubectl/config-current-context"
+        while len(args) >= 2 and args[0] in ("-n", "--namespace"):
+            args = args[2:]
+        if args and args[0] == "get":
+            return "kubectl/get"
+    elif argv[0] == "helm":
+        while len(args) >= 2 and args[0] in ("-n", "--namespace"):
+            args = args[2:]
+        if args and args[0] in ("list", "status", "history"):
+            return f"helm/{args[0]}"
+    elif argv[0] == "git" and args == ["rev-parse", "HEAD"]:
+        return "git/rev-parse-head"
+    elif argv[0] == sys.executable and args == [
+        str(ROOT / "scripts/cluster_identity.py"),
+        "assert",
+        "--kubeconfig",
+        os.environ.get("KUBECONFIG", str(Path.home() / ".kube/config")),
+        "--env",
+        "prod",
+    ]:
+        return "python/cluster-identity-assert-prod"
+    elif (
+        argv[0] == "curl"
+        and len(argv) == 15
+        and args[:-1]
+        == [
+            "--silent",
+            "--show-error",
+            "--output",
+            "/dev/null",
+            "--max-time",
+            "8",
+            "--connect-timeout",
+            "3",
+            "--write-out",
+            "%{http_code}\t%{time_connect}\t%{time_starttransfer}\t%{time_total}",
+            "--proto",
+            "=https",
+            "--location",
+        ]
+        and args[-1] in probe_urls(json.loads(TARGETS.read_text()))
+    ):
+        return "curl/public-probe"
+    raise HardFailure("internal safety policy rejected a non-allowlisted operation")
+
+
+def run(argv: list[str], *, ok=(0,), timeout=30) -> subprocess.CompletedProcess[str]:
+    op = operation(argv)
     proc = subprocess.run(argv, text=True, capture_output=True, timeout=timeout, check=False)
     if proc.returncode not in ok:
-        stderr = " ".join(proc.stderr.split())[:500] or "<empty>"
-        raise HardFailure(
-            f"read-only command failed (exit {proc.returncode}): {shlex.join(argv)}; "
-            f"stderr: {stderr}"
-        )
+        # Raw argv and stderr can expose credentials, connector IDs, labels, or bodies.
+        raise HardFailure(f"read-only {op} failed (exit {proc.returncode}; external-error)")
     return proc
 
 
@@ -84,19 +122,54 @@ def probe_urls(target_map: Any) -> list[str]:
     """Expand the public target manifest, failing closed when it has no URLs."""
     if not isinstance(target_map, dict):
         raise HardFailure("production probe target manifest must be an object")
-    urls = sorted(
-        f"https://{host}{path}"
-        for host, paths in target_map.items()
-        if isinstance(paths, list)
-        for path in paths
-    )
+    urls = []
+    for host, paths in target_map.items():
+        if not isinstance(host, str) or not host or not isinstance(paths, list) or not paths:
+            raise HardFailure("production probe target manifest contains a malformed entry")
+        if any(not isinstance(path, str) or not path.startswith("/") for path in paths):
+            raise HardFailure("production probe target manifest contains a malformed path")
+        urls.extend(f"https://{host}{path}" for path in paths)
+    urls.sort()
     if not urls:
         raise HardFailure("production probe target manifest contains no URLs")
     return urls
 
 
 def probes_unhealthy(rows: list[dict[str, Any]]) -> bool:
-    return any(row.get("error") or not 200 <= row["status"] < 400 for row in rows)
+    return any(row.get("error") != "none" or not 200 <= row["status"] < 400 for row in rows)
+
+
+def selector_matches(selector: Any, labels: dict[str, Any]) -> bool:
+    match = selector.get("matchLabels", {}) if isinstance(selector, dict) else {}
+    return bool(match) and all(labels.get(k) == v for k, v in match.items())
+
+
+def required_hostname_anti_affinity(affinity: Any, labels: dict[str, Any]) -> bool:
+    if not isinstance(affinity, dict):
+        return False
+    terms = affinity.get("podAntiAffinity", {}).get(
+        "requiredDuringSchedulingIgnoredDuringExecution", []
+    )
+    return any(
+        isinstance(term, dict)
+        and term.get("topologyKey") == "kubernetes.io/hostname"
+        and selector_matches(term.get("labelSelector"), labels)
+        for term in terms
+    )
+
+
+def traefik_desired_snapshot(content: Any) -> dict[str, Any]:
+    """Extract only the two approved fields from K3s Helm values (never raw values)."""
+    text = content if isinstance(content, str) else ""
+    replica = re.search(r"(?m)^\s{2}replicas:\s*([0-9]+)\s*$", text)
+    return {
+        "replicas": int(replica.group(1)) if replica else None,
+        "requiredHostnameAntiAffinity": bool(
+            re.search(r"(?m)^\s*requiredDuringSchedulingIgnoredDuringExecution:\s*$", text)
+            and re.search(r"(?m)^\s*topologyKey:\s*kubernetes\.io/hostname\s*$", text)
+            and re.search(r"(?m)^\s*app\.kubernetes\.io/name:\s*traefik\s*$", text)
+        ),
+    }
 
 
 def ready(pod: dict[str, Any]) -> bool:
@@ -246,6 +319,9 @@ def probe(url: str) -> dict[str, Any]:
                 "3",
                 "--write-out",
                 "%{http_code}\t%{time_connect}\t%{time_starttransfer}\t%{time_total}",
+                "--proto",
+                "=https",
+                "--location",
                 url,
             ],
             ok=tuple(range(0, 100)),
@@ -255,7 +331,7 @@ def probe(url: str) -> dict[str, Any]:
         return {"url": url, "status": 0, "error": "timeout"}
     fields = proc.stdout.strip().split("\t")
     status = int(fields[0]) if fields and fields[0].isdigit() else 0
-    row: dict[str, Any] = {"url": url, "status": status}
+    row: dict[str, Any] = {"url": url, "status": status, "error": "none"}
     if len(fields) == 4:
         row.update(zip(("connectSeconds", "startTransferSeconds", "totalSeconds"), fields[1:]))
     if proc.returncode:
@@ -374,6 +450,17 @@ def main() -> int:
             "internalTrafficPolicy", "Cluster"
         )
     }
+    add_gap(
+        gaps, "TRAEFIK_TRAFFIC_POLICY_MISMATCH", ingress_service["internalTrafficPolicy"] != "Local"
+    )
+    traefik = components.get("traefik", {})
+    add_gap(
+        gaps,
+        "TRAEFIK_SCHEDULING_CONTRACT_MISMATCH",
+        not required_hostname_anti_affinity(
+            traefik.get("affinity", {}), {"app.kubernetes.io/name": "traefik"}
+        ),
+    )
     lifecycle = {}
     for kind, name in (("helmchartconfig", "traefik"), ("deployment", "coredns-ha")):
         obj = kubectl("-n", "kube-system", "get", kind, name, "-o", "json", allow_missing=True)
@@ -391,13 +478,17 @@ def main() -> int:
                     .get("affinity", {}),
                 }
                 if kind == "deployment"
-                else {
-                    "valuesContentSha256": hashlib.sha256(
-                        str(obj.get("spec", {}).get("valuesContent", "")).encode()
-                    ).hexdigest()
-                }
+                else traefik_desired_snapshot(obj.get("spec", {}).get("valuesContent"))
             ),
         }
+    desired_traefik = lifecycle["helmchartconfig/traefik"]["desired"]
+    add_gap(
+        gaps,
+        "TRAEFIK_DESIRED_CONFIG_MISMATCH",
+        desired_traefik.get("replicas") != 2
+        or not desired_traefik.get("requiredHostnameAntiAffinity"),
+    )
+    add_gap(gaps, "COREDNS_HA_MISSING", not lifecycle["deployment/coredns-ha"]["present"])
 
     deployments = list_items(
         "get", "deployment", "-A", "-l", "app.kubernetes.io/name=cloudflare-tunnel", "-o", "json"
@@ -443,15 +534,28 @@ def main() -> int:
     selector = ",".join(
         f"{k}={v}" for k, v in sorted(tunnel_dep["spec"]["selector"]["matchLabels"].items())
     )
+    workload_labels = (
+        tunnel_dep.get("spec", {}).get("template", {}).get("metadata", {}).get("labels", {})
+    )
     tunnel["pods"] = pods_snapshot(kubectl("-n", ns, "get", "pods", "-l", selector, "-o", "json"))
     ready_tunnel = [p for p in tunnel["pods"] if p["ready"]]
     container = tunnel["containers"][0] if tunnel["containers"] else {}
     strategy = tunnel["strategy"].get("rollingUpdate", {})
     add_gap(gaps, "CF_IMAGE_NOT_IMMUTABLE_PIN", container.get("image") != EXPECTED_IMAGE)
     add_gap(gaps, "CF_CHART_VERSION_MISMATCH", release.get("chart") != "cloudflare-tunnel-0.3.2")
-    add_gap(gaps, "CF_HELM_RELEASE_NOT_DEPLOYED", tunnel["helmStatus"] != "deployed")
+    tunnel["helmListStatus"] = release.get("status")
+    add_gap(
+        gaps,
+        "CF_HELM_RELEASE_NOT_DEPLOYED",
+        tunnel["helmStatus"] != "deployed" or tunnel["helmListStatus"] != "deployed",
+    )
     add_gap(gaps, "CF_CONNECTORS_INSUFFICIENT", len(ready_tunnel) < 2)
     add_gap(gaps, "CF_CONNECTORS_UNSPREAD", len({p["node"] for p in ready_tunnel}) < 2)
+    add_gap(
+        gaps,
+        "CF_ANTI_AFFINITY_MISSING",
+        not required_hostname_anti_affinity(tunnel.get("affinity"), workload_labels),
+    )
     add_gap(
         gaps,
         "CF_UNSAFE_ROLLOUT",
@@ -466,22 +570,9 @@ def main() -> int:
         or not int_or_string_equals(probe_spec.get("port"), 2000)
         or bool(container.get("livenessProbe")),
     )
-    pdbs = list_items(
-        "-n", ns, "get", "pdb", "-l", f"app.kubernetes.io/instance={release_name}", "-o", "json"
-    )
-    services = list_items(
-        "-n", ns, "get", "service", "-l", f"app.kubernetes.io/instance={release_name}", "-o", "json"
-    )
-    monitors = list_items(
-        "-n",
-        ns,
-        "get",
-        "servicemonitor",
-        "-l",
-        f"app.kubernetes.io/instance={release_name}",
-        "-o",
-        "json",
-    )
+    pdbs = list_items("-n", ns, "get", "pdb", "-o", "json")
+    services = list_items("-n", ns, "get", "service", "-o", "json")
+    monitors = list_items("-n", ns, "get", "servicemonitor", "-o", "json")
     tunnel["pdb"] = [
         {
             "name": x["metadata"]["name"],
@@ -489,25 +580,52 @@ def main() -> int:
             "maxUnavailable": x.get("spec", {}).get("maxUnavailable"),
         }
         for x in pdbs
+        if selector_matches(x.get("spec", {}).get("selector"), workload_labels)
+    ]
+    matching_services = []
+    for service in services:
+        spec = service.get("spec", {})
+        ports = spec.get("ports", [])
+        if (
+            spec.get("type", "ClusterIP") == "ClusterIP"
+            and selector_matches({"matchLabels": spec.get("selector", {})}, workload_labels)
+            and any(
+                p.get("name") == "metrics"
+                and int_or_string_equals(p.get("port"), 2000)
+                and int_or_string_equals(p.get("targetPort"), 2000)
+                for p in ports
+            )
+        ):
+            matching_services.append(service)
+    service_labels = (
+        matching_services[0].get("metadata", {}).get("labels", {})
+        if len(matching_services) == 1
+        else {}
+    )
+    matching_monitors = [
+        monitor
+        for monitor in monitors
+        if selector_matches(monitor.get("spec", {}).get("selector"), service_labels)
+        and ns in monitor.get("spec", {}).get("namespaceSelector", {}).get("matchNames", [])
+        and any(
+            endpoint.get("port") == "metrics" and endpoint.get("path") == "/metrics"
+            for endpoint in monitor.get("spec", {}).get("endpoints", [])
+        )
     ]
     tunnel["metrics"] = {
-        "services": [
-            x["metadata"]["name"]
-            for x in services
-            if x.get("spec", {}).get("type", "ClusterIP") == "ClusterIP"
-        ],
-        "serviceMonitors": [x["metadata"]["name"] for x in monitors],
+        "services": [x["metadata"]["name"] for x in matching_services],
+        "serviceMonitors": [x["metadata"]["name"] for x in matching_monitors],
     }
     add_gap(
         gaps,
         "CF_PDB_MISSING",
-        not any(
-            p.get("spec", {}).get("minAvailable") == 1
-            or p.get("spec", {}).get("maxUnavailable") == 1
-            for p in pdbs
-        ),
+        not any(int_or_string_equals(p.get("minAvailable"), 1) for p in tunnel["pdb"]),
     )
-    add_gap(gaps, "CF_METRICS_DISCOVERY_MISSING", not tunnel["metrics"]["services"] or not monitors)
+    add_gap(
+        gaps,
+        "CF_METRICS_DISCOVERY_MISSING",
+        len(matching_services) != 1 or len(matching_monitors) != 1,
+    )
     metrics_service = tunnel["metrics"]["services"][0] if tunnel["metrics"]["services"] else ""
     metrics = {
         "healthyTargets": prom_count(
@@ -532,7 +650,9 @@ def main() -> int:
 
     target_map = json.loads(TARGETS.read_text())
     urls = probe_urls(target_map)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(urls)) as pool:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(MAX_PROBE_WORKERS, len(urls))
+    ) as pool:
         probe_rows = sorted(pool.map(probe, urls), key=lambda row: row["url"])
     add_gap(
         gaps,

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -8,6 +8,7 @@ import concurrent.futures
 import datetime as dt
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -487,17 +488,37 @@ def endpoints(document: dict[str, Any], service: str) -> dict[str, Any]:
         for value in list_shape(item.get("endpoints"), "malformed EndpointSlice entry"):
             endpoint = object_shape(value, "malformed EndpointSlice entry")
             cond = object_shape(endpoint.get("conditions", {}), "malformed EndpointSlice entry")
+            if any(
+                key in cond and not isinstance(cond[key], bool)
+                for key in ("ready", "serving", "terminating")
+            ):
+                raise HardFailure("malformed EndpointSlice entry")
             effective_ready = cond.get("ready", True)
             serving = cond.get("serving", effective_ready)
             terminating = cond.get("terminating", False)
             addresses = list_shape(endpoint.get("addresses"), "malformed EndpointSlice entry")
-            if not all(isinstance(address, str) for address in addresses):
+            if not addresses or not all(
+                isinstance(address, str) and address for address in addresses
+            ):
                 raise HardFailure("malformed EndpointSlice entry")
-            target = object_shape(endpoint.get("targetRef", {}), "malformed EndpointSlice entry")
+            node = endpoint.get("nodeName")
+            if node is not None and (not isinstance(node, str) or not node):
+                raise HardFailure("malformed EndpointSlice entry")
+            target_value = endpoint.get("targetRef")
+            target = (
+                {}
+                if target_value is None
+                else object_shape(target_value, "malformed EndpointSlice entry")
+            )
+            target_fields = tuple(
+                target.get(k, "") for k in ("apiVersion", "kind", "namespace", "name", "uid")
+            )
+            if not all(isinstance(field, str) for field in target_fields):
+                raise HardFailure("malformed EndpointSlice entry")
             key = (
-                endpoint.get("nodeName") or "",
+                node or "",
                 tuple(sorted(set(addresses))),
-                tuple(str(target.get(k, "")) for k in ("kind", "namespace", "name", "uid")),
+                target_fields,
             )
             grouped.setdefault(key, []).append((effective_ready, serving, terminating))
     healthy = [k for k, states in grouped.items() if all(r and s and not t for r, s, t in states)]
@@ -529,10 +550,38 @@ def prom_count(query: str) -> int:
         "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
         + quote(query, safe="")
     )
-    result = kubectl("get", "--raw", path).get("data", {}).get("result", [])
+    document = kubectl("get", "--raw", path)
+    data = document.get("data")
+    if document.get("status") != "success" or not isinstance(data, dict):
+        raise HardFailure("Prometheus returned an invalid aggregate")
+    result = data.get("result")
+    if not isinstance(result, list) or len(result) > 1:
+        raise HardFailure("Prometheus returned an invalid aggregate")
+    if not result:
+        return 0
     try:
-        return int(float(result[0]["value"][1])) if result else 0
-    except (KeyError, TypeError, ValueError, IndexError) as exc:
+        sample = result[0]
+        if not isinstance(sample, dict):
+            raise TypeError
+        value = sample["value"]
+        if (
+            not isinstance(value, list)
+            or len(value) != 2
+            or isinstance(value[0], bool)
+            or isinstance(value[1], bool)
+        ):
+            raise TypeError
+        timestamp = float(value[0])
+        count = float(value[1])
+        if (
+            not math.isfinite(timestamp)
+            or not math.isfinite(count)
+            or count < 0
+            or not count.is_integer()
+        ):
+            raise ValueError
+        return int(count)
+    except (KeyError, TypeError, ValueError) as exc:
         raise HardFailure("Prometheus returned an invalid aggregate") from exc
 
 

--- a/scripts/prod_resilience_audit.py
+++ b/scripts/prod_resilience_audit.py
@@ -39,15 +39,91 @@ def operation(argv: list[str]) -> str:
     if argv[0] == "kubectl":
         if args == ["config", "current-context"]:
             return "kubectl/config-current-context"
-        while len(args) >= 2 and args[0] in ("-n", "--namespace"):
-            args = args[2:]
-        if args and args[0] == "get":
+        namespace = None
+        if len(args) >= 2 and args[0] in ("-n", "--namespace"):
+            namespace, args = args[1], args[2:]
+            if not re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", namespace):
+                raise HardFailure("internal safety policy rejected a non-allowlisted operation")
+        if namespace is None and args == ["get", "nodes", "-o", "json"]:
             return "kubectl/get"
+        if namespace is None and args == [
+            "get",
+            "deployment",
+            "-A",
+            "-l",
+            "app.kubernetes.io/name=cloudflare-tunnel",
+            "-o",
+            "json",
+        ]:
+            return "kubectl/get"
+        if args[:2] == ["get", "--raw"] and len(args) == 3:
+            path = args[2]
+            if namespace is None and path == "/readyz?verbose":
+                return "kubectl/get-raw-readyz"
+            prom_prefix = (
+                "/api/v1/namespaces/monitoring/services/"
+                "http:kube-prometheus-stack-prometheus:9090/proxy/api/v1/query?query="
+            )
+            if namespace is None and path.startswith(prom_prefix) and len(path) <= 1000:
+                from urllib.parse import unquote
+
+                query = unquote(path[len(prom_prefix) :])
+                if re.fullmatch(
+                    r'count\((?:up|cloudflared_tunnel_ha_connections)\{namespace="[-a-z0-9]+",service="[-a-z0-9]*"\} (?:== 1|>= 4)\)'
+                    r'|count\(ALERTS\{alertname=~"CloudflareTunnel\(NoHealthyConnections\|ConnectionsDegraded\|MetricsTargetsDown\)",alertstate="firing"\}\)',
+                    query,
+                ):
+                    return "kubectl/get-raw-prometheus-query"
+        namespaced_gets = {
+            ("deployment", "coredns"),
+            ("deployment", "coredns-ha"),
+            ("deployment", "traefik"),
+            ("service", "traefik"),
+            ("helmchartconfig", "traefik"),
+        }
+        if namespace == "kube-system" and len(args) == 5 and args[:1] == ["get"]:
+            if tuple(args[1:3]) in namespaced_gets and args[3:] == ["-o", "json"]:
+                return "kubectl/get"
+        if namespace is not None and args[:2] == ["get", "pods"] and len(args) == 6:
+            if (
+                args[2] == "-l"
+                and re.fullmatch(r"[-A-Za-z0-9_./=,]+", args[3])
+                and args[4:] == ["-o", "json"]
+            ):
+                return "kubectl/get"
+        if namespace is not None and args in (
+            ["get", "pdb", "-o", "json"],
+            ["get", "service", "-o", "json"],
+            ["get", "servicemonitor", "-o", "json"],
+        ):
+            return "kubectl/get"
+        if (
+            namespace == "kube-system"
+            and len(args) == 6
+            and args[:2]
+            == [
+                "get",
+                "endpointslices.discovery.k8s.io",
+            ]
+        ):
+            if (
+                args[2] == "-l"
+                and re.fullmatch(r"kubernetes\.io/service-name=[-a-z0-9]+", args[3])
+                and args[4:] == ["-o", "json"]
+            ):
+                return "kubectl/get"
     elif argv[0] == "helm":
-        while len(args) >= 2 and args[0] in ("-n", "--namespace"):
-            args = args[2:]
-        if args and args[0] in ("list", "status", "history"):
-            return f"helm/{args[0]}"
+        if args == ["list", "-A", "-o", "json"]:
+            return "helm/list"
+        if len(args) == 6 and args[0] in ("-n", "--namespace"):
+            namespace, verb, release = args[1:4]
+            if (
+                verb in ("status", "history")
+                and re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", namespace)
+                and re.fullmatch(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?", release)
+                and args[4:] == ["-o", "json"]
+            ):
+                return f"helm/{verb}"
     elif argv[0] == "git" and args == ["rev-parse", "HEAD"]:
         return "git/rev-parse-head"
     elif argv[0] == sys.executable and args == [

--- a/scripts/prod_resilience_audit.sh
+++ b/scripts/prod_resilience_audit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Strictly read-only wrapper. The Python collector enforces an internal command allowlist.
+set -Eeuo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 "${ROOT}/scripts/prod_resilience_audit.py" "$@"

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -33,6 +33,11 @@ def slices(endpoints_by_slice):
     }
 
 
+def test_list_shape_rejects_non_list_values() -> None:
+    with pytest.raises(audit.HardFailure, match="^malformed list canary$"):
+        audit.list_shape({}, "malformed list canary")
+
+
 def test_endpoint_slices_aggregate_all_slices_and_effective_conditions() -> None:
     document = slices(
         [

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -155,6 +155,9 @@ def test_internal_runner_rejects_mutation_before_execution(monkeypatch, argv) ->
         ["kubectl", "get", "nodes", "-o", "json", "--show-labels"],
         ["kubectl", "get", "nodes", "--unknown"],
         ["helm", "list", "-A", "-o", "json", "--pending"],
+        ["helm", "status", "release"],
+        ["helm", "-n", "default", "status", "release", "-o", "json"],
+        ["helm", "--namespace", "default", "status", "release", "-o", "json"],
         ["helm", "-n", "default", "status", "release", "-o", "json", "--show-resources"],
         ["helm", "-n", "default", "history", "release", "-o", "json", "--max", "1"],
     ],
@@ -306,13 +309,21 @@ if tool == "helm":
     if clean[0] == "list":
         if state.get("malformed_helm"):
             emit(["credential=SECRET-CANARY connector=CONNECTOR-CANARY"]); raise SystemExit()
-        emit([{ "name": "cloudflare", "namespace": "cloudflare", "status": "deployed",
-                "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3", "revision": "1"}])
+        emit([{ "name": "cloudflare", "namespace": "cloudflare",
+                "status": state.get("helm_list_status", "deployed"),
+                "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
+                "revision": state.get("helm_revision", "1"),
+                "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}])
     elif clean[0] == "history":
-        emit([{"revision": 1, "updated": "fixed", "status": "deployed",
-               "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3"}])
-    else:
-        emit({"info": {"status": "deployed"}})
+        entries = [{"revision": 1, "updated": "fixed",
+                    "status": state.get("helm_history_status", "deployed"),
+                    "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
+                    "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}]
+        if state.get("helm_history_missing"):
+            entries[0]["revision"] = 2
+        if state.get("helm_history_duplicate"):
+            entries.append(dict(entries[0]))
+        emit(entries)
     raise SystemExit()
 
 identity = args[:1] == ["--kubeconfig"]
@@ -547,6 +558,7 @@ def test_cli_compliant_gap_determinism_sanitization_and_read_only_log(audit_harn
         if command[0] == "kubectl"
     )
     assert all((command[1] in {"list", "-n"}) for command in commands if command[0] == "helm")
+    assert not any(command[0] == "helm" and "status" in command for command in commands)
 
 
 def test_cli_completed_gap_exit_contract(audit_harness) -> None:
@@ -557,6 +569,56 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize("scenario", [{}, {"helm_revision": 1}])
+def test_cli_helm_list_and_current_history_deployed_pass(audit_harness, scenario) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("helm-deployed-" + str(scenario), **scenario)
+    assert result.returncode == 0
+    document = json.loads((evidence / "audit.json").read_text())
+    assert "CF_HELM_RELEASE_NOT_DEPLOYED" not in document["gaps"]
+    tunnel = document["observed"]["cloudflareTunnel"]
+    assert tunnel["helmListStatus"] == "deployed"
+    assert tunnel["helmCurrentHistoryStatus"] == "deployed"
+    assert "helmStatus" not in tunnel
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        {"helm_list_status": "failed"},
+        {"helm_list_status": "pending-upgrade"},
+        {"helm_history_status": "failed"},
+        {"helm_history_status": "pending-upgrade"},
+    ],
+)
+def test_cli_helm_non_deployed_status_is_a_gap(audit_harness, scenario) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("helm-status-gap-" + str(scenario), **scenario)
+    assert result.returncode == 0
+    assert (
+        "CF_HELM_RELEASE_NOT_DEPLOYED" in json.loads((evidence / "audit.json").read_text())["gaps"]
+    )
+
+
+@pytest.mark.parametrize(
+    "scenario", [{"helm_history_missing": True}, {"helm_history_duplicate": True}]
+)
+def test_cli_current_helm_history_revision_must_be_unique_and_sanitized(
+    audit_harness, scenario
+) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("helm-history-" + str(scenario), **scenario)
+    assert result.returncode == 2
+    assert (
+        result.stderr.strip()
+        == "HARD_FAILURE: unable to identify unique current Helm history revision"
+    )
+    assert not evidence.exists()
+    combined = result.stdout + result.stderr
+    for canary in ("SECRET-CANARY", "CONNECTOR-CANARY", "credential", "manifest"):
+        assert canary not in combined
 
 
 @pytest.mark.parametrize("scenario", [{"malformed_nodes": True}, {"malformed_helm": True}])

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -318,6 +318,46 @@ def test_traefik_desired_snapshot_rejects_decoys_and_ambiguity(content) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "term, unrelated",
+    [
+        (
+            "      - labelSelector: {}\n",
+            "  labelSelector:\n"
+            "    matchLabels:\n"
+            "      app.kubernetes.io/name: traefik\n"
+            "  topologyKey: kubernetes.io/hostname\n",
+        ),
+        (
+            "      - labelSelector:\n"
+            "          matchLabels:\n"
+            "            app.kubernetes.io/name: traefik\n",
+            "  topologyKey: kubernetes.io/hostname\n",
+        ),
+        (
+            "      - topologyKey: kubernetes.io/hostname\n",
+            "  labelSelector:\n" "    matchLabels:\n" "      app.kubernetes.io/name: traefik\n",
+        ),
+    ],
+)
+def test_traefik_desired_snapshot_does_not_complete_term_after_dedent(term, unrelated) -> None:
+    content = (
+        "deployment:\n"
+        "  replicas: 2\n"
+        "affinity:\n"
+        "  podAntiAffinity:\n"
+        "    requiredDuringSchedulingIgnoredDuringExecution:\n"
+        f"{term}"
+        "unrelated:\n"
+        f"{unrelated}"
+    )
+
+    assert audit.traefik_desired_snapshot(content) == {
+        "replicas": 2,
+        "requiredHostnameAntiAffinity": False,
+    }
+
+
 FAKE_TOOL = r"""#!/usr/bin/python3 -S
 import json, os, sys
 from pathlib import Path

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -269,15 +269,53 @@ def test_required_hostname_anti_affinity_matches_workload() -> None:
     assert not audit.required_hostname_anti_affinity(affinity, {"app": "unrelated"})
 
 
+APPROVED_TRAEFIK_VALUES = """deployment:
+  replicas: 2
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: traefik
+        topologyKey: kubernetes.io/hostname
+secret: do-not-retain
+"""
+
+
 def test_traefik_desired_snapshot_never_retains_raw_values() -> None:
-    result = audit.traefik_desired_snapshot(
-        "deployment:\n  replicas: 2\naffinity:\n  "
-        "requiredDuringSchedulingIgnoredDuringExecution:\n"
-        "    app.kubernetes.io/name: traefik\n"
-        "    topologyKey: kubernetes.io/hostname\nsecret: do-not-retain\n"
-    )
+    result = audit.traefik_desired_snapshot(APPROVED_TRAEFIK_VALUES)
     assert result == {"replicas": 2, "requiredHostnameAntiAffinity": True}
     assert "do-not-retain" not in json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "unrelated:\n  replicas: 2\n",
+        "deployment:\n  replicas: 2\naffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    app.kubernetes.io/name: traefik\n    topologyKey: kubernetes.io/hostname\n",
+        APPROVED_TRAEFIK_VALUES.replace(
+            "        topologyKey: kubernetes.io/hostname",
+            "      - topologyKey: kubernetes.io/hostname",
+        ),
+        APPROVED_TRAEFIK_VALUES.replace("traefik", "not-traefik"),
+        APPROVED_TRAEFIK_VALUES.replace("kubernetes.io/hostname", "topology.kubernetes.io/zone"),
+        APPROVED_TRAEFIK_VALUES + "deployment:\n  replicas: 2\n",
+        APPROVED_TRAEFIK_VALUES.replace(
+            "    requiredDuringSchedulingIgnoredDuringExecution:",
+            "    requiredDuringSchedulingIgnoredDuringExecution:\n"
+            "      - labelSelector:\n"
+            "          matchLabels:\n"
+            "            app.kubernetes.io/name: traefik\n"
+            "        topologyKey: kubernetes.io/hostname\n"
+            "    requiredDuringSchedulingIgnoredDuringExecution:",
+        ),
+    ],
+)
+def test_traefik_desired_snapshot_rejects_decoys_and_ambiguity(content) -> None:
+    assert audit.traefik_desired_snapshot(content) != {
+        "replicas": 2,
+        "requiredHostnameAntiAffinity": True,
+    }
 
 
 FAKE_TOOL = r"""#!/usr/bin/python3 -S
@@ -417,11 +455,14 @@ elif kind == "endpointslices.discovery.k8s.io":
                      "endpoints": [{"addresses": ["10.0.0.1"], "nodeName": "sugarkube0", "conditions": {}},
                                    {"addresses": ["10.0.0.2"], "nodeName": "sugarkube1", "conditions": {}}]}]})
 elif kind == "service" and name == "traefik":
-    emit({"spec": {"internalTrafficPolicy": "Local"}})
+    emit({"spec": {} if state.get("traffic_policy_absent") else
+          {"internalTrafficPolicy": state.get("traffic_policy", "Cluster")}})
 elif kind == "helmchartconfig":
     emit({"metadata": {"uid": "hcc"}, "spec": {"valuesContent":
-          "deployment:\n  replicas: 2\naffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n"
-          "    app.kubernetes.io/name: traefik\n    topologyKey: kubernetes.io/hostname\n"}})
+          "deployment:\n  replicas: 2\naffinity:\n  podAntiAffinity:\n"
+          "    requiredDuringSchedulingIgnoredDuringExecution:\n      - labelSelector:\n"
+          "          matchLabels:\n            app.kubernetes.io/name: traefik\n"
+          "        topologyKey: kubernetes.io/hostname\n"}})
 elif kind == "service":
     emit({"items": [{"metadata": {"name": "cloudflare-metrics", "labels": {"monitor": "cloudflare"}},
                      "spec": {"selector": pod_labels, "ports": [{"name": "metrics", "port": 2000,
@@ -569,6 +610,21 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [{"traffic_policy_absent": True}, {"traffic_policy": "Cluster"}, {"traffic_policy": "Local"}],
+)
+def test_cli_traffic_policy_is_observed_without_an_unsupported_gap(audit_harness, scenario) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("traffic-policy-" + str(scenario), **scenario)
+    assert result.returncode == 0
+    document = json.loads((evidence / "audit.json").read_text())
+    assert "TRAEFIK_TRAFFIC_POLICY_MISMATCH" not in document["gaps"]
+    assert document["observed"]["traefikService"]["internalTrafficPolicy"] == scenario.get(
+        "traffic_policy", "Cluster"
+    )
 
 
 @pytest.mark.parametrize("scenario", [{}, {"helm_revision": 1}])

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -132,6 +132,33 @@ def test_internal_runner_rejects_mutation_before_execution(monkeypatch, argv) ->
     assert called is False
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["kubectl", "get", "secrets", "-A", "-o", "json"],
+        ["kubectl", "-n", "default", "get", "secret", "token", "-o", "json"],
+        ["kubectl", "get", "--raw", "/api/v1/namespaces/default/secrets"],
+        ["kubectl", "get", "nodes", "-o", "yaml"],
+        ["kubectl", "get", "nodes", "-o", "json", "--show-labels"],
+        ["kubectl", "get", "nodes", "--unknown"],
+        ["helm", "list", "-A", "-o", "json", "--pending"],
+        ["helm", "-n", "default", "status", "release", "-o", "json", "--show-resources"],
+        ["helm", "-n", "default", "history", "release", "-o", "json", "--max", "1"],
+    ],
+)
+def test_operation_rejects_non_allowlisted_read_shapes_before_execution(monkeypatch, argv) -> None:
+    called = False
+
+    def forbidden(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(audit.subprocess, "run", forbidden)
+    with pytest.raises(audit.HardFailure, match="safety policy"):
+        audit.run(argv)
+    assert called is False
+
+
 def test_source_has_no_cluster_mutation_or_dormant_flux_discovery() -> None:
     source = (ROOT / "scripts/prod_resilience_audit.py").read_text()
     for forbidden in ("flux reconcile", "systemctl", "nftables", "poweroff"):
@@ -164,7 +191,7 @@ def test_runner_failure_is_bounded_and_redacted(monkeypatch) -> None:
     monkeypatch.setattr(audit.subprocess, "run", lambda *args, **kwargs: result)
 
     with pytest.raises(audit.HardFailure) as caught:
-        audit.run(["kubectl", "get", "nodes"])
+        audit.run(["kubectl", "get", "nodes", "-o", "json"])
 
     message = str(caught.value)
     assert "exit 7" in message

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -304,6 +304,8 @@ if tool == "curl":
 if tool == "helm":
     clean = args[2:] if args[:1] in (["-n"], ["--namespace"]) else args
     if clean[0] == "list":
+        if state.get("malformed_helm"):
+            emit(["credential=SECRET-CANARY connector=CONNECTOR-CANARY"]); raise SystemExit()
         emit([{ "name": "cloudflare", "namespace": "cloudflare", "status": "deployed",
                 "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3", "revision": "1"}])
     elif clean[0] == "history":
@@ -322,6 +324,9 @@ if identity and args[:2] == ["get", "nodes"] and state.get("identity_fail"):
     print("credential=SECRET-CANARY connector=CONNECTOR-CANARY", file=sys.stderr)
     raise SystemExit(1)
 if args[:2] == ["get", "nodes"]:
+    if state.get("malformed_nodes"):
+        emit({"items": [{"metadata": "credential=SECRET-CANARY connector=CONNECTOR-CANARY"}]})
+        raise SystemExit()
     emit(nodes); raise SystemExit()
 if args[:3] == ["config", "view", "--minify"]:
     emit("https://sanitized.invalid"); raise SystemExit()
@@ -552,6 +557,51 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize("scenario", [{"malformed_nodes": True}, {"malformed_helm": True}])
+def test_cli_malformed_external_shapes_are_sanitized(audit_harness, scenario) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("malformed-" + next(iter(scenario)), **scenario)
+    assert result.returncode == 2
+    assert not evidence.exists()
+    combined = result.stdout + result.stderr
+    assert "HARD_FAILURE:" in result.stderr
+    assert "Traceback" not in combined
+    assert "SECRET-CANARY" not in combined
+    assert "CONNECTOR-CANARY" not in combined
+
+
+def test_cli_filesystem_failure_is_generic_and_leaves_no_partial_evidence(
+    audit_harness, monkeypatch, capsys
+) -> None:
+    execute, _ = audit_harness
+    command, env, evidence = execute.configure("filesystem-failure")
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    original_write_text = Path.write_text
+
+    def fail_audit_write(path, *args, **kwargs):
+        if path.name == "audit.json":
+            raise OSError("FILESYSTEM-CANARY /private/path")
+        return original_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_audit_write)
+    assert audit.cli(command[2:]) == 2
+    captured = capsys.readouterr()
+    assert captured.err.strip() == "HARD_FAILURE: unexpected collection failure"
+    assert "FILESYSTEM-CANARY" not in captured.out + captured.err
+    assert not evidence.exists()
+    assert not list(evidence.parent.glob(".prod-audit-*"))
+
+
+def test_cli_boundary_does_not_catch_keyboard_interrupt(monkeypatch) -> None:
+    def interrupted(argv=None):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(audit, "main", interrupted)
+    with pytest.raises(KeyboardInterrupt):
+        audit.cli([])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -174,6 +174,29 @@ def test_runner_failure_is_bounded_and_redacted(monkeypatch) -> None:
     assert len(message) < 100
 
 
+def test_kubectl_rejects_malformed_json_shapes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        audit,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout="not-json"),
+    )
+    with pytest.raises(audit.HardFailure, match="malformed JSON"):
+        audit.kubectl("get", "nodes")
+
+    monkeypatch.setattr(
+        audit,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout="[]"),
+    )
+    with pytest.raises(audit.HardFailure, match="must be an object"):
+        audit.kubectl("get", "nodes")
+
+
+def test_empty_command_is_rejected() -> None:
+    with pytest.raises(audit.HardFailure, match="empty command"):
+        audit.operation([])
+
+
 def test_successful_status_with_transport_error_is_unhealthy() -> None:
     assert audit.probes_unhealthy([{"status": 200, "error": "transport"}])
     assert not audit.probes_unhealthy([{"status": 204, "error": "none"}])
@@ -214,7 +237,7 @@ def test_traefik_desired_snapshot_never_retains_raw_values() -> None:
     assert "do-not-retain" not in json.dumps(result)
 
 
-FAKE_TOOL = r"""#!/usr/bin/env python3
+FAKE_TOOL = r"""#!/usr/bin/python3 -S
 import json, os, sys
 from pathlib import Path
 
@@ -348,7 +371,7 @@ def audit_harness(tmp_path):
     state = tmp_path / "state.json"
     log = tmp_path / "commands.jsonl"
 
-    def execute(label, *, cli_env="prod", require_parity=False, **scenario):
+    def configure(label, *, cli_env="prod", require_parity=False, **scenario):
         state.write_text(json.dumps(scenario))
         evidence = tmp_path / label
         env = os.environ.copy()
@@ -369,9 +392,16 @@ def audit_harness(tmp_path):
         ]
         if require_parity:
             command.append("--require-parity")
+        return command, env, evidence
+
+    def execute(label, *, cli_env="prod", require_parity=False, **scenario):
+        command, env, evidence = configure(
+            label, cli_env=cli_env, require_parity=require_parity, **scenario
+        )
         result = subprocess.run(command, text=True, capture_output=True, env=env, check=False)
         return result, evidence
 
+    execute.configure = configure
     return execute, log
 
 
@@ -462,3 +492,15 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+def test_cli_compliant_fixture_covers_in_process_collection(audit_harness, monkeypatch) -> None:
+    """Exercise collector branches in-process so patch coverage observes the CLI work."""
+    execute, _ = audit_harness
+    command, env, evidence = execute.configure("covered-compliant")
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(sys, "argv", command[1:])
+
+    assert audit.main() == 0
+    assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_OK"

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -108,6 +108,12 @@ def test_deployment_snapshot_keeps_secret_reference_but_not_value() -> None:
         ["kubectl", "exec", "pod/x"],
         ["helm", "upgrade", "x", "chart"],
         ["helm", "repo", "add", "x", "url"],
+        ["kubectl", "scale", "deployment/x"],
+        ["kubectl", "cp", "pod/x:/x", "."],
+        ["helm", "test", "x"],
+        ["flux", "reconcile", "kustomization", "x"],
+        ["sudo", "true"],
+        ["ssh", "host"],
     ],
 )
 def test_internal_runner_rejects_mutation_before_execution(monkeypatch, argv) -> None:
@@ -148,7 +154,7 @@ def test_int_or_string_comparison_rejects_other_values(value) -> None:
     assert not audit.int_or_string_equals(value, 0)
 
 
-def test_runner_failure_includes_bounded_diagnostics(monkeypatch) -> None:
+def test_runner_failure_is_bounded_and_redacted(monkeypatch) -> None:
     result = subprocess.CompletedProcess(
         ["kubectl", "get", "nodes"], 7, stderr="permission denied " + "x" * 600
     )
@@ -159,17 +165,47 @@ def test_runner_failure_includes_bounded_diagnostics(monkeypatch) -> None:
 
     message = str(caught.value)
     assert "exit 7" in message
-    assert "kubectl get nodes" in message
-    assert "permission denied" in message
-    assert len(message) < 600
+    assert "kubectl/get" in message
+    assert "permission denied" not in message
+    assert "x" * 20 not in message
+    assert len(message) < 100
 
 
 def test_successful_status_with_transport_error_is_unhealthy() -> None:
     assert audit.probes_unhealthy([{"status": 200, "error": "transport"}])
-    assert not audit.probes_unhealthy([{"status": 204}])
+    assert not audit.probes_unhealthy([{"status": 204, "error": "none"}])
 
 
-@pytest.mark.parametrize("targets", [{}, {"example.com": []}, []])
+@pytest.mark.parametrize(
+    "targets",
+    [{}, {"example.com": []}, [], {"example.com": "path"}, {1: ["/"]}, {"x": [1]}],
+)
 def test_empty_probe_targets_fail_closed(targets) -> None:
     with pytest.raises(audit.HardFailure, match="target manifest"):
         audit.probe_urls(targets)
+
+
+def test_required_hostname_anti_affinity_matches_workload() -> None:
+    affinity = {
+        "podAntiAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "topologyKey": "kubernetes.io/hostname",
+                    "labelSelector": {"matchLabels": {"app": "tunnel"}},
+                }
+            ]
+        }
+    }
+    assert audit.required_hostname_anti_affinity(affinity, {"app": "tunnel"})
+    assert not audit.required_hostname_anti_affinity(affinity, {"app": "unrelated"})
+
+
+def test_traefik_desired_snapshot_never_retains_raw_values() -> None:
+    result = audit.traefik_desired_snapshot(
+        "deployment:\n  replicas: 2\naffinity:\n  "
+        "requiredDuringSchedulingIgnoredDuringExecution:\n"
+        "    app.kubernetes.io/name: traefik\n"
+        "    topologyKey: kubernetes.io/hostname\nsecret: do-not-retain\n"
+    )
+    assert result == {"replicas": 2, "requiredHostnameAntiAffinity": True}
+    assert "do-not-retain" not in json.dumps(result)

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -425,7 +425,7 @@ def test_traefik_desired_snapshot_does_not_complete_term_after_dedent(term, unre
 
 
 FAKE_TOOL = r"""#!/usr/bin/python3 -S
-import json, os, sys
+import json, os, sys, time
 from pathlib import Path
 
 state = json.loads(Path(os.environ["AUDIT_FAKE_STATE"]).read_text())
@@ -439,12 +439,24 @@ def emit(value):
 labels = {"sugarkube.env": "prod", "sugarkube.cluster": "sugar-prod"}
 node_names = state.get("nodes", ["sugarkube0", "sugarkube1", "sugarkube2"])
 nodes = {"items": [{"metadata": {"name": n, "labels": labels},
-                    "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+                    "status": {"conditions": [{"type": "Ready", "status":
+                               "False" if state.get("nodes_unready") and n == "sugarkube0"
+                               else "True"}]}}
                    for n in node_names]}
 if tool == "git":
     emit("0123456789abcdef0123456789abcdef01234567"); raise SystemExit()
 if tool == "curl":
     print("credential=SECRET-CANARY connector=CONNECTOR-CANARY", file=sys.stderr)
+    if state.get("timeout_isolation"):
+        marker = Path(os.environ["AUDIT_TIMEOUT_MARKER"])
+        if args[-1] == "https://danielsmith.io/":
+            for _ in range(100):
+                if marker.exists():
+                    Path(os.environ["AUDIT_TIMEOUT_OBSERVED"]).write_text("observed")
+                    emit("000\t0.01\t0.00\t0.02"); raise SystemExit(28)
+                time.sleep(0.01)
+            emit("000\t0.01\t0.00\t0.02"); raise SystemExit(9)
+        marker.write_text("FAST-BODY-CANARY SECRET-CANARY CONNECTOR-CANARY")
     if state.get("failed_probe") and args[-1].endswith("/healthz"):
         emit("000\t0.01\t0.00\t0.02"); raise SystemExit(28)
     emit("204\t0.01\t0.02\t0.03"); raise SystemExit()
@@ -496,7 +508,8 @@ if args[:2] == ["get", "nodes"]:
 if args[:3] == ["config", "view", "--minify"]:
     emit("https://sanitized.invalid"); raise SystemExit()
 if args[:3] == ["get", "--raw", "/readyz?verbose"]:
-    emit("readyz check passed\n[+]etcd ok"); raise SystemExit()
+    emit("readyz check failed\n[-]etcd failed" if state.get("readyz_failed") else
+         "readyz check passed\n[+]etcd ok"); raise SystemExit()
 if args[:2] == ["get", "--raw"]:
     if args[2].endswith("/api/v1/rules?type=alert"):
         if state.get("alert_malformed"):
@@ -526,7 +539,12 @@ if args[:2] == ["get", "--raw"]:
             response["status"] = "error"
         emit(response)
         raise SystemExit()
-    count = 0 if "ALERTS" in args[2] else 2
+    if "ALERTS" in args[2]:
+        count = 0
+    elif "cloudflared_tunnel_ha_connections" in args[2]:
+        count = state.get("ha_connections", 2)
+    else:
+        count = state.get("healthy_targets", 2)
     emit({"status": "success", "data": {"result": [
         {"metric": {"connector": "CONNECTOR-CANARY", "credential": "SECRET-CANARY"},
          "value": [0, str(count)]}]}}); raise SystemExit()
@@ -544,15 +562,23 @@ traefik_anti = {"podAntiAffinity": {"requiredDuringSchedulingIgnoredDuringExecut
     {"topologyKey": "kubernetes.io/hostname",
      "labelSelector": {"matchLabels": {"app.kubernetes.io/name": "traefik"}}}
 ]}}
-def pod(uid, node):
+def pod(uid, node, ready=True):
     return {"metadata": {"uid": uid}, "spec": {"nodeName": node},
-            "status": {"conditions": [{"type": "Ready", "status": "True"}],
+            "status": {"conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
                        "containerStatuses": [{"restartCount": 0}]}}
 def deployment(dep_name, labels_, affinity):
     container = {"name": dep_name, "image": "unused"}
     if dep_name == "cloudflare":
         container = {"name": "cloudflared", "image": os.environ["AUDIT_EXPECTED_IMAGE"],
                      "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}}}
+        if state.get("image_unpinned"):
+            container["image"] = "cloudflare/cloudflared:latest"
+        if state.get("probe_path_wrong"):
+            container["readinessProbe"]["httpGet"]["path"] = "/wrong"
+        if state.get("probe_port_wrong"):
+            container["readinessProbe"]["httpGet"]["port"] = 2001
+        if state.get("liveness_probe"):
+            container["livenessProbe"] = {"httpGet": {"path": "/ready", "port": 2000}}
     return {"metadata": {"name": dep_name, "namespace": ns or "cloudflare", "uid": dep_name,
                          "generation": 1, "labels": dict(labels_)},
             "spec": {"replicas": 2, "selector": {"matchLabels": dict(labels_)},
@@ -602,11 +628,23 @@ if kind == "deployment" and args[2:3] == ["-A"]:
         items.append(second)
     emit({"items": [] if state.get("zero_candidates") else items}); raise SystemExit()
 if kind == "deployment" and name in ("coredns", "coredns-ha", "traefik"):
+    if state.get("missing_component") == name:
+        emit({}); raise SystemExit()
     lab = {"app.kubernetes.io/name": name}
     emit(deployment(name, lab, traefik_anti if name == "traefik" else anti)); raise SystemExit()
 if kind == "pods":
-    one = state.get("gap") and ns == "kube-system"
-    emit({"items": [pod("a", "sugarkube0")] + ([] if one else [pod("b", "sugarkube1")])})
+    selector = next((value for value in args if "=" in value), "")
+    component = "cloudflare" if ns == "cloudflare" else selector.rsplit("=", 1)[-1]
+    selected = state.get("pod_component")
+    applies = selected == component or (selected == "coredns" and component.startswith("coredns"))
+    mode = state.get("pod_mode") if applies else None
+    if state.get("gap") and ns == "kube-system":
+        mode = "singleton"
+    items = [pod("a", "sugarkube0")]
+    if mode != "singleton":
+        items.append(pod("b", "sugarkube0" if mode == "unspread" else "sugarkube1",
+                         ready=mode != "unhealthy"))
+    emit({"items": items})
 elif kind == "pdb":
     pdb_selector = {"other": "workload"} if state.get("pdb_selector_mismatch") else pod_labels
     pdb_items = [
@@ -620,9 +658,12 @@ elif kind == "pdb":
     emit({"items": [] if ns == "kube-system" else pdb_items})
 elif kind == "endpointslices.discovery.k8s.io":
     service = next(x.split("=", 1)[1] for x in args if x.startswith("kubernetes.io/service-name="))
+    insufficient = state.get("endpoint_insufficient") == service
     emit({"items": [{"metadata": {"labels": {"kubernetes.io/service-name": service}},
                      "endpoints": [{"addresses": ["10.0.0.1"], "nodeName": "sugarkube0", "conditions": {}},
-                                   {"addresses": ["10.0.0.2"], "nodeName": "sugarkube1", "conditions": {}}]}]})
+                                   {"addresses": ["10.0.0.2"], "nodeName":
+                                    "sugarkube0" if insufficient else "sugarkube1",
+                                    "conditions": {}}]}]})
 elif kind == "service" and name == "traefik":
     emit({"spec": {} if state.get("traffic_policy_absent") else
           {"internalTrafficPolicy": state.get("traffic_policy", "Cluster")}})
@@ -687,6 +728,8 @@ def audit_harness(tmp_path):
             AUDIT_FAKE_STATE=str(state),
             AUDIT_COMMAND_LOG=str(log),
             AUDIT_EXPECTED_IMAGE=audit.EXPECTED_IMAGE,
+            AUDIT_TIMEOUT_MARKER=str(tmp_path / "timeout-marker-SECRET-CANARY"),
+            AUDIT_TIMEOUT_OBSERVED=str(tmp_path / "timeout-observed-CONNECTOR-CANARY"),
             SUGARKUBE_AUDIT_TIMESTAMP="2026-08-12T00:00:00Z",
         )
         command = [
@@ -803,6 +846,137 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize(
+    ("scenario", "added_gaps"),
+    [
+        ({"missing_component": "coredns"}, {"COREDNS_MISSING"}),
+        ({"missing_component": "coredns-ha"}, {"COREDNS_HA_MISSING"}),
+        (
+            {"missing_component": "traefik"},
+            {
+                "TRAEFIK_MISSING",
+                "TRAEFIK_SINGLETON",
+                "TRAEFIK_UNSPREAD",
+                "TRAEFIK_SCHEDULING_CONTRACT_MISMATCH",
+            },
+        ),
+        (
+            {
+                "missing_component": "coredns-ha",
+                "pod_component": "coredns",
+                "pod_mode": "singleton",
+            },
+            {"COREDNS_HA_MISSING", "COREDNS_SINGLETON", "COREDNS_UNSPREAD"},
+        ),
+        (
+            {"pod_component": "traefik", "pod_mode": "singleton"},
+            {"TRAEFIK_SINGLETON", "TRAEFIK_UNSPREAD"},
+        ),
+        (
+            {"pod_component": "cloudflare", "pod_mode": "singleton"},
+            {"CF_CONNECTORS_INSUFFICIENT", "CF_CONNECTORS_UNSPREAD"},
+        ),
+        ({"pod_component": "coredns", "pod_mode": "unspread"}, {"COREDNS_UNSPREAD"}),
+        ({"pod_component": "traefik", "pod_mode": "unspread"}, {"TRAEFIK_UNSPREAD"}),
+        (
+            {"pod_component": "cloudflare", "pod_mode": "unspread"},
+            {"CF_CONNECTORS_UNSPREAD"},
+        ),
+        ({"nodes_unready": True}, {"NODE_NOT_READY"}),
+        ({"readyz_failed": True}, {"API_OR_ETCD_NOT_READY"}),
+        (
+            {
+                "missing_component": "coredns-ha",
+                "pod_component": "coredns",
+                "pod_mode": "unhealthy",
+            },
+            {"COREDNS_HA_MISSING", "COREDNS_SINGLETON", "COREDNS_UNSPREAD"},
+        ),
+        (
+            {"pod_component": "traefik", "pod_mode": "unhealthy"},
+            {"TRAEFIK_SINGLETON", "TRAEFIK_UNSPREAD"},
+        ),
+        (
+            {"pod_component": "cloudflare", "pod_mode": "unhealthy"},
+            {"CF_CONNECTORS_INSUFFICIENT", "CF_CONNECTORS_UNSPREAD"},
+        ),
+        ({"endpoint_insufficient": "kube-dns"}, {"KUBE_DNS_ENDPOINTS_INSUFFICIENT"}),
+        ({"endpoint_insufficient": "traefik"}, {"TRAEFIK_ENDPOINTS_INSUFFICIENT"}),
+        ({"image_unpinned": True}, {"CF_IMAGE_NOT_IMMUTABLE_PIN"}),
+        ({"probe_path_wrong": True}, {"CF_PROBE_CONTRACT"}),
+        ({"probe_port_wrong": True}, {"CF_PROBE_CONTRACT"}),
+        ({"liveness_probe": True}, {"CF_PROBE_CONTRACT"}),
+        ({"healthy_targets": 1}, {"CF_METRICS_TARGETS_UNHEALTHY"}),
+        ({"ha_connections": 1}, {"CF_HA_CONNECTIONS_INSUFFICIENT"}),
+    ],
+    ids=[
+        "missing-coredns",
+        "missing-coredns-ha",
+        "missing-traefik",
+        "singleton-coredns",
+        "singleton-traefik",
+        "singleton-cloudflare",
+        "unspread-coredns",
+        "unspread-traefik",
+        "unspread-cloudflare",
+        "unready-node",
+        "api-etcd-unready",
+        "unready-coredns-pod",
+        "unready-traefik-pod",
+        "unready-cloudflare-pod",
+        "kube-dns-endpoints",
+        "traefik-endpoints",
+        "cloudflare-image",
+        "probe-path",
+        "probe-port",
+        "liveness-probe",
+        "prometheus-targets",
+        "prometheus-ha",
+    ],
+)
+def test_cli_prompt_gap_matrix(audit_harness, scenario, added_gaps) -> None:
+    execute, _ = audit_harness
+    baseline_result, baseline_dir = execute("matrix-compliant")
+    baseline = json.loads((baseline_dir / "audit.json").read_text())
+    assert baseline_result.returncode == 0
+    assert baseline["result"] == "PARITY_OK"
+    assert baseline["gaps"] == []
+    assert baseline["gapCount"] == 0
+
+    result, evidence = execute("matrix-" + next(iter(scenario)), **scenario)
+    document = json.loads((evidence / "audit.json").read_text())
+    assert result.returncode == 0
+    assert set(document["gaps"]) - set(baseline["gaps"]) == added_gaps
+    assert document["gapCount"] == len(added_gaps)
+
+
+def test_cli_endpoint_timeout_isolation_is_concurrent_and_sanitized(audit_harness) -> None:
+    execute, _ = audit_harness
+    command, env, evidence = execute.configure("timeout-isolation", timeout_isolation=True)
+    result = subprocess.run(
+        command, text=True, capture_output=True, env=env, check=False, timeout=15
+    )
+
+    assert result.returncode == 0
+    rows = (evidence / "endpoints.tsv").read_text().splitlines()
+    assert any(
+        row.startswith("https://danielsmith.io/\t0\t") and row.endswith("\ttimeout") for row in rows
+    )
+    assert any(row.endswith("\tnone") for row in rows)
+    assert Path(env["AUDIT_TIMEOUT_OBSERVED"]).read_text() == "observed"
+    combined = (
+        result.stdout + result.stderr + "".join(path.read_text() for path in evidence.iterdir())
+    )
+    for canary in (
+        "SECRET-CANARY",
+        "CONNECTOR-CANARY",
+        "FAST-BODY-CANARY",
+        env["AUDIT_TIMEOUT_MARKER"],
+        env["AUDIT_TIMEOUT_OBSERVED"],
+    ):
+        assert canary not in combined
 
 
 @pytest.mark.parametrize(

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -1,0 +1,137 @@
+"""Focused offline contracts for the production resilience collector."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "prod_audit", ROOT / "scripts/prod_resilience_audit.py"
+)
+assert SPEC and SPEC.loader
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+def slices(endpoints_by_slice):
+    return {
+        "items": [
+            {
+                "metadata": {"labels": {"kubernetes.io/service-name": "traefik"}},
+                "endpoints": endpoints,
+            }
+            for endpoints in endpoints_by_slice
+        ]
+    }
+
+
+def test_endpoint_slices_aggregate_all_slices_and_effective_conditions() -> None:
+    document = slices(
+        [
+            [{"addresses": ["10.0.0.1"], "nodeName": "a", "conditions": {}}],
+            [
+                {
+                    "addresses": ["10.0.0.2"],
+                    "nodeName": "b",
+                    "conditions": {"ready": True, "serving": True, "terminating": False},
+                },
+                {
+                    "addresses": ["10.0.0.3"],
+                    "nodeName": "c",
+                    "conditions": {"ready": True, "terminating": True},
+                },
+            ],
+        ]
+    )
+    result = audit.endpoints(document, "traefik")
+    assert result == {
+        "service": "traefik",
+        "slices": 2,
+        "uniqueEndpoints": 3,
+        "healthyEndpoints": 2,
+        "unhealthyEndpoints": 1,
+        "healthyNodes": ["a", "b"],
+    }
+    assert "10.0.0.1" not in json.dumps(result)
+
+
+def test_conflicting_duplicate_endpoint_fails_closed() -> None:
+    endpoint = {"addresses": ["10.0.0.1"], "nodeName": "a", "conditions": {"ready": True}}
+    other = json.loads(json.dumps(endpoint))
+    other["conditions"]["ready"] = False
+    result = audit.endpoints(slices([[endpoint], [other]]), "traefik")
+    assert result["healthyEndpoints"] == 0
+    assert result["unhealthyEndpoints"] == 1
+
+
+def test_deployment_snapshot_keeps_secret_reference_but_not_value() -> None:
+    dep = {
+        "metadata": {"name": "tunnel", "namespace": "cf", "uid": "pod-uid"},
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "cloudflared",
+                            "image": "image@sha256:digest",
+                            "env": [
+                                {
+                                    "name": "TUNNEL_TOKEN",
+                                    "valueFrom": {
+                                        "secretKeyRef": {"name": "tunnel-token", "key": "token"}
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+    }
+    result = audit.deployment_snapshot(dep)
+    encoded = json.dumps(result)
+    assert "tunnel-token" in encoded
+    assert '"value"' not in encoded
+    assert "connector" not in encoded.lower()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["kubectl", "apply", "-f", "x"],
+        ["kubectl", "rollout", "restart", "deployment/x"],
+        ["kubectl", "exec", "pod/x"],
+        ["helm", "upgrade", "x", "chart"],
+        ["helm", "repo", "add", "x", "url"],
+    ],
+)
+def test_internal_runner_rejects_mutation_before_execution(monkeypatch, argv) -> None:
+    called = False
+
+    def forbidden(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(audit.subprocess, "run", forbidden)
+    with pytest.raises(audit.HardFailure, match="safety policy"):
+        audit.run(argv)
+    assert called is False
+
+
+def test_source_has_no_cluster_mutation_or_dormant_flux_discovery() -> None:
+    source = (ROOT / "scripts/prod_resilience_audit.py").read_text()
+    for forbidden in ("flux reconcile", "systemctl", "nftables", "poweroff"):
+        assert forbidden not in source
+    assert '["kubectl", "port-forward"' not in source
+    assert "platform/cloudflared" not in source
+    assert "cloudflared-values.yaml" not in source
+
+
+def test_target_manifest_is_canonical_and_narrow() -> None:
+    targets = json.loads((ROOT / "config/prod-resilience-audit-targets.json").read_text())
+    assert sorted(targets) == ["danielsmith.io", "democratized.space", "token.place"]
+    assert all(path.startswith("/") for paths in targets.values() for path in paths)

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -387,11 +387,14 @@ if tool == "helm":
     if clean[0] == "list":
         if state.get("malformed_helm"):
             emit(["credential=SECRET-CANARY connector=CONNECTOR-CANARY"]); raise SystemExit()
-        emit([{ "name": "cloudflare", "namespace": "cloudflare",
+        releases = [{ "name": "cloudflare", "namespace": "cloudflare",
                 "status": state.get("helm_list_status", "deployed"),
                 "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
                 "revision": state.get("helm_revision", "1"),
-                "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}])
+                "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}]
+        if state.get("multiple_candidates"):
+            releases.append({**releases[0], "name": "cloudflare-second"})
+        emit(releases)
     elif clean[0] == "history":
         entries = [{"revision": 1, "updated": "fixed",
                     "status": state.get("helm_history_status", "deployed"),
@@ -468,17 +471,53 @@ def deployment(dep_name, labels_, affinity):
         container = {"name": "cloudflared", "image": os.environ["AUDIT_EXPECTED_IMAGE"],
                      "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}}}
     return {"metadata": {"name": dep_name, "namespace": ns or "cloudflare", "uid": dep_name,
-                         "generation": 1, "labels": labels_},
-            "spec": {"replicas": 2, "selector": {"matchLabels": labels_},
+                         "generation": 1, "labels": dict(labels_)},
+            "spec": {"replicas": 2, "selector": {"matchLabels": dict(labels_)},
                      "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
-                     "template": {"metadata": {"labels": labels_},
+                     "template": {"metadata": {"labels": dict(labels_)},
                                   "spec": {"affinity": affinity, "containers": [container]}}},
             "status": {"readyReplicas": 2, "availableReplicas": 2}}
 if kind == "deployment" and args[2:3] == ["-A"]:
     dep = deployment("cloudflare", pod_labels, anti)
     dep["metadata"]["labels"]["app.kubernetes.io/name"] = "cloudflare-tunnel"
     dep["metadata"]["labels"]["app.kubernetes.io/instance"] = "cloudflare"
-    emit({"items": [dep]}); raise SystemExit()
+    dep["metadata"]["labels"]["app.kubernetes.io/managed-by"] = "Helm"
+    dep["metadata"]["labels"]["canary-label"] = "CONNECTOR-CANARY"
+    dep["metadata"]["annotations"] = {
+        "meta.helm.sh/release-name": "cloudflare",
+        "meta.helm.sh/release-namespace": "cloudflare",
+        "canary-annotation": "SECRET-CANARY",
+    }
+    ownership = state.get("ownership")
+    if ownership == "missing-managed-by":
+        dep["metadata"]["labels"].pop("app.kubernetes.io/managed-by")
+    elif ownership == "flux-managed":
+        dep["metadata"]["labels"]["app.kubernetes.io/managed-by"] = "Flux"
+    elif ownership == "missing-release-name":
+        dep["metadata"]["annotations"].pop("meta.helm.sh/release-name")
+    elif ownership == "wrong-release-namespace":
+        dep["metadata"]["annotations"]["meta.helm.sh/release-namespace"] = "other"
+    elif ownership == "conflicting-instance":
+        dep["metadata"]["labels"]["app.kubernetes.io/instance"] = "other"
+    items = [dep]
+    if state.get("dormant_flux"):
+        flux = deployment("dormant-flux", pod_labels, anti)
+        flux["metadata"]["labels"].update({"app.kubernetes.io/name": "cloudflare-tunnel",
+                                             "app.kubernetes.io/instance": "cloudflare",
+                                             "app.kubernetes.io/managed-by": "Flux",
+                                             "flux-canary": "CONNECTOR-CANARY"})
+        items.append(flux)
+    if state.get("multiple_candidates"):
+        second = deployment("cloudflare-second", pod_labels, anti)
+        second["metadata"]["labels"].update({"app.kubernetes.io/name": "cloudflare-tunnel",
+                                               "app.kubernetes.io/instance": "cloudflare-second",
+                                               "app.kubernetes.io/managed-by": "Helm"})
+        second["metadata"]["annotations"] = {
+            "meta.helm.sh/release-name": "cloudflare-second",
+            "meta.helm.sh/release-namespace": "cloudflare",
+        }
+        items.append(second)
+    emit({"items": [] if state.get("zero_candidates") else items}); raise SystemExit()
 if kind == "deployment" and name in ("coredns", "coredns-ha", "traefik"):
     lab = {"app.kubernetes.io/name": name}
     emit(deployment(name, lab, traefik_anti if name == "traefik" else anti)); raise SystemExit()
@@ -486,9 +525,10 @@ if kind == "pods":
     one = state.get("gap") and ns == "kube-system"
     emit({"items": [pod("a", "sugarkube0")] + ([] if one else [pod("b", "sugarkube1")])})
 elif kind == "pdb":
+    pdb_selector = {"other": "workload"} if state.get("pdb_selector_mismatch") else pod_labels
     emit({"items": [] if ns == "kube-system" else
           [{"metadata": {"name": "cloudflare-pdb"},
-            "spec": {"selector": {"matchLabels": pod_labels}, "minAvailable": 1}}]})
+            "spec": {"selector": {"matchLabels": pdb_selector}, "minAvailable": 1}}]})
 elif kind == "endpointslices.discovery.k8s.io":
     service = next(x.split("=", 1)[1] for x in args if x.startswith("kubernetes.io/service-name="))
     emit({"items": [{"metadata": {"labels": {"kubernetes.io/service-name": service}},
@@ -505,13 +545,16 @@ elif kind == "helmchartconfig":
           "        topologyKey: kubernetes.io/hostname\n"}})
 elif kind == "service":
     emit({"items": [{"metadata": {"name": "cloudflare-metrics", "labels": {"monitor": "cloudflare"}},
-                     "spec": {"selector": pod_labels, "ports": [{"name": "metrics", "port": 2000,
-                                                                   "targetPort": 2000}]}}]})
+                     "spec": {"selector": ({"other": "workload"}
+                                             if state.get("service_selector_mismatch") else pod_labels),
+                              "ports": [{"name": "metrics", "port": (9090 if state.get("port_mismatch") else 2000),
+                                         "targetPort": 2000}]}}]})
 elif kind == "servicemonitor":
     emit({"items": [{"metadata": {"name": "cloudflare"},
-                     "spec": {"selector": {"matchLabels": {"monitor": "cloudflare"}},
-                              "namespaceSelector": {"matchNames": ["cloudflare"]},
-                              "endpoints": [{"port": "metrics", "path": "/metrics"}]}}]})
+                     "spec": {"selector": {"matchLabels": ({"other": "service"}
+                                      if state.get("monitor_selector_mismatch") else {"monitor": "cloudflare"})},
+                              "namespaceSelector": {"matchNames": ["other" if state.get("namespace_mismatch") else "cloudflare"]},
+                              "endpoints": [{"port": "metrics", "path": ("/wrong" if state.get("path_mismatch") else "/metrics")}]}}]})
 else:
     print("unexpected fake kubectl invocation", args, file=sys.stderr); raise SystemExit(9)
 """
@@ -650,6 +693,122 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+def test_cli_cloudflare_evidence_proves_sanitized_helm_ownership_and_bindings(
+    audit_harness,
+) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("ownership-evidence")
+    assert result.returncode == 0
+    tunnel = json.loads((evidence / "audit.json").read_text())["observed"]["cloudflareTunnel"]
+    assert tunnel["helmOwnership"] == {
+        "managedBy": "Helm",
+        "releaseName": "cloudflare",
+        "releaseNamespace": "cloudflare",
+        "managedByHelm": True,
+        "instanceMatchesRelease": True,
+        "namespaceMatchesDeployment": True,
+        "matchesUniqueHelmRelease": True,
+    }
+    assert tunnel["pdb"] == [
+        {
+            "name": "cloudflare-pdb",
+            "minAvailable": 1,
+            "maxUnavailable": None,
+            "selectorTargetsWorkload": True,
+        }
+    ]
+    assert tunnel["metrics"] == {
+        "services": [
+            {
+                "name": "cloudflare-metrics",
+                "type": "ClusterIP",
+                "selectorTargetsWorkload": True,
+                "metricsPortName": "metrics",
+                "port": 2000,
+                "targetPort": 2000,
+            }
+        ],
+        "serviceMonitors": [
+            {
+                "name": "cloudflare",
+                "selectorTargetsService": True,
+                "namespaceTargetsRelease": True,
+                "endpointPort": "metrics",
+                "endpointPath": "/metrics",
+            }
+        ],
+    }
+    encoded = "".join(path.read_text() for path in evidence.iterdir())
+    assert "canary-label" not in encoded
+    assert "canary-annotation" not in encoded
+    assert "SECRET-CANARY" not in encoded
+    assert "CONNECTOR-CANARY" not in encoded
+
+
+@pytest.mark.parametrize(
+    "ownership",
+    [
+        "missing-managed-by",
+        "flux-managed",
+        "missing-release-name",
+        "wrong-release-namespace",
+        "conflicting-instance",
+    ],
+)
+def test_cli_invalid_ownership_cannot_become_release_candidate(audit_harness, ownership) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("invalid-ownership-" + ownership, ownership=ownership)
+    assert result.returncode == 2
+    assert (
+        result.stderr
+        == "HARD_FAILURE: expected exactly one live Cloudflare release candidate; found 0\n"
+    )
+    assert not evidence.exists()
+
+
+def test_cli_dormant_flux_deployment_is_ignored(audit_harness) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("dormant-flux", dormant_flux=True)
+    assert result.returncode == 0
+    encoded = "".join(path.read_text() for path in evidence.iterdir())
+    assert '"managedBy": "Helm"' in encoded
+    assert "Flux" not in encoded
+    assert "CONNECTOR-CANARY" not in encoded
+
+
+@pytest.mark.parametrize(
+    ("scenario", "count"), [({"zero_candidates": True}, 0), ({"multiple_candidates": True}, 2)]
+)
+def test_cli_candidate_cardinality_is_a_sanitized_hard_failure(
+    audit_harness, scenario, count
+) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("candidate-cardinality-" + str(count), **scenario)
+    assert result.returncode == 2
+    assert result.stderr == (
+        f"HARD_FAILURE: expected exactly one live Cloudflare release candidate; found {count}\n"
+    )
+    assert not evidence.exists()
+
+
+@pytest.mark.parametrize(
+    ("scenario", "gap"),
+    [
+        ({"pdb_selector_mismatch": True}, "CF_PDB_MISSING"),
+        ({"service_selector_mismatch": True}, "CF_METRICS_DISCOVERY_MISSING"),
+        ({"monitor_selector_mismatch": True}, "CF_METRICS_DISCOVERY_MISSING"),
+        ({"port_mismatch": True}, "CF_METRICS_DISCOVERY_MISSING"),
+        ({"namespace_mismatch": True}, "CF_METRICS_DISCOVERY_MISSING"),
+        ({"path_mismatch": True}, "CF_METRICS_DISCOVERY_MISSING"),
+    ],
+)
+def test_cli_resource_binding_mismatches_retain_stable_gaps(audit_harness, scenario, gap) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("binding-mismatch-" + next(iter(scenario)), **scenario)
+    assert result.returncode == 0
+    assert gap in json.loads((evidence / "audit.json").read_text())["gaps"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -72,6 +72,72 @@ def test_conflicting_duplicate_endpoint_fails_closed() -> None:
     assert result["unhealthyEndpoints"] == 1
 
 
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        {"addresses": ["10.0.0.1"], "conditions": {"ready": "false"}},
+        {"addresses": ["10.0.0.1"], "conditions": {"serving": 1}},
+        {"addresses": ["10.0.0.1"], "conditions": {"terminating": None}},
+        {"addresses": []},
+        {"addresses": [""]},
+        {"addresses": [1]},
+        {"addresses": ["10.0.0.1"], "nodeName": ""},
+        {"addresses": ["10.0.0.1"], "nodeName": 1},
+        {"addresses": ["10.0.0.1"], "targetRef": []},
+        {"addresses": ["10.0.0.1"], "targetRef": {"uid": 1}},
+    ],
+)
+def test_endpoint_slices_reject_malformed_endpoint_fields(endpoint) -> None:
+    with pytest.raises(audit.HardFailure, match="^malformed EndpointSlice entry$"):
+        audit.endpoints(slices([[endpoint]]), "traefik")
+
+
+def test_endpoint_target_api_version_is_part_of_duplicate_identity() -> None:
+    common = {
+        "addresses": ["10.0.0.1"],
+        "nodeName": "a",
+        "targetRef": {"kind": "Pod", "name": "pod", "uid": "uid"},
+    }
+    first = {**common, "targetRef": {**common["targetRef"], "apiVersion": "v1"}}
+    second = {**common, "targetRef": {**common["targetRef"], "apiVersion": "v2"}}
+    result = audit.endpoints(slices([[first, second]]), "traefik")
+    assert result["uniqueEndpoints"] == result["healthyEndpoints"] == 2
+    assert "apiVersion" not in json.dumps(result)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {"status": "error", "data": {"result": []}},
+        {"status": "success", "data": []},
+        {"status": "success", "data": {"result": {}}},
+        {"status": "success", "data": {"result": [{"value": [0, "1"]}, {"value": [0, "2"]}]}},
+        {"status": "success", "data": {"result": [{}]}},
+        {"status": "success", "data": {"result": [{"value": [0]}]}},
+        {"status": "success", "data": {"result": [{"value": ["bad", "1"]}]}},
+        {"status": "success", "data": {"result": [{"value": [0, "1.5"]}]}},
+        {"status": "success", "data": {"result": [{"value": [0, "-1"]}]}},
+        {"status": "success", "data": {"result": [{"value": [0, "NaN"]}]}},
+    ],
+)
+def test_prom_count_rejects_invalid_aggregates(monkeypatch, response) -> None:
+    monkeypatch.setattr(audit, "kubectl", lambda *args: response)
+    with pytest.raises(audit.HardFailure, match="^Prometheus returned an invalid aggregate$"):
+        audit.prom_count("sum(up)")
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [([], 0), ([{"metric": {"raw": "SECRET-CANARY"}, "value": [0, "2"]}], 2)],
+)
+def test_prom_count_accepts_valid_sanitized_aggregates(monkeypatch, result, expected) -> None:
+    monkeypatch.setattr(
+        audit, "kubectl", lambda *args: {"status": "success", "data": {"result": result}}
+    )
+    assert audit.prom_count("sum(up)") == expected
+
+
 def test_deployment_snapshot_keeps_secret_reference_but_not_value() -> None:
     dep = {
         "metadata": {"name": "tunnel", "namespace": "cf", "uid": "pod-uid"},
@@ -445,8 +511,18 @@ if args[:2] == ["get", "--raw"]:
                          "annotations": {"description": "SECRET-CANARY"}})
         emit({"status": "success", "data": {"groups": [{"rules": rules}]}})
         raise SystemExit()
+    if state.get("prom_invalid"):
+        response = {"data": {"result": [
+            {"metric": {"connector": "CONNECTOR-CANARY"},
+             "value": [0, "credential=SECRET-CANARY"]}]}}
+        if not state.get("prom_missing_status"):
+            response["status"] = "error"
+        emit(response)
+        raise SystemExit()
     count = 0 if "ALERTS" in args[2] else 2
-    emit({"data": {"result": [{"value": [0, str(count)]}]}}); raise SystemExit()
+    emit({"status": "success", "data": {"result": [
+        {"metric": {"connector": "CONNECTOR-CANARY", "credential": "SECRET-CANARY"},
+         "value": [0, str(count)]}]}}); raise SystemExit()
 
 ns = None
 if args[:1] in (["-n"], ["--namespace"]):
@@ -693,6 +769,22 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize(
+    "scenario", [{"prom_invalid": True}, {"prom_invalid": True, "prom_missing_status": True}]
+)
+def test_cli_invalid_prometheus_aggregate_is_sanitized_hard_failure(
+    audit_harness, scenario
+) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("prometheus-invalid-" + str(scenario), **scenario)
+    combined = result.stdout + result.stderr
+    assert result.returncode == 2
+    assert result.stderr == "HARD_FAILURE: Prometheus returned an invalid aggregate\n"
+    assert "SECRET-CANARY" not in combined
+    assert "CONNECTOR-CANARY" not in combined
+    assert not evidence.exists()
 
 
 def test_cli_cloudflare_evidence_proves_sanitized_helm_ownership_and_bindings(

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -135,3 +136,40 @@ def test_target_manifest_is_canonical_and_narrow() -> None:
     targets = json.loads((ROOT / "config/prod-resilience-audit-targets.json").read_text())
     assert sorted(targets) == ["danielsmith.io", "democratized.space", "token.place"]
     assert all(path.startswith("/") for paths in targets.values() for path in paths)
+
+
+@pytest.mark.parametrize("value", [0, "0"])
+def test_int_or_string_comparison_accepts_kubernetes_encodings(value) -> None:
+    assert audit.int_or_string_equals(value, 0)
+
+
+@pytest.mark.parametrize("value", [None, 1, "1", False])
+def test_int_or_string_comparison_rejects_other_values(value) -> None:
+    assert not audit.int_or_string_equals(value, 0)
+
+
+def test_runner_failure_includes_bounded_diagnostics(monkeypatch) -> None:
+    result = subprocess.CompletedProcess(
+        ["kubectl", "get", "nodes"], 7, stderr="permission denied " + "x" * 600
+    )
+    monkeypatch.setattr(audit.subprocess, "run", lambda *args, **kwargs: result)
+
+    with pytest.raises(audit.HardFailure) as caught:
+        audit.run(["kubectl", "get", "nodes"])
+
+    message = str(caught.value)
+    assert "exit 7" in message
+    assert "kubectl get nodes" in message
+    assert "permission denied" in message
+    assert len(message) < 600
+
+
+def test_successful_status_with_transport_error_is_unhealthy() -> None:
+    assert audit.probes_unhealthy([{"status": 200, "error": "transport"}])
+    assert not audit.probes_unhealthy([{"status": 204}])
+
+
+@pytest.mark.parametrize("targets", [{}, {"example.com": []}, []])
+def test_empty_probe_targets_fail_closed(targets) -> None:
+    with pytest.raises(audit.HardFailure, match="target manifest"):
+        audit.probe_urls(targets)

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -138,6 +138,19 @@ def test_internal_runner_rejects_mutation_before_execution(monkeypatch, argv) ->
         ["kubectl", "get", "secrets", "-A", "-o", "json"],
         ["kubectl", "-n", "default", "get", "secret", "token", "-o", "json"],
         ["kubectl", "get", "--raw", "/api/v1/namespaces/default/secrets"],
+        ["kubectl", "get", "--raw", audit.PROMETHEUS_ALERT_RULES_PATH + "&x=1"],
+        [
+            "kubectl",
+            "get",
+            "--raw",
+            audit.PROMETHEUS_ALERT_RULES_PATH.replace("monitoring", "default"),
+        ],
+        [
+            "kubectl",
+            "get",
+            "--raw",
+            audit.PROMETHEUS_ALERT_RULES_PATH.replace("type=alert", "type=record"),
+        ],
         ["kubectl", "get", "nodes", "-o", "yaml"],
         ["kubectl", "get", "nodes", "-o", "json", "--show-labels"],
         ["kubectl", "get", "nodes", "--unknown"],
@@ -315,6 +328,26 @@ if args[:3] == ["config", "view", "--minify"]:
 if args[:3] == ["get", "--raw", "/readyz?verbose"]:
     emit("readyz check passed\n[+]etcd ok"); raise SystemExit()
 if args[:2] == ["get", "--raw"]:
+    if args[2].endswith("/api/v1/rules?type=alert"):
+        if state.get("alert_malformed"):
+            emit({"status": "success", "data": {"groups": "credential=SECRET-CANARY"}})
+            raise SystemExit()
+        rules = [
+            {"name": "CloudflareTunnelNoHealthyConnections", "health": "ok"},
+            {"name": "CloudflareTunnelConnectionsDegraded", "health": "ok"},
+            {"name": "CloudflareTunnelMetricsTargetsDown", "health": "ok"},
+        ]
+        if state.get("alert_missing"):
+            rules.pop()
+        if state.get("alert_unhealthy"):
+            rules[0]["health"] = "err"
+        if state.get("alert_duplicate"):
+            rules.append(dict(rules[0]))
+        for rule in rules:
+            rule.update({"query": "credential=SECRET-CANARY", "labels": {"connector": "CONNECTOR-CANARY"},
+                         "annotations": {"description": "SECRET-CANARY"}})
+        emit({"status": "success", "data": {"groups": [{"rules": rules}]}})
+        raise SystemExit()
     count = 0 if "ALERTS" in args[2] else 2
     emit({"data": {"result": [{"value": [0, str(count)]}]}}); raise SystemExit()
 
@@ -519,6 +552,41 @@ def test_cli_completed_gap_exit_contract(audit_harness) -> None:
     assert required.returncode == 1
     assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert required_evidence.exists()
+
+
+@pytest.mark.parametrize(
+    ("scenario", "gap"),
+    [
+        ({}, None),
+        ({"alert_missing": True}, "CF_ALERT_RULE_SET_MISMATCH"),
+        ({"alert_duplicate": True}, "CF_ALERT_RULE_SET_MISMATCH"),
+        ({"alert_unhealthy": True}, "CF_ALERT_RULES_UNHEALTHY"),
+    ],
+)
+def test_cli_alert_rule_parity_is_sanitized(audit_harness, scenario, gap) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("alerts-" + (gap or "healthy") + str(scenario), **scenario)
+    assert result.returncode == 0
+    document = json.loads((evidence / "audit.json").read_text())
+    assert (
+        (gap in document["gaps"])
+        if gap
+        else not any(code.startswith("CF_ALERT_RULE") for code in document["gaps"])
+    )
+    combined = (
+        result.stdout + result.stderr + "".join(path.read_text() for path in evidence.iterdir())
+    )
+    for canary in ("SECRET-CANARY", "CONNECTOR-CANARY", "credential", "annotations", "query"):
+        assert canary not in combined
+
+
+def test_cli_malformed_alert_rules_are_a_sanitized_hard_failure(audit_harness) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute("alerts-malformed", alert_malformed=True)
+    assert result.returncode == 2
+    assert not evidence.exists()
+    assert result.stderr.strip() == "HARD_FAILURE: Prometheus returned malformed alert rules"
+    assert "SECRET-CANARY" not in result.stdout + result.stderr
 
 
 def test_cli_compliant_fixture_covers_in_process_collection(audit_harness, monkeypatch) -> None:

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -456,20 +456,27 @@ if tool == "helm":
         releases = [{ "name": "cloudflare", "namespace": "cloudflare",
                 "status": state.get("helm_list_status", "deployed"),
                 "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
-                "revision": state.get("helm_revision", "1"),
+                "revision": state.get("helm_revision", 2 if state.get("reverse_order") else "2"),
                 "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}]
         if state.get("multiple_candidates"):
             releases.append({**releases[0], "name": "cloudflare-second"})
         emit(releases)
     elif clean[0] == "history":
-        entries = [{"revision": 1, "updated": "fixed",
-                    "status": state.get("helm_history_status", "deployed"),
-                    "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
-                    "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"}]
+        revision = (lambda value: str(value)) if state.get("reverse_order") else (lambda value: value)
+        entries = [
+            {"revision": revision(1), "updated": "older", "status": "superseded",
+             "chart": "cloudflare-tunnel-0.3.1", "app_version": "2026.7.2"},
+            {"revision": revision(2), "updated": "fixed",
+             "status": state.get("helm_history_status", "deployed"),
+             "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3",
+             "config": "credential=SECRET-CANARY", "manifest": "CONNECTOR-CANARY"},
+        ]
         if state.get("helm_history_missing"):
-            entries[0]["revision"] = 2
+            entries[1]["revision"] = revision(3)
         if state.get("helm_history_duplicate"):
-            entries.append(dict(entries[0]))
+            entries.append(dict(entries[1]))
+        if state.get("reverse_order"):
+            entries.reverse()
         emit(entries)
     raise SystemExit()
 
@@ -602,9 +609,15 @@ if kind == "pods":
     emit({"items": [pod("a", "sugarkube0")] + ([] if one else [pod("b", "sugarkube1")])})
 elif kind == "pdb":
     pdb_selector = {"other": "workload"} if state.get("pdb_selector_mismatch") else pod_labels
-    emit({"items": [] if ns == "kube-system" else
-          [{"metadata": {"name": "cloudflare-pdb"},
-            "spec": {"selector": {"matchLabels": pdb_selector}, "minAvailable": 1}}]})
+    pdb_items = [
+        {"metadata": {"name": "cloudflare-pdb"},
+         "spec": {"selector": {"matchLabels": pdb_selector}, "minAvailable": 1}},
+        {"metadata": {"name": "cloudflare-pdb-secondary"},
+         "spec": {"selector": {"matchLabels": pdb_selector}, "minAvailable": 1}},
+    ]
+    if state.get("reverse_order"):
+        pdb_items.reverse()
+    emit({"items": [] if ns == "kube-system" else pdb_items})
 elif kind == "endpointslices.discovery.k8s.io":
     service = next(x.split("=", 1)[1] for x in args if x.startswith("kubernetes.io/service-name="))
     emit({"items": [{"metadata": {"labels": {"kubernetes.io/service-name": service}},
@@ -620,17 +633,34 @@ elif kind == "helmchartconfig":
           "          matchLabels:\n            app.kubernetes.io/name: traefik\n"
           "        topologyKey: kubernetes.io/hostname\n"}})
 elif kind == "service":
-    emit({"items": [{"metadata": {"name": "cloudflare-metrics", "labels": {"monitor": "cloudflare"}},
-                     "spec": {"selector": ({"other": "workload"}
-                                             if state.get("service_selector_mismatch") else pod_labels),
-                              "ports": [{"name": "metrics", "port": (9090 if state.get("port_mismatch") else 2000),
-                                         "targetPort": 2000}]}}]})
+    service_items = [
+        {"metadata": {"name": "cloudflare-metrics", "labels": {"monitor": "cloudflare"}},
+         "spec": {"selector": ({"other": "workload"}
+                                 if state.get("service_selector_mismatch") else pod_labels),
+                  "ports": [{"name": "metrics", "port": (9090 if state.get("port_mismatch") else 2000),
+                             "targetPort": 2000}]}},
+        {"metadata": {"name": "unrelated-metrics", "labels": {"monitor": "unrelated"}},
+         "spec": {"selector": {"other": "workload"},
+                  "ports": [{"name": "metrics", "port": 9090, "targetPort": 9090}]}},
+    ]
+    if state.get("reverse_order"):
+        service_items.reverse()
+    emit({"items": service_items})
 elif kind == "servicemonitor":
-    emit({"items": [{"metadata": {"name": "cloudflare"},
-                     "spec": {"selector": {"matchLabels": ({"other": "service"}
-                                      if state.get("monitor_selector_mismatch") else {"monitor": "cloudflare"})},
-                              "namespaceSelector": {"matchNames": ["other" if state.get("namespace_mismatch") else "cloudflare"]},
-                              "endpoints": [{"port": "metrics", "path": ("/wrong" if state.get("path_mismatch") else "/metrics")}]}}]})
+    monitor_items = [
+        {"metadata": {"name": "cloudflare"},
+         "spec": {"selector": {"matchLabels": ({"other": "service"}
+                          if state.get("monitor_selector_mismatch") else {"monitor": "cloudflare"})},
+                  "namespaceSelector": {"matchNames": ["other" if state.get("namespace_mismatch") else "cloudflare"]},
+                  "endpoints": [{"port": "metrics", "path": ("/wrong" if state.get("path_mismatch") else "/metrics")}]}},
+        {"metadata": {"name": "unrelated"},
+         "spec": {"selector": {"matchLabels": {"monitor": "unrelated"}},
+                  "namespaceSelector": {"matchNames": ["other"]},
+                  "endpoints": [{"port": "other", "path": "/other"}]}},
+    ]
+    if state.get("reverse_order"):
+        monitor_items.reverse()
+    emit({"items": monitor_items})
 else:
     print("unexpected fake kubectl invocation", args, file=sys.stderr); raise SystemExit(9)
 """
@@ -701,10 +731,14 @@ def test_cli_identity_guards_fail_without_evidence(audit_harness, label, scenari
 def test_cli_compliant_gap_determinism_sanitization_and_read_only_log(audit_harness) -> None:
     execute, log = audit_harness
     first, first_dir = execute("compliant-one")
-    second, second_dir = execute("compliant-two")
+    second, second_dir = execute("compliant-two", reverse_order=True)
     failed, failed_dir = execute("endpoint-error", failed_probe=True)
     assert first.returncode == second.returncode == failed.returncode == 0
-    assert json.loads((first_dir / "audit.json").read_text())["result"] == "PARITY_OK"
+    first_audit = json.loads((first_dir / "audit.json").read_text())
+    assert first_audit["result"] == "PARITY_OK"
+    tunnel = first_audit["observed"]["cloudflareTunnel"]
+    assert tunnel["revision"] == 2
+    assert [record["revision"] for record in tunnel["history"]] == [1, 2]
     assert json.loads((failed_dir / "audit.json").read_text())["result"] == "PARITY_GAPS"
     assert {p.name for p in first_dir.iterdir()} == {
         "audit.json",
@@ -809,7 +843,13 @@ def test_cli_cloudflare_evidence_proves_sanitized_helm_ownership_and_bindings(
             "minAvailable": 1,
             "maxUnavailable": None,
             "selectorTargetsWorkload": True,
-        }
+        },
+        {
+            "name": "cloudflare-pdb-secondary",
+            "minAvailable": 1,
+            "maxUnavailable": None,
+            "selectorTargetsWorkload": True,
+        },
     ]
     assert tunnel["metrics"] == {
         "services": [
@@ -820,7 +860,15 @@ def test_cli_cloudflare_evidence_proves_sanitized_helm_ownership_and_bindings(
                 "metricsPortName": "metrics",
                 "port": 2000,
                 "targetPort": 2000,
-            }
+            },
+            {
+                "name": "unrelated-metrics",
+                "type": "ClusterIP",
+                "selectorTargetsWorkload": False,
+                "metricsPortName": "metrics",
+                "port": 9090,
+                "targetPort": 9090,
+            },
         ],
         "serviceMonitors": [
             {
@@ -829,7 +877,14 @@ def test_cli_cloudflare_evidence_proves_sanitized_helm_ownership_and_bindings(
                 "namespaceTargetsRelease": True,
                 "endpointPort": "metrics",
                 "endpointPath": "/metrics",
-            }
+            },
+            {
+                "name": "unrelated",
+                "selectorTargetsService": False,
+                "namespaceTargetsRelease": False,
+                "endpointPort": "other",
+                "endpointPath": "/other",
+            },
         ],
     }
     encoded = "".join(path.read_text() for path in evidence.iterdir())
@@ -918,7 +973,7 @@ def test_cli_traffic_policy_is_observed_without_an_unsupported_gap(audit_harness
     )
 
 
-@pytest.mark.parametrize("scenario", [{}, {"helm_revision": 1}])
+@pytest.mark.parametrize("scenario", [{}, {"helm_revision": 2}])
 def test_cli_helm_list_and_current_history_deployed_pass(audit_harness, scenario) -> None:
     execute, _ = audit_harness
     result, evidence = execute("helm-deployed-" + str(scenario), **scenario)

--- a/tests/test_prod_resilience_audit.py
+++ b/tests/test_prod_resilience_audit.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -209,3 +212,253 @@ def test_traefik_desired_snapshot_never_retains_raw_values() -> None:
     )
     assert result == {"replicas": 2, "requiredHostnameAntiAffinity": True}
     assert "do-not-retain" not in json.dumps(result)
+
+
+FAKE_TOOL = r"""#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+
+state = json.loads(Path(os.environ["AUDIT_FAKE_STATE"]).read_text())
+with Path(os.environ["AUDIT_COMMAND_LOG"]).open("a") as stream:
+    stream.write(json.dumps([Path(sys.argv[0]).name, *sys.argv[1:]]) + "\n")
+tool, args = Path(sys.argv[0]).name, sys.argv[1:]
+
+def emit(value):
+    print(json.dumps(value) if not isinstance(value, str) else value)
+
+labels = {"sugarkube.env": "prod", "sugarkube.cluster": "sugar-prod"}
+node_names = state.get("nodes", ["sugarkube0", "sugarkube1", "sugarkube2"])
+nodes = {"items": [{"metadata": {"name": n, "labels": labels},
+                    "status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+                   for n in node_names]}
+if tool == "git":
+    emit("0123456789abcdef0123456789abcdef01234567"); raise SystemExit()
+if tool == "curl":
+    print("credential=SECRET-CANARY connector=CONNECTOR-CANARY", file=sys.stderr)
+    if state.get("failed_probe") and args[-1].endswith("/healthz"):
+        emit("000\t0.01\t0.00\t0.02"); raise SystemExit(28)
+    emit("204\t0.01\t0.02\t0.03"); raise SystemExit()
+if tool == "helm":
+    clean = args[2:] if args[:1] in (["-n"], ["--namespace"]) else args
+    if clean[0] == "list":
+        emit([{ "name": "cloudflare", "namespace": "cloudflare", "status": "deployed",
+                "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3", "revision": "1"}])
+    elif clean[0] == "history":
+        emit([{"revision": 1, "updated": "fixed", "status": "deployed",
+               "chart": "cloudflare-tunnel-0.3.2", "app_version": "2026.7.3"}])
+    else:
+        emit({"info": {"status": "deployed"}})
+    raise SystemExit()
+
+identity = args[:1] == ["--kubeconfig"]
+if identity:
+    args = args[2:]
+if args == ["config", "current-context"]:
+    emit(state.get("context", "sugar-prod")); raise SystemExit()
+if identity and args[:2] == ["get", "nodes"] and state.get("identity_fail"):
+    print("credential=SECRET-CANARY connector=CONNECTOR-CANARY", file=sys.stderr)
+    raise SystemExit(1)
+if args[:2] == ["get", "nodes"]:
+    emit(nodes); raise SystemExit()
+if args[:3] == ["config", "view", "--minify"]:
+    emit("https://sanitized.invalid"); raise SystemExit()
+if args[:3] == ["get", "--raw", "/readyz?verbose"]:
+    emit("readyz check passed\n[+]etcd ok"); raise SystemExit()
+if args[:2] == ["get", "--raw"]:
+    count = 0 if "ALERTS" in args[2] else 2
+    emit({"data": {"result": [{"value": [0, str(count)]}]}}); raise SystemExit()
+
+ns = None
+if args[:1] in (["-n"], ["--namespace"]):
+    ns, args = args[1], args[2:]
+kind = args[1] if args[:1] == ["get"] and len(args) > 1 else ""
+name = args[2] if len(args) > 2 and not args[2].startswith("-") else ""
+pod_labels = {"app": "cloudflare"}
+anti = {"podAntiAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": [
+    {"topologyKey": "kubernetes.io/hostname", "labelSelector": {"matchLabels": pod_labels}}
+]}}
+traefik_anti = {"podAntiAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": [
+    {"topologyKey": "kubernetes.io/hostname",
+     "labelSelector": {"matchLabels": {"app.kubernetes.io/name": "traefik"}}}
+]}}
+def pod(uid, node):
+    return {"metadata": {"uid": uid}, "spec": {"nodeName": node},
+            "status": {"conditions": [{"type": "Ready", "status": "True"}],
+                       "containerStatuses": [{"restartCount": 0}]}}
+def deployment(dep_name, labels_, affinity):
+    container = {"name": dep_name, "image": "unused"}
+    if dep_name == "cloudflare":
+        container = {"name": "cloudflared", "image": os.environ["AUDIT_EXPECTED_IMAGE"],
+                     "readinessProbe": {"httpGet": {"path": "/ready", "port": 2000}}}
+    return {"metadata": {"name": dep_name, "namespace": ns or "cloudflare", "uid": dep_name,
+                         "generation": 1, "labels": labels_},
+            "spec": {"replicas": 2, "selector": {"matchLabels": labels_},
+                     "strategy": {"rollingUpdate": {"maxUnavailable": 0, "maxSurge": 1}},
+                     "template": {"metadata": {"labels": labels_},
+                                  "spec": {"affinity": affinity, "containers": [container]}}},
+            "status": {"readyReplicas": 2, "availableReplicas": 2}}
+if kind == "deployment" and args[2:3] == ["-A"]:
+    dep = deployment("cloudflare", pod_labels, anti)
+    dep["metadata"]["labels"]["app.kubernetes.io/name"] = "cloudflare-tunnel"
+    dep["metadata"]["labels"]["app.kubernetes.io/instance"] = "cloudflare"
+    emit({"items": [dep]}); raise SystemExit()
+if kind == "deployment" and name in ("coredns", "coredns-ha", "traefik"):
+    lab = {"app.kubernetes.io/name": name}
+    emit(deployment(name, lab, traefik_anti if name == "traefik" else anti)); raise SystemExit()
+if kind == "pods":
+    one = state.get("gap") and ns == "kube-system"
+    emit({"items": [pod("a", "sugarkube0")] + ([] if one else [pod("b", "sugarkube1")])})
+elif kind == "pdb":
+    emit({"items": [] if ns == "kube-system" else
+          [{"metadata": {"name": "cloudflare-pdb"},
+            "spec": {"selector": {"matchLabels": pod_labels}, "minAvailable": 1}}]})
+elif kind == "endpointslices.discovery.k8s.io":
+    service = next(x.split("=", 1)[1] for x in args if x.startswith("kubernetes.io/service-name="))
+    emit({"items": [{"metadata": {"labels": {"kubernetes.io/service-name": service}},
+                     "endpoints": [{"addresses": ["10.0.0.1"], "nodeName": "sugarkube0", "conditions": {}},
+                                   {"addresses": ["10.0.0.2"], "nodeName": "sugarkube1", "conditions": {}}]}]})
+elif kind == "service" and name == "traefik":
+    emit({"spec": {"internalTrafficPolicy": "Local"}})
+elif kind == "helmchartconfig":
+    emit({"metadata": {"uid": "hcc"}, "spec": {"valuesContent":
+          "deployment:\n  replicas: 2\naffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n"
+          "    app.kubernetes.io/name: traefik\n    topologyKey: kubernetes.io/hostname\n"}})
+elif kind == "service":
+    emit({"items": [{"metadata": {"name": "cloudflare-metrics", "labels": {"monitor": "cloudflare"}},
+                     "spec": {"selector": pod_labels, "ports": [{"name": "metrics", "port": 2000,
+                                                                   "targetPort": 2000}]}}]})
+elif kind == "servicemonitor":
+    emit({"items": [{"metadata": {"name": "cloudflare"},
+                     "spec": {"selector": {"matchLabels": {"monitor": "cloudflare"}},
+                              "namespaceSelector": {"matchNames": ["cloudflare"]},
+                              "endpoints": [{"port": "metrics", "path": "/metrics"}]}}]})
+else:
+    print("unexpected fake kubectl invocation", args, file=sys.stderr); raise SystemExit(9)
+"""
+
+
+@pytest.fixture
+def audit_harness(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in ("kubectl", "helm", "curl", "git"):
+        path = bin_dir / name
+        path.write_text(FAKE_TOOL)
+        path.chmod(0o755)
+    state = tmp_path / "state.json"
+    log = tmp_path / "commands.jsonl"
+
+    def execute(label, *, cli_env="prod", require_parity=False, **scenario):
+        state.write_text(json.dumps(scenario))
+        evidence = tmp_path / label
+        env = os.environ.copy()
+        env.update(
+            PATH=f"{bin_dir}{os.pathsep}{env['PATH']}",
+            KUBECONFIG=str(tmp_path / "kubeconfig"),
+            AUDIT_FAKE_STATE=str(state),
+            AUDIT_COMMAND_LOG=str(log),
+            AUDIT_EXPECTED_IMAGE=audit.EXPECTED_IMAGE,
+            SUGARKUBE_AUDIT_TIMESTAMP="2026-08-12T00:00:00Z",
+        )
+        command = [
+            sys.executable,
+            str(ROOT / "scripts/prod_resilience_audit.py"),
+            cli_env,
+            "--evidence-dir",
+            str(evidence),
+        ]
+        if require_parity:
+            command.append("--require-parity")
+        result = subprocess.run(command, text=True, capture_output=True, env=env, check=False)
+        return result, evidence
+
+    return execute, log
+
+
+@pytest.mark.parametrize(
+    ("label", "scenario"),
+    [
+        ("invalid-env", {"cli_env": "staging"}),
+        ("wrong-context", {"context": "sugar-dev"}),
+        ("identity", {"identity_fail": True}),
+        ("nodes", {"nodes": ["sugarkube0"]}),
+    ],
+)
+def test_cli_identity_guards_fail_without_evidence(audit_harness, label, scenario) -> None:
+    execute, _ = audit_harness
+    result, evidence = execute(label, **scenario)
+    assert result.returncode == 2
+    assert not evidence.exists()
+    assert "HARD_FAILURE:" in result.stderr
+
+
+def test_cli_compliant_gap_determinism_sanitization_and_read_only_log(audit_harness) -> None:
+    execute, log = audit_harness
+    first, first_dir = execute("compliant-one")
+    second, second_dir = execute("compliant-two")
+    failed, failed_dir = execute("endpoint-error", failed_probe=True)
+    assert first.returncode == second.returncode == failed.returncode == 0
+    assert json.loads((first_dir / "audit.json").read_text())["result"] == "PARITY_OK"
+    assert json.loads((failed_dir / "audit.json").read_text())["result"] == "PARITY_GAPS"
+    assert {p.name for p in first_dir.iterdir()} == {
+        "audit.json",
+        "summary.md",
+        "endpoints.tsv",
+        "SHA256SUMS",
+    }
+    for name in ("audit.json", "summary.md", "endpoints.tsv", "SHA256SUMS"):
+        assert (first_dir / name).read_bytes() == (second_dir / name).read_bytes()
+    for line in (first_dir / "SHA256SUMS").read_text().splitlines():
+        digest, name = line.split("  ")
+        assert digest == hashlib.sha256((first_dir / name).read_bytes()).hexdigest()
+    combined = (
+        first.stdout
+        + first.stderr
+        + failed.stdout
+        + failed.stderr
+        + "".join(
+            path.read_text()
+            for directory in (first_dir, failed_dir)
+            for path in directory.iterdir()
+        )
+    )
+    assert "SECRET-CANARY" not in combined
+    assert "CONNECTOR-CANARY" not in combined
+    endpoint_text = (failed_dir / "endpoints.tsv").read_text()
+    assert "\tnone\n" in endpoint_text
+    assert "\ttimeout\n" in endpoint_text
+
+    commands = [json.loads(line) for line in log.read_text().splitlines()]
+    forbidden = {
+        "secret",
+        "logs",
+        "values",
+        "apply",
+        "delete",
+        "patch",
+        "exec",
+        "port-forward",
+        "rollout",
+        "flux",
+        "ssh",
+        "sudo",
+        "systemctl",
+    }
+    assert not any(forbidden.intersection(command) for command in commands)
+    assert all(command[0] in {"kubectl", "helm", "curl", "git"} for command in commands)
+    assert all(
+        command[1] in {"config", "get", "--kubeconfig", "-n"}
+        for command in commands
+        if command[0] == "kubectl"
+    )
+    assert all((command[1] in {"list", "-n"}) for command in commands if command[0] == "helm")
+
+
+def test_cli_completed_gap_exit_contract(audit_harness) -> None:
+    execute, _ = audit_harness
+    default, evidence = execute("gap-default", gap=True)
+    required, required_evidence = execute("gap-required", gap=True, require_parity=True)
+    assert default.returncode == 0
+    assert required.returncode == 1
+    assert json.loads((evidence / "audit.json").read_text())["result"] == "PARITY_GAPS"
+    assert required_evidence.exists()


### PR DESCRIPTION
### Motivation

Add the strictly read-only production resilience parity audit required before any production DNS/ingress or Cloudflare Tunnel HA rollout is designed or authorized. This follows the staging WAN drill recorded in #2407; #2408 remains separate application-replica work.

### Summary

- Add `just prod-resilience-audit env=prod --evidence-dir=<path>`, with optional `--require-parity`.
- Fail closed unless:
  - the environment normalizes exactly to `prod`;
  - the current Kubernetes context is exactly `sugar-prod`;
  - repository cluster-identity detection confirms `prod`;
  - the observed nodes are exactly `sugarkube0`, `sugarkube1`, and `sugarkube2`;
  - all required read-only tools are available.
- Enforce an exact operation allowlist before process execution. The audit cannot run Kubernetes, Helm, Flux, node, SSH, or WAN-drill mutation operations.
- Collect sanitized production DNS/ingress evidence covering node and API/etcd readiness, CoreDNS and Traefik replicas, pods, restarts, placement, rollout strategy, scheduling constraints, PDBs, deterministic EndpointSlice aggregation, Traefik `internalTrafficPolicy`, and structural lifecycle configuration.
- Classify missing, singleton, insufficiently spread, or unhealthy DNS/ingress components with stable parity-gap codes.
- Discover exactly one live Helm-owned Cloudflare Tunnel deployment/release from cluster state instead of assuming dormant Flux resources are authoritative.
- Record sanitized Cloudflare release metadata/history, ownership, deployment configuration, immutable image digest, replicas, rollout strategy, affinity/spread, readiness/liveness probes, PDB, metrics discovery, pod identity/readiness/placement, and aggregate Prometheus health.
- Compare the live tunnel with the staging-proven contract, including at least two Ready connectors on distinct nodes, safe rolling strategy, readiness-only `/ready`, private metrics discovery, healthy targets, and at least four HA connections per Ready connector. The audit does not select or apply a production replica count.
- Probe the approved production surfaces for `democratized.space`, `token.place`, and `danielsmith.io` using the narrowly scoped endpoints in `config/prod-resilience-audit-targets.json`. Requests run concurrently with independent bounds and retain only URL, status, bounded timing fields, and sanitized error classifications.
- Emit deterministic sanitized `audit.json`, `summary.md`, `endpoints.tsv`, and `SHA256SUMS` evidence.
- Return success when collection completes even if parity gaps exist; `--require-parity` returns nonzero for a completed audit containing gaps. Identity, collection, and sanitization failures remain distinct hard failures.
- Document the operator workflow and production safety boundary in `docs/production-resilience-audit.md`.

### Safety boundary

This PR performs no production deployment, patch, restart, deletion, reconciliation, rollout, or WAN/node-loss drill. It does not inspect Secret values, Helm values, pod logs, connector identifiers, raw Prometheus label sets, credentials, or user data.

The existing non-staging `cf-tunnel-install` behavior is not invoked or adapted as a production promotion path. Dormant `platform/cloudflared` and `clusters/*/patches/cloudflared-values.yaml` resources are not treated as live ownership.

Operators must review the captured evidence before designing a separate production lifecycle or rollout PR. Issue #2407 remains closed, and #2408 remains open and untouched.

### Testing

At head `36af8c39`:

- `python3 -m pytest -q tests/test_prod_resilience_audit.py` — 151 passed.
- `python3 -m pytest -q --cov=. --cov-report=term-missing tests/test_prod_resilience_audit.py` — 151 passed; `scripts/prod_resilience_audit.py` covered 502/557 statements, approximately 90.13%.
- `python3 -m pytest -q tests/test_prod_resilience_audit.py tests/test_cloudflare_tunnel_hardening.py tests/test_verify_cloudflare_tunnel.py tests/test_cloudflare_tunnel_token_mode.py tests/test_staging_ingress_ha.py` — 201 passed.
- `bash -n scripts/prod_resilience_audit.sh` — passed.
- `python3 -m py_compile scripts/prod_resilience_audit.py` — passed.
- `python3 -m black --check scripts/prod_resilience_audit.py tests/test_prod_resilience_audit.py` — passed.
- `git diff --check` — passed.
- Secret scanning reported no new secrets.
- Latest-head GitHub Actions completed successfully, including the relevant test, documentation, spellcheck, Justfile, unit, and OCI parity checks.
- `codecov/patch` passed with 90.12% of the diff covered against the 90.00% target.
- Event/path-inapplicable matrix jobs were skipped as expected.

The offline fixture suite covers exact identity guards, mutation rejection, Secret and connector-ID redaction, EndpointSlice semantics, missing/singleton/unspread/unhealthy/compliant components, deterministic Cloudflare release discovery, zero/multiple-candidate rejection, image and probe gaps, sanitized Prometheus aggregation, independent endpoint timeout isolation, deterministic evidence, exit behavior, and rejection of dormant Flux ownership.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bb3e6fc48832fa3fd49eb957e1e4c)