### PR TITLE
Normalize missing chart-default image.repository in DSPACE configuration preflight

### DIFF
--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -582,6 +582,28 @@ def assert_production_target(kubeconfig: str, runner: Runner) -> None:
     )
 
 
+def configuration_reconciliation_baselines(
+    live_values: dict[str, Any], desired_values: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return full baselines with only the canonical chart-default omission normalized."""
+    baseline = copy.deepcopy(live_values)
+    baseline.pop("metrics", None)
+    baseline.pop("serviceMonitor", None)
+    desired_baseline = copy.deepcopy(desired_values)
+    desired_baseline.pop("metrics", None)
+    desired_baseline.pop("serviceMonitor", None)
+
+    live_image = baseline.get("image")
+    desired_image = desired_baseline.get("image")
+    if not isinstance(live_image, dict) or not isinstance(desired_image, dict):
+        raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+    if desired_image.get("repository") != release.IMAGE_REF:
+        raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+    if "repository" not in live_image:
+        live_image["repository"] = release.IMAGE_REF
+    return baseline, desired_baseline
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -771,12 +793,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             {"enabled": False},
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline = copy.deepcopy(live_values)
-        baseline.pop("metrics", None)
-        baseline.pop("serviceMonitor", None)
-        desired_baseline = copy.deepcopy(desired_values)
-        desired_baseline.pop("metrics", None)
-        desired_baseline.pop("serviceMonitor", None)
+        baseline, desired_baseline = configuration_reconciliation_baselines(
+            live_values, desired_values
+        )
         if baseline != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -584,6 +584,79 @@ def assert_no_mutation(commands: list[list[str]]) -> None:
     assert not any("upgrade" in command or "rollout" in command for command in commands)
 
 
+def test_configuration_reconciliation_baselines_normalize_only_canonical_omission() -> None:
+    image = {"tag": "main-abcdef0", "pullPolicy": "Always"}
+    desired = {"replicaCount": 2, "image": {**image, "repository": manifest.IMAGE_REF}}
+
+    baseline, desired_baseline = rollback.configuration_reconciliation_baselines(
+        {"replicaCount": 2, "image": image}, desired
+    )
+    assert baseline == desired_baseline
+    assert rollback.configuration_reconciliation_baselines(desired, desired)[0] == desired
+
+
+@pytest.mark.parametrize(
+    ("live_image", "desired_repository"),
+    (
+        (
+            {
+                "repository": "example.invalid/dspace",
+                "tag": "main-abcdef0",
+                "pullPolicy": "Always",
+            },
+            manifest.IMAGE_REF,
+        ),
+        (
+            {"repository": None, "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+        ),
+        (
+            {"repository": "", "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+        ),
+        (
+            {"repository": 42, "tag": "main-abcdef0", "pullPolicy": "Always"},
+            manifest.IMAGE_REF,
+        ),
+        ("not-a-mapping", manifest.IMAGE_REF),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, None),
+        ({"tag": "main-abcdef0", "pullPolicy": "Always"}, ""),
+        (
+            {"tag": "main-abcdef0", "pullPolicy": "Always"},
+            "example.invalid/dspace",
+        ),
+    ),
+)
+def test_configuration_reconciliation_baselines_reject_unsafe_image_shapes(
+    live_image: object, desired_repository: object
+) -> None:
+    live = {"image": live_image}
+    desired = {
+        "image": {
+            "repository": desired_repository,
+            "tag": "main-abcdef0",
+            "pullPolicy": "Always",
+        }
+    }
+    with pytest.raises(rollback.RollbackError, match="unrelated Helm values drift"):
+        baseline, desired_baseline = rollback.configuration_reconciliation_baselines(live, desired)
+        if baseline != desired_baseline:
+            raise rollback.RollbackError(
+                "unrelated Helm values drift blocks configuration reconciliation"
+            )
+
+
+def test_configuration_reconciliation_baselines_preserve_additional_drift() -> None:
+    image = {"tag": "main-abcdef0", "pullPolicy": "Always"}
+    live = {"image": image, "replicaCount": 1}
+    desired = {
+        "image": {**image, "repository": manifest.IMAGE_REF},
+        "replicaCount": 2,
+    }
+    baseline, desired_baseline = rollback.configuration_reconciliation_baselines(live, desired)
+    assert baseline != desired_baseline
+
+
 def test_render_failure_precedes_reservation_and_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1106,7 +1179,10 @@ def test_configuration_reconciliation_completes_all_production_gates(
             "cluster": "sugarkube-prod",
         },
     }
-    live = {"replicaCount": 2, "image": image}
+    live = {
+        "replicaCount": 2,
+        "image": {"tag": selected["imageTag"], "pullPolicy": "Always"},
+    }
     stored_proof = [{"check": "helmStoredValues", "passed": True, "details": "safe"}]
     finalized: dict[str, object] = {}
     monkeypatch.setattr(rollback.app_chart, "merged_values_document", lambda _paths: desired)


### PR DESCRIPTION
### Motivation

- Helm user-supplied stored values for the DSPACE chart may omit `image.repository` because the chart provides the canonical repository default, which caused an otherwise-equivalent live/deserved-values comparison to fail. 
- The intent is to accept only that single representation-only omission while preserving all existing fail-closed checks for provenance, credentials, unrelated drift, and pre-mutation guards.

### Description

- Add `configuration_reconciliation_baselines(live_values, desired_values)` to `scripts/dspace_manifest_rollback.py` which deep-copies both baselines, strips the authorized `metrics`/`serviceMonitor` differences, validates that both `image` values are mappings, asserts the desired repository equals `release.IMAGE_REF`, and, if the live mapping omits `repository`, injects `repository: release.IMAGE_REF` into the live comparison copy only. 
- Use the new helper in the configuration-reconciliation preflight so the subsequent exact-dictionary equality check still runs unchanged, ensuring that any other drift continues to block reconciliation. 
- Preserve fail-closed behavior: an explicitly different live repository, malformed/non-string `repository`, non-mapping `image` values, a noncanonical desired repository, or any additional unrelated-drift still fail. 
- Add focused regression tests in `tests/test_manifest_rollback.py` covering the canonical-omission pass case, explicit-canonical pass case, explicit-different repository fail, omission-plus-other-drift fail, non-mapping live image fail, malformed desired repository fail, and preserving the existing full production reconciliation success path with the generic-deployment shape.

### Testing

- Ran `python3 -m py_compile scripts/dspace_manifest_rollback.py` which succeeded. 
- Ran the requested unit tests: `pytest -q tests/test_manifest_rollback.py` (83 passed), `pytest -q tests/test_release_manifest.py` (234 passed), `pytest -q tests/test_generic_app_just_recipes.py` (422 passed with one existing SyntaxWarning), and `pytest -q tests/test_dspace_runtime_values.py` (10 passed). 
- Ran repository checks `git diff --check` and `git diff | ./scripts/scan-secrets.py`, both of which completed with no issues in the introduced diff; `pre-commit`, `pyspelling`, and `linkchecker` were unavailable in the execution environment so they were not run here. 

Files changed: `scripts/dspace_manifest_rollback.py`, `tests/test_manifest_rollback.py`.

Residual notes: the normalization is applied only to comparison copies and only in the exact case where the desired repository equals `release.IMAGE_REF`, so it cannot hide any second mismatch elsewhere in the `image` mapping or in other values paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc795801c832f91778f1c9d8b095b)