### PR TITLE
Accept chart-default image.repository omission in DSPACE configuration preflight

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -525,6 +525,24 @@ def replace_reserved(path: Path, value: dict[str, Any]) -> None:
     release._sync_directory(path.parent)
 
 
+def configuration_baselines_match(
+    live_baseline: dict[str, Any], desired_baseline: dict[str, Any]
+) -> bool:
+    """Compare baselines while accepting the chart-default image repository omission."""
+    live_image = live_baseline.get("image")
+    desired_image = desired_baseline.get("image")
+    if not isinstance(live_image, dict) or not isinstance(desired_image, dict):
+        return False
+    if desired_image.get("repository") != release.IMAGE_REF:
+        return False
+
+    live_comparison = copy.deepcopy(live_baseline)
+    desired_comparison = copy.deepcopy(desired_baseline)
+    if "repository" not in live_image:
+        live_comparison["image"]["repository"] = release.IMAGE_REF
+    return live_comparison == desired_comparison
+
+
 def verify_post_pods(
     after: list[dict[str, Any]],
     before: list[dict[str, Any]],
@@ -777,7 +795,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         desired_baseline = copy.deepcopy(desired_values)
         desired_baseline.pop("metrics", None)
         desired_baseline.pop("serviceMonitor", None)
-        if baseline != desired_baseline:
+        if not configuration_baselines_match(baseline, desired_baseline):
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -722,6 +722,81 @@ def test_configuration_reconciliation_invalid_render_fails_before_reservation_an
     assert_no_mutation(commands)
 
 
+@pytest.mark.parametrize(
+    ("live_image", "desired_repository", "extra_live", "matches"),
+    (
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, manifest.IMAGE_REF, {}, True),
+        (
+            {
+                "repository": manifest.IMAGE_REF,
+                "tag": "main-abcdef0",
+                "pullPolicy": "Always",
+            },
+            manifest.IMAGE_REF,
+            {},
+            True,
+        ),
+        (
+            {"repository": "example.invalid/dspace", "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+            {},
+            False,
+        ),
+        (
+            {"repository": None, "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+            {},
+            False,
+        ),
+        (
+            {"repository": "", "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+            {},
+            False,
+        ),
+        (
+            {"tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+            {"drift": True},
+            False,
+        ),
+        ("not-a-mapping", manifest.IMAGE_REF, {}, False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, None, {}, False),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, "", {}, False),
+        (
+            {"tag": "main-abcdef0", "pullPolicy": "Always"},
+            "example.invalid/dspace",
+            {},
+            False,
+        ),
+    ),
+)
+def test_configuration_baseline_repository_normalization_is_narrow(
+    live_image: object,
+    desired_repository: object,
+    extra_live: dict[str, object],
+    matches: bool,
+) -> None:
+    live = {"replicaCount": 2, "image": live_image, **extra_live}
+    desired = {
+        "replicaCount": 2,
+        "image": {
+            "repository": desired_repository,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        },
+    }
+
+    assert rollback.configuration_baselines_match(live, desired) is matches
+    assert live["image"] is live_image
+
+
+def test_configuration_baseline_requires_desired_image_mapping() -> None:
+    live = {"image": {"tag": "main-abcdef0", "pullPolicy": "Always"}}
+
+    assert rollback.configuration_baselines_match(live, {"image": None}) is False
+
+
 @pytest.mark.parametrize("kubeconfig", ("", "relative/kubeconfig", "/tmp/one:/tmp/two"))
 def test_configuration_reconciliation_requires_one_absolute_kubeconfig(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kubeconfig: str
@@ -747,7 +822,8 @@ def test_configuration_reconciliation_requires_one_absolute_kubeconfig(
         ("desired", "desired values are structurally invalid"),
         ("manifest", "live manifest does not match"),
         ("contract", "desired production metrics contract is invalid"),
-        ("baseline", "approved disabled baseline"),
+        ("baseline_metrics", "approved disabled baseline"),
+        ("baseline_monitor", "approved disabled baseline"),
         ("drift", "unrelated Helm values drift"),
         ("image", "live image coordinate differs"),
     ),
@@ -776,9 +852,12 @@ def test_configuration_reconciliation_preconditions_fail_before_reservation(
     live = {"image": image}
     if failure == "desired":
         desired = []
-    elif failure == "baseline":
+    elif failure == "baseline_metrics":
         live["metrics"] = {"enabled": True}
+    elif failure == "baseline_monitor":
+        live["serviceMonitor"] = {"enabled": True}
     elif failure == "drift":
+        live["image"] = {"tag": "main-abcdef0", "pullPolicy": "Always"}
         live["unrelated"] = True
 
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)
@@ -1106,7 +1185,10 @@ def test_configuration_reconciliation_completes_all_production_gates(
             "cluster": "sugarkube-prod",
         },
     }
-    live = {"replicaCount": 2, "image": image}
+    live = {
+        "replicaCount": 2,
+        "image": {"tag": selected["imageTag"], "pullPolicy": "Always"},
+    }
     stored_proof = [{"check": "helmStoredValues", "passed": True, "details": "safe"}]
     finalized: dict[str, object] = {}
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)


### PR DESCRIPTION
### Motivation
- The configuration-reconciliation preflight rejected an otherwise-equivalent live Helm values shape when the live release omitted `image.repository` (chart default) while the desired contract explicitly set `image.repository` to `release.IMAGE_REF`.
- We must accept this single representation-only omission while preserving fail-closed semantics for any other drift, malformed values, provenance, or secrets.

### Description
- Add a small helper `configuration_baselines_match(live_baseline, desired_baseline)` in `scripts/dspace_manifest_rollback.py` that accepts the canonical omission only when both `live['image']` and `desired['image']` are mappings and `desired['image']['repository'] == release.IMAGE_REF`, and otherwise performs strict equality on deep-copied baselines.
- Use the helper to replace the previous direct `baseline != desired_baseline` check so the preflight treats a missing live `image.repository` as equal only in the single, explicitly constrained case.
- Add focused regression tests in `tests/test_manifest_rollback.py` covering: omitted canonical repository, explicit canonical repository, differing repository, omission combined with unrelated drift, non-mapping live image, malformed/empty/noncanonical desired repository, enabled metrics/ServiceMonitor rejections, and that the normalization does not mutate the original live dict.
- Files changed: `scripts/dspace_manifest_rollback.py`, `tests/test_manifest_rollback.py`.
- The normalization is narrow and cannot hide a second mismatch because it only inserts `repository: release.IMAGE_REF` into a deep-copied live baseline when (1) both image values are dicts and (2) the desired repository exactly equals `release.IMAGE_REF`; after that it requires complete dict equality, so any additional or differing keys remain blocking.

### Testing
- Ran `python3 -m py_compile scripts/dspace_manifest_rollback.py` which succeeded.
- Ran `pytest -q tests/test_manifest_rollback.py` which passed (`85 passed`).
- Ran `pytest -q tests/test_release_manifest.py` which passed (`234 passed`).
- Ran `pytest -q tests/test_generic_app_just_recipes.py` which passed (`422 passed`, with one pre-existing SyntaxWarning reported by pytest).
- Ran `pytest -q tests/test_dspace_runtime_values.py` which passed (`10 passed`).
- Ran repository checks `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` which produced no issues; `pre-commit run --all-files` was not executed because `pre-commit` is not installed in the environment.
- No production or cluster commands were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc7934088832f9101dab284595b01)