### PR TITLE
Fix DSPACE metrics reconciliation baseline comparison

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import time
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable
 
@@ -56,6 +57,23 @@ class RollbackError(ValueError):
 
 
 Runner = Callable[[list[str]], str]
+
+
+def configuration_baselines_match(
+    live_baseline: dict[str, Any], desired_baseline: dict[str, Any]
+) -> bool:
+    """Compare baselines, accepting only the canonical chart-default repository omission."""
+    live_comparison = copy.deepcopy(live_baseline)
+    desired_comparison = copy.deepcopy(desired_baseline)
+    live_image = live_comparison.get("image")
+    desired_image = desired_comparison.get("image")
+    if not isinstance(live_image, Mapping) or not isinstance(desired_image, Mapping):
+        return False
+    if desired_image.get("repository") != release.IMAGE_REF:
+        return False
+    if "repository" not in live_image:
+        live_comparison["image"] = {**live_image, "repository": release.IMAGE_REF}
+    return live_comparison == desired_comparison
 
 
 def run(command: list[str]) -> str:
@@ -777,7 +795,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         desired_baseline = copy.deepcopy(desired_values)
         desired_baseline.pop("metrics", None)
         desired_baseline.pop("serviceMonitor", None)
-        if baseline != desired_baseline:
+        if not configuration_baselines_match(baseline, desired_baseline):
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -584,6 +584,71 @@ def assert_no_mutation(commands: list[list[str]]) -> None:
     assert not any("upgrade" in command or "rollout" in command for command in commands)
 
 
+@pytest.mark.parametrize(
+    ("live_image", "desired_repository", "expected"),
+    (
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, manifest.IMAGE_REF, True),
+        (
+            {
+                "repository": manifest.IMAGE_REF,
+                "tag": "main-abcdef0",
+                "pullPolicy": "Always",
+            },
+            manifest.IMAGE_REF,
+            True,
+        ),
+        (
+            {"repository": "example.invalid/dspace", "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+            False,
+        ),
+        ("not-a-mapping", manifest.IMAGE_REF, False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, "", False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, None, False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, 123, False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, "example.invalid/dspace", False),
+    ),
+)
+def test_configuration_baselines_match_only_normalizes_canonical_repository_omission(
+    live_image: object, desired_repository: object, expected: bool
+) -> None:
+    live = {"replicaCount": 2, "image": live_image}
+    desired = {
+        "replicaCount": 2,
+        "image": {
+            "repository": desired_repository,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        },
+    }
+
+    assert rollback.configuration_baselines_match(live, desired) is expected
+    assert live["image"] == live_image
+
+
+def test_configuration_baselines_match_rejects_omission_with_unrelated_drift() -> None:
+    live = {
+        "replicaCount": 1,
+        "image": {"tag": "main-abcdef0", "pullPolicy": "Always"},
+    }
+    desired = {
+        "replicaCount": 2,
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        },
+    }
+
+    assert not rollback.configuration_baselines_match(live, desired)
+
+
+def test_configuration_baselines_match_rejects_non_mapping_desired_image() -> None:
+    live = {"image": {"tag": "main-abcdef0", "pullPolicy": "Always"}}
+
+    assert not rollback.configuration_baselines_match(live, {"image": "not-a-mapping"})
+
+
 def test_render_failure_precedes_reservation_and_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -748,6 +813,7 @@ def test_configuration_reconciliation_requires_one_absolute_kubeconfig(
         ("manifest", "live manifest does not match"),
         ("contract", "desired production metrics contract is invalid"),
         ("baseline", "approved disabled baseline"),
+        ("monitor-baseline", "approved disabled baseline"),
         ("drift", "unrelated Helm values drift"),
         ("image", "live image coordinate differs"),
     ),
@@ -778,7 +844,10 @@ def test_configuration_reconciliation_preconditions_fail_before_reservation(
         desired = []
     elif failure == "baseline":
         live["metrics"] = {"enabled": True}
+    elif failure == "monitor-baseline":
+        live["serviceMonitor"] = {"enabled": True}
     elif failure == "drift":
+        live["image"] = {"tag": "main-abcdef0", "pullPolicy": "Always"}
         live["unrelated"] = True
 
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
@@ -1106,7 +1175,10 @@ def test_configuration_reconciliation_completes_all_production_gates(
             "cluster": "sugarkube-prod",
         },
     }
-    live = {"replicaCount": 2, "image": image}
+    live = {
+        "replicaCount": 2,
+        "image": {"tag": selected["imageTag"], "pullPolicy": "Always"},
+    }
     stored_proof = [{"check": "helmStoredValues", "passed": True, "details": "safe"}]
     finalized: dict[str, object] = {}
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)


### PR DESCRIPTION
### Motivation

- The production configuration-reconciliation rejected a valid, representation-only difference where Helm-stored values omit `image.repository` because the chart supplies that default, so the preflight must accept that single, canonical omission while remaining fail-closed for all other differences. 
- The change must not weaken any other pre-mutation, provenance, credential, or evidence guarantees and must not expose Helm/Secret data in errors or logs.

### Description

- Add a small comparison helper `configuration_baselines_match(live_baseline, desired_baseline)` that deep-copies both baselines, requires both `image` entries be mappings, requires the desired `image.repository` equal exactly `release.IMAGE_REF`, and only in that exact case fills an omitted live `image.repository` before performing full dictionary equality. 
- Use the helper when comparing baselines after removing the approved `metrics` and `serviceMonitor` differences so the canonical omission is accepted but any other drift remains blocking. 
- Add focused regression tests that exercise accepted omission, explicit-canonical repository, noncanonical/different repository, non-mapping image, omission plus unrelated-drift, and ensure the helper does not mutate inputs. 
- Files changed: `scripts/dspace_manifest_rollback.py` and `tests/test_manifest_rollback.py` (helper plus test additions and small test shape adjustments). The commit is recorded as `f501b0b7`.

### Testing

- Ran `python3 -m py_compile scripts/dspace_manifest_rollback.py` which passed.  
- Ran unit suites: `pytest -q tests/test_manifest_rollback.py` (84 passed), `pytest -q tests/test_release_manifest.py` (234 passed), `pytest -q tests/test_generic_app_just_recipes.py` (422 passed with one pre-existing warning), and `pytest -q tests/test_dspace_runtime_values.py` (10 passed).  
- Ran repository checks: `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` (no secrets/errors reported), and `linkchecker --no-warnings README.md docs/` (no link errors).  
- `pre-commit run --all-files` in this environment surfaced unrelated, repository-wide YAML and lint issues (and its auto-fix hooks modified unrelated files, which were reverted); these failures are pre-existing and unrelated to this change; the patch itself touches only the two files above and was committed.  
- `pyspelling -c .spellcheck.yaml` could not be executed because the environment lacks the `aspell` binary.

Residual risk: the helper is intentionally narrowly scoped to a single canonical omission and performs a strict full equality check afterward, so it cannot hide a second mismatch; no production reconciliation commands were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc78ad500832f88118a407d7ef6cd)