### PR TITLE
Allow canonical image.repository omission in DSPACE metrics reconciliation preflight

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -582,6 +582,29 @@ def assert_production_target(kubeconfig: str, runner: Runner) -> None:
     )
 
 
+def configuration_comparison_baselines(
+    live_values: dict[str, Any], desired_values: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build strict baselines, canonicalizing only an omitted live image repository."""
+    baseline = copy.deepcopy(live_values)
+    baseline.pop("metrics", None)
+    baseline.pop("serviceMonitor", None)
+    desired_baseline = copy.deepcopy(desired_values)
+    desired_baseline.pop("metrics", None)
+    desired_baseline.pop("serviceMonitor", None)
+
+    live_image = baseline.get("image")
+    desired_image = desired_baseline.get("image")
+    if not isinstance(live_image, dict) or not isinstance(desired_image, dict):
+        raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+    desired_repository = desired_image.get("repository")
+    if not isinstance(desired_repository, str) or desired_repository != release.IMAGE_REF:
+        raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+    if "repository" not in live_image:
+        live_image["repository"] = release.IMAGE_REF
+    return baseline, desired_baseline
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -771,12 +794,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             {"enabled": False},
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline = copy.deepcopy(live_values)
-        baseline.pop("metrics", None)
-        baseline.pop("serviceMonitor", None)
-        desired_baseline = copy.deepcopy(desired_values)
-        desired_baseline.pop("metrics", None)
-        desired_baseline.pop("serviceMonitor", None)
+        baseline, desired_baseline = configuration_comparison_baselines(
+            live_values, desired_values
+        )
         if baseline != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -190,7 +190,15 @@ def test_configuration_baselines_accept_only_canonical_repository_omission() -> 
 @pytest.mark.parametrize(
     ("live_image", "desired_repository", "extra_live_value"),
     [
-        ({"repository": "example.invalid/dspace", "tag": "main-abcdef0"}, manifest.IMAGE_REF, None),
+        (
+            {
+                "repository": "example.invalid/dspace",
+                "tag": "main-abcdef0",
+                "pullPolicy": "Always",
+            },
+            manifest.IMAGE_REF,
+            None,
+        ),
         ({"tag": "main-abcdef0", "pullPolicy": "Always"}, manifest.IMAGE_REF, True),
         ("not-a-mapping", manifest.IMAGE_REF, None),
         ({"tag": "main-abcdef0", "pullPolicy": "Always"}, None, None),

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -174,6 +174,52 @@ def test_production_confirmation_is_bound_to_full_target_sha() -> None:
     rollback.confirmation("staging", "", target())
 
 
+def test_configuration_baselines_accept_only_canonical_repository_omission() -> None:
+    image = {"tag": "main-abcdef0", "pullPolicy": "Always"}
+    desired = {"replicaCount": 2, "image": {**image, "repository": manifest.IMAGE_REF}}
+
+    omitted, expected = rollback.configuration_comparison_baselines(
+        {"replicaCount": 2, "image": image}, desired
+    )
+    explicit, _ = rollback.configuration_comparison_baselines(desired, desired)
+
+    assert omitted == expected == explicit
+    assert "repository" not in image
+
+
+@pytest.mark.parametrize(
+    ("live_image", "desired_repository", "extra_live_value"),
+    [
+        ({"repository": "example.invalid/dspace", "tag": "main-abcdef0"}, manifest.IMAGE_REF, None),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, manifest.IMAGE_REF, True),
+        ("not-a-mapping", manifest.IMAGE_REF, None),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, None, None),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, "", None),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, "example.invalid/dspace", None),
+    ],
+)
+def test_configuration_baselines_keep_all_other_drift_fail_closed(
+    live_image: object, desired_repository: object, extra_live_value: object
+) -> None:
+    live = {"image": live_image}
+    if extra_live_value is not None:
+        live["unrelated"] = extra_live_value
+    desired = {
+        "image": {
+            "repository": desired_repository,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        }
+    }
+
+    with pytest.raises(rollback.RollbackError, match="unrelated Helm values drift"):
+        live_baseline, desired_baseline = rollback.configuration_comparison_baselines(live, desired)
+        if live_baseline != desired_baseline:
+            raise rollback.RollbackError(
+                "unrelated Helm values drift blocks configuration reconciliation"
+            )
+
+
 def test_missing_or_candidate_target_fails_before_any_external_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -748,6 +794,7 @@ def test_configuration_reconciliation_requires_one_absolute_kubeconfig(
         ("manifest", "live manifest does not match"),
         ("contract", "desired production metrics contract is invalid"),
         ("baseline", "approved disabled baseline"),
+        ("monitor", "approved disabled baseline"),
         ("drift", "unrelated Helm values drift"),
         ("image", "live image coordinate differs"),
     ),
@@ -778,6 +825,8 @@ def test_configuration_reconciliation_preconditions_fail_before_reservation(
         desired = []
     elif failure == "baseline":
         live["metrics"] = {"enabled": True}
+    elif failure == "monitor":
+        live["serviceMonitor"] = {"enabled": True}
     elif failure == "drift":
         live["unrelated"] = True
 
@@ -1106,7 +1155,10 @@ def test_configuration_reconciliation_completes_all_production_gates(
             "cluster": "sugarkube-prod",
         },
     }
-    live = {"replicaCount": 2, "image": image}
+    live = {
+        "replicaCount": 2,
+        "image": {"tag": selected["imageTag"], "pullPolicy": "Always"},
+    }
     stored_proof = [{"check": "helmStoredValues", "passed": True, "details": "safe"}]
     finalized: dict[str, object] = {}
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)


### PR DESCRIPTION
### Motivation

- The production reconciliation rejected a valid release when the live Helm-stored values omitted `image.repository` while the desired contract explicitly set it to the chart-canonical `release.IMAGE_REF`. 
- The intent is to accept this single representation-only difference while preserving the existing fail-closed safety contract for all other provenance, credential, and unrelated-drift checks. 

### Description

- Added `configuration_comparison_baselines(live_values, desired_values)` in `scripts/dspace_manifest_rollback.py` which deep-copies baselines, strips `metrics` and `serviceMonitor`, and canonicalizes only the case where both `image` entries are mappings, the desired `image.repository` equals `release.IMAGE_REF`, and the live mapping omits `repository` (the live copy is given `repository: release.IMAGE_REF`); all other cases raise `RollbackError` so behavior remains fail-closed. 
- Replaced the prior ad-hoc baseline creation with a call to the new helper before performing the existing strict equality check so the only permitted normalization is the single omission case; every other difference (including non-mapping image values, malformed or noncanonical desired repository, explicit differing live repository, or any other unrelated drift) still blocks reconciliation. 
- Added focused regression tests in `tests/test_manifest_rollback.py` that cover: the omitted canonical repository acceptance, explicit canonical repository acceptance, explicit different repository rejection, omission-plus-other-drift rejection, non-mapping live image rejection, malformed/noncanonical desired repository rejection, ServiceMonitor/metrics baseline checks, and that preflight failures happen before evidence reservation or any Helm mutation. 

### Testing

- Ran Python syntax check and unit tests: `python3 -m py_compile scripts/dspace_manifest_rollback.py` succeeded, `pytest -q tests/test_manifest_rollback.py` succeeded (81 passed), `pytest -q tests/test_release_manifest.py` succeeded (234 passed), `pytest -q tests/test_generic_app_just_recipes.py` succeeded (422 passed, 1 existing SyntaxWarning), and `pytest -q tests/test_dspace_runtime_values.py` succeeded (10 passed). 
- Ran repository safety checks: `git diff --check` passed and secret-scan commands `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` produced no findings; `pre-commit run --all-files` could not be executed in this environment because `pre-commit` is not installed. 
- Why the normalization cannot hide a second mismatch: the helper only mutates a deep-copy baseline and only when (1) both `image` values are mappings, (2) the desired repository is exactly `release.IMAGE_REF`, and (3) the live mapping omits `repository`; after that single, narrow normalization the code still performs a full dictionary equality check (with `metrics` and `serviceMonitor` removed) so any other drift remains visible and continues to block reconciliation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc796d36c832fb666cb2a836c106e)