### PR TITLE
Guarded chart-only production metrics reconciliation: pin DSPACE chart 3.0.3

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,59 +2,43 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
-## Production authenticated metrics at the existing release
+## Production authenticated metrics chart maintenance
 
-DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
-**3.0.2**. This repository change does not deploy application or chart code, and it is not a
-promotion. It supplies the reviewed values contract for an upgrade-only configuration
-reconciliation at the existing immutable coordinates.
+This guarded operation is a **chart-only maintenance upgrade** from immutable DSPACE chart 3.0.2
+to 3.0.3 so authenticated production metrics can be enabled. It is not an application promotion:
+application 3.0.1, source `1a31a569aff2dbeb238e8c2688b9e85140d2077d`, image
+`main-1a31a56` and its digest, provider `openai`, two replicas, routing, and credentials remain
+unchanged. The finalized 3.0.2 production evidence remains historical, byte-for-byte unchanged;
+the separately reviewed chart target is `docs/apps/dspace.prod-metrics-chart-target.json`.
 
-Run production operations from `sugarkube3` with the externally managed API tunnel listening on
-`127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
-`just kubeconfig-env env=prod` on that host:
+Run from `sugarkube3` with the externally managed API tunnel on `127.0.0.1:16443`. Supply the
+explicit production kubeconfig. The operation checks context `sugar-prod`, production cluster
+identity, the genuine finalized baseline, exact live revision/chart/pods, the metrics Secret
+contract without reading its value, strict values drift, the digest-qualified render, and fresh OCI
+provenance before reserving evidence or mutating Helm. Do not install or rotate
+`dspace-prod-metrics-token` as part of this operation.
 
-```bash
-export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
-test "$(kubectl config current-context)" = sugar-prod
-python3 scripts/cluster_identity.py assert --kubeconfig "$KUBECONFIG" --env prod
-just observability-app-metrics-secret-install app=dspace env=prod
-just observability-app-metrics-secret-check app=dspace env=prod
-```
-
-The hidden-input installer creates or rotates only `dspace/dspace-prod-metrics-token` key `token`;
-the check proves that the key is nonempty without reading it. Install and check it before any
-reconciliation. Never put the credential in an argument, environment variable, transcript, or
-evidence file.
-
-The reconciliation operator must supply the genuine existing finalized production evidence, the
-executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destination. Discover the
-current Helm revision immediately before the operation rather than assuming revision 9. Review the
-digest-qualified chart render and transient live-versus-desired values comparison: the only
-permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
-3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
-`--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
+The currently verified transition is revision 9 to 10. Tooling derives revision 9 from the baseline
+and requires exactly one revision advance; it does not blindly hard-code either revision. Use a
+fresh, nonexisting evidence destination and the executable remote `/chat` smoke runner:
 
 ```bash
 just dspace-prod-metrics-reconcile \
-  manifest="$GENUINE_FINALIZED_PROD_EVIDENCE" \
+  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
   evidence="$FRESH_NONEXISTING_EVIDENCE" \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$HOME/.kube/config-sugarkube-prod" \
-  confirm="dspace:prod:<40-character-application-SHA>"
+  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
 ```
 
-After rollout, run the DSPACE runtime and `/chat` verification, then run:
-
-```bash
-just observability-app-metrics-verify app=dspace env=prod
-just observability-dashboard-verify env=prod
-```
-
-Inspect the production dashboard manually. DSPACE HTTP, runtime, and feature panels should
-populate. Release-integrity, blackbox, token.place, and alerting panels may remain `NO DATA` until
-those separate production integrations are deployed. A failure after mutation is not permission
-to rerun or roll back immediately: preserve and review the reserved failure evidence, discover the
-new live revision, and plan a deliberate reconciliation.
+The command uses only the exact digest-qualified 3.0.3 OCI chart, the complete committed production
+values chain, and an invocation-bound opaque Helm description; it never uses `--reuse-values`.
+Afterward it proves replacement Ready pods retain the exact image digest, runs strict runtime,
+frontend, provider, remote `/chat`, and production metrics verification, and finalizes evidence.
+Any failure after reservation preserves failed evidence. Review that evidence and live Helm history
+before any further mutation; never automatically rerun, uninstall, roll back, delete, or rotate the
+Secret.
 
 ## Production Helm reconciliation for application 3.0.1
 
@@ -300,6 +284,12 @@ contract explicitly to the smoke runner. This is not a fallback: any coordinate 
 modern contract and a modern identity failure remains fatal. The exception changes neither the
 immutable recovery coordinates nor candidate approval.
 
+The separately reviewed production metrics target selects chart 3.0.3 at source revision
+`62da11005354e9f9a89c2e58584cdce4c8ec35aa` and digest
+`sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c` while retaining every
+3.0.1 application coordinate above. That exact tuple is also eligible for the same bounded legacy
+identity contract; this is not a general version fallback.
+
 The exact immutable DSPACE 3.1.0 artifact (source `018687f5a7f4de45508c6e36eb28afb3e44da24d`,
 image `main-018687f`, and chart `3.1.1`) also predates `build-info-v1` and is explicitly allowlisted
 for the same strict legacy contract. This is not a general fallback: every coordinate must match,
@@ -380,7 +370,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.3`, chart-only application 3.0.1 maintenance) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -92,14 +92,16 @@ mkdir -p deployment-candidates/dspace
 # Keep the shared staging pin unchanged while selecting the independently
 # approved 3.0.2 production pin for this recovery only.
 RECOVERY_CONFIG=$(mktemp)
-trap 'rm -f "$RECOVERY_CONFIG"' EXIT
-python3 - "$RECOVERY_CONFIG" <<'PY'
+RECOVERY_VERSION=$(mktemp)
+trap 'rm -f "$RECOVERY_CONFIG" "$RECOVERY_VERSION"' EXIT
+printf '%s\n' 3.0.2 >"$RECOVERY_VERSION"
+python3 - "$RECOVERY_CONFIG" "$RECOVERY_VERSION" <<'PY'
 from pathlib import Path
 import sys
 
 source = Path("docs/examples/apps/dspace.env").read_text(encoding="utf-8")
 old = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version"
-new = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.prod.version"
+new = f"SUGARKUBE_VERSION_FILE_STAGING={Path(sys.argv[2]).resolve()}"
 if source.count(old) != 1:
     raise SystemExit("expected exactly one staging version-file assignment")
 Path(sys.argv[1]).write_text(source.replace(old, new), encoding="utf-8")

--- a/docs/apps/dspace.prod-metrics-chart-target.json
+++ b/docs/apps/dspace.prod-metrics-chart-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "semanticTag": "v3.0.1",
+  "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+  "chartVersion": "3.0.3",
+  "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.2
+# DSPACE production chart pin. Application 3.0.1 remains unchanged.
+3.0.3

--- a/justfile
+++ b/justfile
@@ -1795,7 +1795,7 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
     "${rollback_command[@]}"
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
-dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1805,7 +1805,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         value="${value#"${name}="}"
       else
         case "${value}" in
-          manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
             echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
             return 2
             ;;
@@ -1818,7 +1818,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       printf '%s' "${value}"
     }
 
-    manifest_path="$(normalize_argument manifest {{ quote(manifest) }} true)"
+    baseline_path="$(normalize_argument baseline_manifest {{ quote(baseline_manifest) }} true)"
+    target_path="$(normalize_argument maintenance_target {{ quote(maintenance_target) }} true)"
     evidence_path="$(normalize_argument evidence {{ quote(evidence) }} true)"
     smoke_path="$(normalize_argument smoke_runner {{ quote(smoke_runner) }} true)"
     kubeconfig_path="$(normalize_argument kubeconfig {{ quote(kubeconfig) }} true)"
@@ -1838,7 +1839,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+        baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
           echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
           exit 2
           ;;
@@ -1850,7 +1851,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
       --configuration-reconciliation
       --environment prod
-      --manifest "${manifest_path}"
+      --baseline-manifest "${baseline_path}"
+      --maintenance-target "${target_path}"
       --evidence "${evidence_path}"
       --smoke-runner "${smoke_path}"
       --kubeconfig "${kubeconfig_path}"

--- a/justfile
+++ b/justfile
@@ -1805,7 +1805,7 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
         value="${value#"${name}="}"
       else
         case "${value}" in
-          baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          manifest=*|baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
             echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
             return 2
             ;;
@@ -1839,7 +1839,7 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+        manifest=*|baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
           echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
           exit 2
           ;;

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -78,6 +78,14 @@ def run(command: list[str]) -> str:
     return completed.stdout
 
 
+def chart_pin(path: Path) -> str:
+    """Read a chart pin with the shared parser and redact filesystem failures."""
+    try:
+        return app_chart.read_pin(str(path))
+    except (OSError, SystemExit, ValueError) as exc:
+        raise RollbackError("configured production chart pin is unreadable or invalid") from exc
+
+
 def json_command(runner: Runner, command: list[str], label: str) -> dict[str, Any]:
     try:
         value = json.loads(runner(command))
@@ -96,15 +104,6 @@ def exact_fields(value: dict[str, Any], fields: tuple[str, ...], label: str) -> 
             f"{label} schema mismatch (missing={','.join(missing) or '-'}; "
             f"unknown={','.join(unknown) or '-'})"
         )
-
-
-def chart_pin(path: Path) -> str:
-    """Return the first non-comment, non-blank chart version pin."""
-    for line in path.read_text(encoding="utf-8").splitlines():
-        value = line.split("#", 1)[0].strip()
-        if value:
-            return value
-    return ""
 
 
 def verifier_capabilities(
@@ -642,6 +641,14 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
     exact_fields(reviewed, MAINTENANCE_TARGET_FIELDS, "chart maintenance target")
     if reviewed.get("schemaVersion") != 2 or reviewed.get("app") != "dspace":
         raise RollbackError("chart maintenance target must be schema 2 for dspace")
+    approved_application = {
+        "app": "dspace",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "semanticTag": "v3.0.1",
+    }
     preserved = (
         "app",
         "applicationVersion",
@@ -652,6 +659,8 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
     )
     if any(reviewed.get(field) != baseline.get(field) for field in preserved):
         raise RollbackError("chart maintenance target changes an application or image field")
+    if any(reviewed.get(field) != wanted for field, wanted in approved_application.items()):
+        raise RollbackError("chart maintenance target is not the approved application tuple")
     chart_tuple = (
         reviewed.get("chartSourceRevision"),
         reviewed.get("chartVersion"),
@@ -718,8 +727,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
-        version_path = root / config["SUGARKUBE_VERSION_FILE"]
-        if chart_pin(version_path) != target["chartVersion"]:
+        configured_version = chart_pin(root / config["SUGARKUBE_VERSION_FILE"])
+        if configured_version != target["chartVersion"]:
             raise RollbackError("configured production chart pin differs from maintenance target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
@@ -1118,7 +1127,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision != before_identity[2] + 1:
+        if configuration_reconciliation and after_revision != before_identity[2] + 1:
             raise RollbackError("Helm revision did not advance exactly once")
         if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -49,6 +49,18 @@ VERIFIER_FIELDS = (
 )
 POD_TIMEOUT = 60.0
 POLL_INTERVAL = 2.0
+MAINTENANCE_TARGET_FIELDS = (
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "semanticTag",
+    "chartSourceRevision",
+    "chartVersion",
+    "chartDigest",
+)
 
 
 class RollbackError(ValueError):
@@ -280,9 +292,7 @@ def helm_status(
     )
 
 
-def helm_history(
-    runner: Runner, kubeconfig: str, release_name: str, namespace: str
-) -> object:
+def helm_history(runner: Runner, kubeconfig: str, release_name: str, namespace: str) -> object:
     try:
         return json.loads(
             runner(
@@ -310,9 +320,7 @@ def helm_snapshot(
     namespace: str,
     *,
     require_deployed: bool = True,
-) -> tuple[
-    dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]
-]:
+) -> tuple[dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]]:
     """Read a redaction-safe, revision-bound Helm release identity."""
     status = helm_status(runner, kubeconfig, release_name, namespace)
     history: list[dict[str, Any]] | None = None
@@ -348,9 +356,7 @@ def helm_snapshot(
             expected_version
         ):
             raise release.ManifestError("invalid Helm release identity")
-        identity = release.resolve_helm_identity(
-            status, history, release_name, expected_version
-        )
+        identity = release.resolve_helm_identity(status, history, release_name, expected_version)
     except release.ManifestError as exc:
         raise RollbackError("Helm release identity is invalid") from exc
     if status.get("name") != release_name or status.get("namespace") != namespace:
@@ -564,9 +570,7 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
 
 
 def assert_production_target(kubeconfig: str, runner: Runner) -> None:
-    context = runner(
-        ["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]
-    ).strip()
+    context = runner(["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]).strip()
     if context != "sugar-prod":
         raise RollbackError("metrics configuration reconciliation requires sugar-prod")
     runner(
@@ -605,6 +609,57 @@ def configuration_comparison_baselines(
     return baseline, desired_baseline
 
 
+def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, Any]:
+    """Apply a strict reviewed chart tuple without rewriting finalized evidence."""
+    if (
+        baseline.get("environment") != "prod"
+        or baseline.get("expectedDefaultChatProvider") != "openai"
+        or (
+            baseline.get("chartSourceRevision"),
+            baseline.get("chartVersion"),
+            baseline.get("chartDigest"),
+        )
+        != (
+            "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+            "3.0.2",
+            "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        )
+    ):
+        raise RollbackError("baseline is not the approved finalized production chart tuple")
+    try:
+        reviewed = release._object(path.expanduser())
+    except release.ManifestError as exc:
+        raise RollbackError(f"chart maintenance target is invalid: {exc}") from exc
+    exact_fields(reviewed, MAINTENANCE_TARGET_FIELDS, "chart maintenance target")
+    if reviewed.get("schemaVersion") != 2 or reviewed.get("app") != "dspace":
+        raise RollbackError("chart maintenance target must be schema 2 for dspace")
+    preserved = (
+        "app",
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "semanticTag",
+    )
+    if any(reviewed.get(field) != baseline.get(field) for field in preserved):
+        raise RollbackError("chart maintenance target changes an application or image field")
+    chart_tuple = (
+        reviewed.get("chartSourceRevision"),
+        reviewed.get("chartVersion"),
+        reviewed.get("chartDigest"),
+    )
+    if chart_tuple != (
+        "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+        "3.0.3",
+        "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+    ):
+        raise RollbackError("chart maintenance target is not the reviewed production chart tuple")
+    target = copy.deepcopy(baseline)
+    for field in ("chartSourceRevision", "chartVersion", "chartDigest"):
+        target[field] = reviewed[field]
+    return target
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -629,12 +684,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
     try:
-        target = release.validate(release._object(args.manifest), True)
+        baseline = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
-    if target["environment"] != args.environment:
+    if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    target = baseline
+    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+        target = chart_maintenance_target(baseline, args.maintenance_target)
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -650,6 +708,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
+    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+        version_path = root / config["SUGARKUBE_VERSION_FILE"]
+        if version_path.read_text(encoding="utf-8").strip() != target["chartVersion"]:
+            raise RollbackError("configured production chart pin differs from maintenance target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
@@ -667,10 +729,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     capabilities = verifier_capabilities(
         args.verifier, args.environment, "dspace", "dspace", runner
     )
+    verifier_manifest = args.manifest
+    if configuration_reconciliation and target is not baseline:
+        verifier_manifest = staged_directory / "approved-target.json"
+        verifier_manifest.write_text(release._canonical(approved), encoding="utf-8")
+        os.chmod(verifier_manifest, 0o600)
     extended_verifier = verifier_accepts_runtime_arguments(
         args.verifier,
         args.environment,
-        args.manifest,
+        verifier_manifest,
         getattr(args, "smoke_runner", None),
         args.kubeconfig,
         args.config,
@@ -704,7 +771,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != target["helmRevision"]:
+        if before_identity[2] != baseline["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -719,7 +786,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", target["chartVersion"]):
+        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -769,7 +836,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 args.kubeconfig,
                 "template",
                 "dspace",
-                coordinate,
+                release.chart_coordinate(
+                    {
+                        **approved,
+                        "chartVersion": baseline["chartVersion"],
+                        "chartDigest": baseline["chartDigest"],
+                    }
+                ),
                 "--namespace",
                 "dspace",
                 "--values",
@@ -794,9 +867,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             {"enabled": False},
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(
-            live_values, desired_values
-        )
+        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
         if baseline != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
@@ -1038,12 +1109,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= before_identity[2]:
-            raise RollbackError("Helm revision did not advance")
-        if (
-            after_identity[0] != "dspace"
-            or after_identity[1] != target["chartVersion"]
-        ):
+        if after_revision != before_identity[2] + 1:
+            raise RollbackError("Helm revision did not advance exactly once")
+        if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
             before_identity[1] != target["chartVersion"]
@@ -1158,7 +1226,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         # original verify contract for compatible third-party verifiers rather
         # than discovering that they reject new flags after Helm has mutated.
         if extended_verifier:
-            verifier_command.extend(("--manifest", str(args.manifest)))
+            verifier_command.extend(("--manifest", str(verifier_manifest)))
             smoke_runner = getattr(args, "smoke_runner", None)
             if smoke_runner:
                 verifier_command.extend(("--smoke-runner", str(smoke_runner)))
@@ -1252,8 +1320,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                     "status": observed_info.get("status"),
                     "chartName": observed_identity[0],
                     "chartVersion": observed_identity[1],
-                    "invocationDescriptionMatches": observed_info.get("description")
-                    == description,
+                    "invocationDescriptionMatches": observed_info.get("description") == description,
                 }
             except Exception:
                 diagnostics["helm"] = "unavailable"
@@ -1282,7 +1349,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
-    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--baseline-manifest", type=Path)
+    parser.add_argument("--maintenance-target", type=Path)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--verifier", type=Path, required=True)
     parser.add_argument("--smoke-runner", type=Path)
@@ -1293,6 +1362,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
     args = parser.parse_args(argv)
+    if args.configuration_reconciliation:
+        if (
+            args.manifest is not None
+            or args.baseline_manifest is None
+            or args.maintenance_target is None
+        ):
+            parser.error(
+                "configuration reconciliation requires --baseline-manifest and "
+                "--maintenance-target, not --manifest"
+            )
+        args.manifest = args.baseline_manifest
+    elif (
+        args.manifest is None
+        or args.baseline_manifest is not None
+        or args.maintenance_target is not None
+    ):
+        parser.error("rollback requires --manifest and does not accept maintenance coordinates")
     if args.kubeconfig is None and not args.configuration_reconciliation:
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -1129,6 +1129,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm release description is not bound to this invocation")
         if configuration_reconciliation and after_revision != before_identity[2] + 1:
             raise RollbackError("Helm revision did not advance exactly once")
+        if not configuration_reconciliation and after_revision <= before_identity[2]:
+            raise RollbackError("Helm revision did not advance")
         if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -98,6 +98,15 @@ def exact_fields(value: dict[str, Any], fields: tuple[str, ...], label: str) -> 
         )
 
 
+def chart_pin(path: Path) -> str:
+    """Return the first non-comment, non-blank chart version pin."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        value = line.split("#", 1)[0].strip()
+        if value:
+            return value
+    return ""
+
+
 def verifier_capabilities(
     executable: Path, environment: str, release_name: str, namespace: str, runner: Runner = run
 ) -> dict[str, Any]:
@@ -710,7 +719,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE release and namespace must both be dspace")
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
         version_path = root / config["SUGARKUBE_VERSION_FILE"]
-        if version_path.read_text(encoding="utf-8").strip() != target["chartVersion"]:
+        if chart_pin(version_path) != target["chartVersion"]:
             raise RollbackError("configured production chart pin differs from maintenance target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1097,7 +1097,7 @@ def main(argv: list[str] | None = None) -> int:
     make.add_argument("--approved-by", required=True)
     check = sub.add_parser("validate")
     check.add_argument("--manifest", type=Path, required=True)
-    check.add_argument("--final", action="store_true")
+    check.add_argument("--final", action="store_const", const=True, default=None)
     flight = sub.add_parser("preflight")
     flight.add_argument("--manifest", type=Path, required=True)
     flight.add_argument("--image-ref", default=IMAGE_REF)

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,12 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_303_COORDINATES = {
+    **LEGACY_RECOVERY_COORDINATES,
+    "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+    "chartVersion": "3.0.3",
+    "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+}
 LEGACY_310_COORDINATES = {
     "schemaVersion": 2,
     "applicationVersion": "3.1.0",
@@ -71,7 +77,11 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
-LEGACY_IDENTITY_COORDINATES = (LEGACY_RECOVERY_COORDINATES, LEGACY_310_COORDINATES)
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_303_COORDINATES,
+    LEGACY_310_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -449,10 +459,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
-        if not any(
-            c.get("type") == "Ready" and c.get("status") == "True"
-            for c in conditions
-        ):
+        if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
             fail("pod/replica identity")
         owner = controller_owner(metadata.get("ownerReferences", []), "ReplicaSet")
         replica_set_name, replica_set_uid = owner.get("name"), owner.get("uid")

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -151,7 +151,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3057,6 +3057,36 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+@pytest.mark.parametrize("optional", (False, True))
+def test_dspace_prod_metrics_reconcile_rejects_legacy_manifest_prefix(
+    tmp_path: Path, optional: bool
+) -> None:
+    required = [
+        "/tmp/baseline.json",
+        "/tmp/target.json",
+        "/tmp/evidence.json",
+        "/tmp/smoke-runner",
+        "/tmp/kubeconfig",
+    ]
+    args = (
+        [*required, "manifest=/tmp/legacy.json"]
+        if optional
+        else ["manifest=/tmp/legacy.json", *required[1:]]
+    )
+
+    result, argv = _run_dspace_prod_metrics_reconcile(tmp_path, args)
+
+    assert result.returncode != 0
+    expected = (
+        "unexpected argument prefix in manifest="
+        if optional
+        else "baseline_manifest must be positional"
+    )
+    assert expected in result.stderr
+    assert argv == []
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_recovery_staging_config_uses_production_chart_pin(
     tmp_path: Path, generic_app_stub_env: dict[str, str]
 ) -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3094,10 +3094,12 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     staging_pin = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version"
     assert source.count(staging_pin) == 1
     recovery_config = tmp_path / "recovery-staging.env"
+    recovery_version = tmp_path / "recovery.version"
+    recovery_version.write_text("3.0.2\n", encoding="utf-8")
     recovery_config.write_text(
         source.replace(
             staging_pin,
-            "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.prod.version",
+            f"SUGARKUBE_VERSION_FILE_STAGING={recovery_version}",
         ),
         encoding="utf-8",
     )
@@ -3105,10 +3107,10 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     evidence = tmp_path / "recovery-staging-evidence.json"
     _write_dspace_candidate(manifest, "staging")
     candidate = json.loads(manifest.read_text(encoding="utf-8"))
-    candidate["chartVersion"] = "3.0.3"
+    candidate["chartVersion"] = "3.0.2"
     manifest.write_text(json.dumps(candidate) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
 
     result = _run_just(
         [
@@ -3128,7 +3130,7 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8")
     assert "release-manifest preflight" in commands
     assert "helm template " in commands
-    assert "charts/dspace:3.0.3" in commands
+    assert "charts/dspace:3.0.2" in commands
     assert "docs/examples/dspace.values.staging.yaml" in commands
     assert "main-abcdef0" in commands
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2980,7 +2980,8 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
     tmp_path: Path,
 ) -> None:
     values = {
-        "manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "baseline_manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "maintenance_target": str(tmp_path / "reviewed chart target=3.0.3.json"),
         "evidence": str(tmp_path / "fresh evidence=run-42.json"),
         "smoke_runner": str(tmp_path / "smoke runner=production"),
         "kubeconfig": str(tmp_path / "production kubeconfig=primary"),
@@ -3021,7 +3022,8 @@ def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_conf
     result, argv = _run_dspace_prod_metrics_reconcile(
         tmp_path,
         [
-            "manifest=/tmp/manifest.json",
+            "baseline_manifest=/tmp/manifest.json",
+            "maintenance_target=/tmp/target.json",
             "evidence=/tmp/evidence.json",
             "smoke_runner=/tmp/smoke-runner",
             "kubeconfig=/tmp/kubeconfig",
@@ -3042,6 +3044,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
         tmp_path,
         [
             "evidence=/tmp/manifest.json",
+            "/tmp/target.json",
             "/tmp/evidence.json",
             "/tmp/smoke-runner",
             "/tmp/kubeconfig",
@@ -3049,7 +3052,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
     )
 
     assert result.returncode != 0
-    assert "manifest must be positional or use the manifest= prefix" in result.stderr
+    assert "baseline_manifest must be positional or use the baseline_manifest= prefix" in result.stderr
     assert argv == []
 
 
@@ -3072,10 +3075,10 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     evidence = tmp_path / "recovery-staging-evidence.json"
     _write_dspace_candidate(manifest, "staging")
     candidate = json.loads(manifest.read_text(encoding="utf-8"))
-    candidate["chartVersion"] = "3.0.2"
+    candidate["chartVersion"] = "3.0.3"
     manifest.write_text(json.dumps(candidate) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
 
     result = _run_just(
         [
@@ -3095,7 +3098,7 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8")
     assert "release-manifest preflight" in commands
     assert "helm template " in commands
-    assert "charts/dspace:3.0.2" in commands
+    assert "charts/dspace:3.0.3" in commands
     assert "docs/examples/dspace.values.staging.yaml" in commands
     assert "main-abcdef0" in commands
 
@@ -3690,12 +3693,15 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     )
     assert staged.returncode == 0, staged.stderr + staged.stdout
     staging_record = json.loads(staging_evidence.read_text(encoding="utf-8"))
-    staging_record["chartVersion"] = "3.0.2"
+    staging_record["chartVersion"] = "3.0.3"
     staging_evidence.write_text(json.dumps(staging_record) + "\n", encoding="utf-8")
     _write_dspace_candidate(prod_manifest, "prod")
+    prod_candidate = json.loads(prod_manifest.read_text(encoding="utf-8"))
+    prod_candidate["chartVersion"] = "3.0.3"
+    prod_manifest.write_text(json.dumps(prod_candidate) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
     env["SUGARKUBE_STUB_PROD_VERIFIER_FAIL"] = "1"
     for name in ("helm.log", "commands.log", "runtime-verifier.log"):
         (tmp_path / name).write_text("", encoding="utf-8")

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -170,6 +170,37 @@ def test_chart_maintenance_target_drift_fails_before_reservation_or_mutation(
     assert commands == []
 
 
+def test_configuration_reconciliation_rejects_mismatched_production_pin_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.manifest.write_text(PROD_BASELINE.read_text(encoding="utf-8"), encoding="utf-8")
+    version_file = tmp_path / "dspace.prod.version"
+    version_file.write_text("3.0.2\n", encoding="utf-8")
+    monkeypatch.setattr(
+        rollback.app_config,
+        "load_config",
+        lambda *_args: {
+            "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+            "SUGARKUBE_RELEASE": "dspace",
+            "SUGARKUBE_NAMESPACE": "dspace",
+            "SUGARKUBE_VERSION_FILE": version_file.name,
+        },
+    )
+    args.configuration_reconciliation = True
+    args.maintenance_target = PROD_MAINTENANCE_TARGET
+    staged = tmp_path / "staged"
+    staged.mkdir()
+
+    with pytest.raises(rollback.RollbackError, match="production chart pin differs"):
+        rollback._rollback(args, lambda command: commands.append(command) or "", staged)
+
+    assert not evidence.exists()
+    assert commands == []
+
+
 def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None:
     validated = target(schema_version=2)
     projected = {field: validated[field] for field in manifest.candidate_fields(validated)}
@@ -389,6 +420,36 @@ def test_main_rejects_mixed_or_incomplete_maintenance_coordinates(
 
     with pytest.raises(SystemExit, match="2"):
         rollback.main([*coordinates, *common])
+
+
+def test_main_forwards_complete_maintenance_coordinates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    maintenance_target = tmp_path / "target.json"
+    captured: list[Namespace] = []
+    monkeypatch.setattr(rollback, "rollback", lambda args: captured.append(args) or {})
+
+    result = rollback.main(
+        [
+            "--baseline-manifest",
+            str(baseline),
+            "--maintenance-target",
+            str(maintenance_target),
+            "--configuration-reconciliation",
+            "--environment",
+            "prod",
+            "--evidence",
+            str(tmp_path / "evidence.json"),
+            "--verifier",
+            str(tmp_path / "verifier"),
+        ]
+    )
+
+    assert result == 0
+    assert len(captured) == 1
+    assert captured[0].manifest == baseline
+    assert captured[0].maintenance_target == maintenance_target
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -13,6 +13,8 @@ from scripts import dspace_release_manifest as manifest
 
 SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
+PROD_BASELINE = Path("deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json")
+PROD_MAINTENANCE_TARGET = Path("docs/apps/dspace.prod-metrics-chart-target.json")
 
 
 def target(environment: str = "staging", schema_version: int = 1) -> dict[str, object]:
@@ -45,13 +47,37 @@ def target(environment: str = "staging", schema_version: int = 1) -> dict[str, o
     }
     if schema_version == 2:
         value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
-    checks = sorted(manifest.required_final_checks(value)) + [
-        "imagePlatformSourceRevision[0]"
-    ]
+    checks = sorted(manifest.required_final_checks(value)) + ["imagePlatformSourceRevision[0]"]
     value["verificationResults"] = [
         {"check": check, "passed": True, "details": "observed"} for check in checks
     ]
     return manifest.validate(value, True)
+
+
+def test_chart_maintenance_target_preserves_application_and_changes_only_chart() -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+
+    changed = {field for field in baseline if baseline[field] != selected[field]}
+    assert changed == {"chartSourceRevision", "chartVersion", "chartDigest"}
+    assert selected["chartVersion"] == "3.0.3"
+    assert selected["chartDigest"] == (
+        "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+    )
+
+
+@pytest.mark.parametrize("drift", ("applicationVersion", "unknown"))
+def test_chart_maintenance_target_rejects_drift_and_unknown_fields(
+    tmp_path: Path, drift: str
+) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    reviewed = manifest._object(PROD_MAINTENANCE_TARGET)
+    reviewed[drift] = "unexpected"
+    path = tmp_path / "target.json"
+    path.write_text(json.dumps(reviewed), encoding="utf-8")
+
+    with pytest.raises(rollback.RollbackError, match="application or image|schema mismatch"):
+        rollback.chart_maintenance_target(baseline, path)
 
 
 def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None:
@@ -461,9 +487,7 @@ def test_helm_319_snapshot_resolves_exact_current_history_without_leaking_raw_ou
 
     status = helm_319_status()
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
-    observed, history, identity = rollback.helm_snapshot(
-        runner, "kubeconfig", "dspace", "dspace"
-    )
+    observed, history, identity = rollback.helm_snapshot(runner, "kubeconfig", "dspace", "dspace")
 
     assert identity == ("dspace", "3.0.2", 9)
     assert observed is status
@@ -483,9 +507,7 @@ def test_helm_319_snapshot_resolves_exact_current_history_without_leaking_raw_ou
 def test_helm_snapshot_uses_status_metadata_without_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    status = helm_319_status(
-        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}
-    )
+    status = helm_319_status(chart={"metadata": {"name": "dspace", "version": "3.0.2"}})
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
     _status, history, identity = rollback.helm_snapshot(
         lambda _command: pytest.fail("history must not be queried"),
@@ -516,9 +538,7 @@ def test_helm_snapshot_rejects_non_object_status_metadata(
 
 def test_helm_history_rejects_invalid_json() -> None:
     with pytest.raises(rollback.RollbackError, match="valid JSON"):
-        rollback.helm_history(
-            lambda _command: "not-json", "kubeconfig", "dspace", "dspace"
-        )
+        rollback.helm_history(lambda _command: "not-json", "kubeconfig", "dspace", "dspace")
 
 
 @pytest.mark.parametrize(
@@ -531,9 +551,7 @@ def test_helm_history_rejects_invalid_json() -> None:
 def test_helm_snapshot_rejects_status_identity_or_state(
     monkeypatch: pytest.MonkeyPatch, changes: dict[str, object]
 ) -> None:
-    status = helm_319_status(
-        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}, **changes
-    )
+    status = helm_319_status(chart={"metadata": {"name": "dspace", "version": "3.0.2"}}, **changes)
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
 
     with pytest.raises(rollback.RollbackError, match="identity"):

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -63,6 +63,15 @@ def test_chart_pin_ignores_comments_and_blank_lines(tmp_path: Path) -> None:
     assert rollback.chart_pin(pin) == "3.0.3"
 
 
+def test_chart_pin_failure_is_redacted(tmp_path: Path) -> None:
+    missing = tmp_path / "sensitive" / "dspace.prod.version"
+
+    with pytest.raises(rollback.RollbackError, match="unreadable or invalid") as error:
+        rollback.chart_pin(missing)
+
+    assert str(missing) not in str(error.value)
+
+
 def test_chart_maintenance_target_preserves_application_and_changes_only_chart() -> None:
     baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
     selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
@@ -86,6 +95,20 @@ def test_chart_maintenance_target_rejects_drift_and_unknown_fields(
     path.write_text(json.dumps(reviewed), encoding="utf-8")
 
     with pytest.raises(rollback.RollbackError, match="application or image|schema mismatch"):
+        rollback.chart_maintenance_target(baseline, path)
+
+
+def test_chart_maintenance_target_rejects_matching_but_unapproved_application(
+    tmp_path: Path,
+) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    reviewed = manifest._object(PROD_MAINTENANCE_TARGET)
+    baseline["applicationVersion"] = reviewed["applicationVersion"] = "3.0.0"
+    baseline["semanticTag"] = reviewed["semanticTag"] = "v3.0.0"
+    path = tmp_path / "target.json"
+    path.write_text(json.dumps(reviewed), encoding="utf-8")
+
+    with pytest.raises(rollback.RollbackError, match="approved application tuple"):
         rollback.chart_maintenance_target(baseline, path)
 
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -112,6 +112,40 @@ def test_chart_maintenance_target_rejects_matching_but_unapproved_application(
         rollback.chart_maintenance_target(baseline, path)
 
 
+def test_chart_maintenance_target_rejects_unapproved_baseline_tuple() -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    baseline["chartVersion"] = "3.0.1"
+
+    with pytest.raises(rollback.RollbackError, match="approved finalized production chart tuple"):
+        rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    (
+        ("not JSON", "chart maintenance target is invalid"),
+        (
+            json.dumps(
+                {
+                    **manifest._object(PROD_MAINTENANCE_TARGET),
+                    "schemaVersion": 1,
+                }
+            ),
+            "schema 2 for dspace",
+        ),
+    ),
+)
+def test_chart_maintenance_target_rejects_invalid_records(
+    tmp_path: Path, contents: str, message: str
+) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    path = tmp_path / "maintenance-target.json"
+    path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(rollback.RollbackError, match=message):
+        rollback.chart_maintenance_target(baseline, path)
+
+
 @pytest.mark.parametrize("field", ("chartSourceRevision", "chartDigest"))
 def test_chart_maintenance_target_drift_fails_before_reservation_or_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, field: str
@@ -331,6 +365,30 @@ def test_missing_or_candidate_target_fails_before_any_external_command(
     assert rollback.main(["--manifest", str(source), *common]) == 2
     assert called == []
     assert not (tmp_path / "rollback.json").exists()
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    (
+        ("--manifest", "baseline.json", "--configuration-reconciliation"),
+        ("--baseline-manifest", "baseline.json"),
+        ("--manifest", "baseline.json", "--maintenance-target", "target.json"),
+    ),
+)
+def test_main_rejects_mixed_or_incomplete_maintenance_coordinates(
+    tmp_path: Path, coordinates: tuple[str, ...]
+) -> None:
+    common = (
+        "--environment",
+        "prod",
+        "--evidence",
+        str(tmp_path / "evidence.json"),
+        "--verifier",
+        str(tmp_path / "verifier"),
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        rollback.main([*coordinates, *common])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -54,6 +54,15 @@ def target(environment: str = "staging", schema_version: int = 1) -> dict[str, o
     return manifest.validate(value, True)
 
 
+def test_chart_pin_ignores_comments_and_blank_lines(tmp_path: Path) -> None:
+    pin = tmp_path / "dspace.prod.version"
+    pin.write_text(
+        "# application remains at 3.0.1\n\n  3.0.3  # reviewed chart\n", encoding="utf-8"
+    )
+
+    assert rollback.chart_pin(pin) == "3.0.3"
+
+
 def test_chart_maintenance_target_preserves_application_and_changes_only_chart() -> None:
     baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
     selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -112,6 +112,30 @@ def test_chart_maintenance_target_rejects_matching_but_unapproved_application(
         rollback.chart_maintenance_target(baseline, path)
 
 
+@pytest.mark.parametrize("field", ("chartSourceRevision", "chartDigest"))
+def test_chart_maintenance_target_drift_fails_before_reservation_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, field: str
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    args.manifest.write_text(PROD_BASELINE.read_text(encoding="utf-8"), encoding="utf-8")
+    reviewed = manifest._object(PROD_MAINTENANCE_TARGET)
+    reviewed[field] = "sha256:" + "0" * 64 if field == "chartDigest" else "0" * 40
+    maintenance_target = tmp_path / "maintenance-target.json"
+    maintenance_target.write_text(json.dumps(reviewed), encoding="utf-8")
+    args.configuration_reconciliation = True
+    args.maintenance_target = maintenance_target
+    staged = tmp_path / "staged"
+    staged.mkdir()
+
+    with pytest.raises(rollback.RollbackError, match="reviewed production chart tuple"):
+        rollback._rollback(args, lambda command: commands.append(command) or "", staged)
+
+    assert not evidence.exists()
+    assert commands == []
+
+
 def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None:
     validated = target(schema_version=2)
     projected = {field: validated[field] for field in manifest.candidate_fields(validated)}
@@ -1176,19 +1200,40 @@ def test_configuration_reconciliation_reasserts_target_immediately_before_upgrad
         assert written["diagnostics"][diagnostic_failure] == "unavailable"
 
 
+@pytest.mark.parametrize("after_revision", (10, 11))
 def test_configuration_reconciliation_completes_all_production_gates(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, after_revision: int
 ) -> None:
     args, commands, evidence, verifier = pre_reservation_case(
         tmp_path, monkeypatch, environment="prod"
     )
-    selected = target("prod", schema_version=2)
-    args.manifest.write_text(manifest._canonical(selected), encoding="utf-8")
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    args.manifest.write_text(manifest._canonical(baseline), encoding="utf-8")
+    maintenance_target = tmp_path / "maintenance-target.json"
+    maintenance_target.write_text(
+        PROD_MAINTENANCE_TARGET.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    version_file = tmp_path / "dspace.prod.version"
+    version_file.write_text("# application remains 3.0.1\n3.0.3\n", encoding="utf-8")
+    values_file = tmp_path / "values.yaml"
+    monkeypatch.setattr(
+        rollback.app_config,
+        "load_config",
+        lambda *_args: {
+            "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+            "SUGARKUBE_RELEASE": "dspace",
+            "SUGARKUBE_NAMESPACE": "dspace",
+            "SUGARKUBE_VALUES": str(values_file),
+            "SUGARKUBE_VERSION_FILE": version_file.name,
+        },
+    )
     kubeconfig = tmp_path / "kubeconfig"
     kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
     args.configuration_reconciliation = True
+    args.maintenance_target = maintenance_target
     args.kubeconfig = str(kubeconfig)
-    args.confirm = f"dspace:prod:{SHA}"
+    args.confirm = f"dspace:prod:{selected['sourceRevision']}"
     image = {
         "repository": manifest.IMAGE_REF,
         "tag": selected["imageTag"],
@@ -1238,20 +1283,21 @@ def test_configuration_reconciliation_completes_all_production_gates(
         return {
             **pod(uid),
             "applicationImage": f"{manifest.IMAGE_REF}:{selected['imageTag']}",
-            "applicationImageID": f"{manifest.IMAGE_REF}@{DIGEST}",
+            "applicationImageID": f"{manifest.IMAGE_REF}@{selected['imageDigest']}",
         }
 
     before_pods = [ready("1"), ready("2")]
     after_pods = [ready("3"), ready("4")]
     terminating_pods = [{**ready("2"), "terminating": True}, *after_pods]
     state = {"upgraded": False, "description": "", "post_upgrade_pod_reads": 0}
+    staged_target: dict[str, object] = {}
     monkeypatch.setattr(rollback.time, "sleep", lambda _seconds: None)
 
     def status(*_args: object) -> dict[str, object]:
         return {
             "name": "dspace",
             "namespace": "dspace",
-            "version": 8 if state["upgraded"] else 7,
+            "version": after_revision if state["upgraded"] else 9,
             "info": {
                 "status": "deployed",
                 "description": state["description"] if state["upgraded"] else "previous",
@@ -1283,8 +1329,13 @@ def test_configuration_reconciliation_completes_all_production_gates(
             return json.dumps(
                 [
                     {
-                        "revision": 8 if state["upgraded"] else 7,
-                        "chart": f"dspace-{selected['chartVersion']}",
+                        "revision": after_revision if state["upgraded"] else 9,
+                        "chart": "dspace-"
+                        + (
+                            selected["chartVersion"]
+                            if state["upgraded"]
+                            else baseline["chartVersion"]
+                        ),
                     }
                 ]
             )
@@ -1295,34 +1346,61 @@ def test_configuration_reconciliation_completes_all_production_gates(
         elif command[0] == "helm" and "manifest" in command:
             return "live render"
         elif command[:2] == [str(verifier), "verify"]:
-            return json.dumps(verifier_result(environment="prod"))
+            staged_target.update(
+                json.loads(
+                    Path(command[command.index("--manifest") + 1]).read_text(encoding="utf-8")
+                )
+            )
+            return json.dumps(
+                verifier_result(
+                    environment="prod",
+                    applicationVersion=selected["applicationVersion"],
+                    runtimeSourceRevision=selected["sourceRevision"],
+                    frontendSourceRevision=selected["sourceRevision"],
+                    defaultProvider=selected["expectedDefaultChatProvider"],
+                )
+            )
         elif command[0] == "kubectl" and (
             "replicasets,deployments" in command or "pods" in command
         ):
             return '{"items": []}'
         return ""
 
+    if after_revision == 11:
+        with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+            rollback.rollback(args, runner)
+        written = json.loads(evidence.read_text(encoding="utf-8"))
+        assert written["state"] == "failed"
+        assert written["failedStage"] == "pod-settling-and-proof"
+        assert written["clusterMayHaveChanged"] is True
+        assert sum("upgrade" in command for command in commands) == 1
+        assert not any("rollback" in command or "uninstall" in command for command in commands)
+        return
+
     result = rollback.rollback(args, runner)
 
     upgrade = next(command for command in commands if "upgrade" in command)
+    assert sum("upgrade" in command for command in commands) == 1
     assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
     forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
     assert not any(item in upgrade for item in forbidden)
-    assert DIGEST not in next(item for item in upgrade if item.startswith("image.tag="))
+    assert selected["imageDigest"] not in next(
+        item for item in upgrade if item.startswith("image.tag=")
+    )
     assert finalized["helm_stored_values_result"] is stored_proof
     assert finalized["helm_history"] == [
-        {"revision": 8, "chart": f"dspace-{selected['chartVersion']}"}
+        {"revision": 10, "chart": f"dspace-{selected['chartVersion']}"}
     ]
     assert finalized["expected_image_coordinate"] == (
         f"{manifest.IMAGE_REF}:{selected['imageTag']}"
     )
     assert result["state"] == "succeeded"
-    assert result["helm"]["beforeRevision"] == 7
-    assert result["helm"]["afterRevision"] == 8
+    assert result["helm"]["beforeRevision"] == 9
+    assert result["helm"]["afterRevision"] == 10
     assert result["verification"]["helmStoredValues"] == stored_proof
-    assert result["verification"]["runtime"]["sourceRevision"] == SHA
+    assert result["verification"]["runtime"]["sourceRevision"] == selected["sourceRevision"]
     journeys = {item["name"] for item in result["verification"]["journeys"]}
     assert journeys == {"/", "/chat"}
     assert result["verification"]["productionMetrics"] == {
@@ -1346,6 +1424,15 @@ def test_configuration_reconciliation_completes_all_production_gates(
     ]
     assert len(metrics_verifications) == 1
     assert state["post_upgrade_pod_reads"] == 2
+    assert staged_target["recordType"] == "candidate"
+    for field in manifest.candidate_fields(selected):
+        if field == "recordType":
+            continue
+        assert staged_target[field] == selected[field]
+    verifier_command = next(
+        command for command in commands if command[:2] == [str(verifier), "verify"]
+    )
+    assert verifier_command[verifier_command.index("--manifest") + 1] != str(args.manifest)
 
 
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(
@@ -1398,6 +1485,8 @@ def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
         ("rollout", "rollout-wait", True),
         ("verifier", "runtime-verification", True),
         ("revision", "revision-stability-collection", True),
+        ("unchanged-revision", "pod-settling-and-proof", True),
+        ("lower-revision", "pod-settling-and-proof", True),
     ],
 )
 def test_orchestration_preserves_complete_success_and_failure_evidence(
@@ -1456,6 +1545,10 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
             }
         post_status_calls[0] += 1
         revision = 9 if failure == "revision" and post_status_calls[0] >= 2 else 8
+        if failure == "unchanged-revision":
+            revision = 7
+        elif failure == "lower-revision":
+            revision = 6
         observed: dict[str, object] = {
             "name": "dspace",
             "namespace": "dspace",
@@ -1495,7 +1588,8 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
             if failure == "helm":
                 raise rollback.RollbackError(sentinel)
         if command[0] == "helm" and "history" in command:
-            return json.dumps([{"revision": 8, "chart": "dspace-3.2.0"}])
+            revision = {"unchanged-revision": 7, "lower-revision": 6}.get(failure, 8)
+            return json.dumps([{"revision": revision, "chart": "dspace-3.2.0"}])
         if command[0] == "kubectl" and "rollout" in command and failure == "rollout":
             raise rollback.RollbackError(sentinel)
         if command[:2] == [str(verifier), "verify"]:
@@ -1540,7 +1634,11 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
         assert observed["helm"] == {
             "release": "dspace",
             "namespace": "dspace",
-            "revision": 7 if failure == "pre-mutation" else (9 if failure == "revision" else 8),
+            "revision": (
+                7
+                if failure in ("pre-mutation", "unchanged-revision")
+                else 6 if failure == "lower-revision" else 9 if failure == "revision" else 8
+            ),
             "status": "failed" if failure == "helm" else "deployed",
             "chartName": "dspace",
             "chartVersion": "3.1.0" if failure == "pre-mutation" else "3.2.0",
@@ -1551,6 +1649,9 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
         assert observed["pods"][0]["images"]["dspace"]
         assert observed["pods"][0]["imageIDs"]["dspace"]
         assert "ownerReferences" in observed["pods"][0]
+        if failure in ("unchanged-revision", "lower-revision"):
+            assert sum("upgrade" in command for command in commands) == 1
+            assert not any("rollback" in command or "uninstall" in command for command in commands)
         return
 
     result = rollback.rollback(args, runner)

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -484,6 +484,17 @@ def test_generated_final_record_validates_through_cli(tmp_path: Path) -> None:
     assert manifest.main(["validate", "--manifest", str(output), "--final"]) == 0
 
 
+def test_validate_cli_auto_detects_candidate_and_final_records(tmp_path: Path) -> None:
+    candidate_path = tmp_path / "candidate.json"
+    final_path = tmp_path / "final.json"
+    candidate_path.write_text(manifest._canonical(candidate()), encoding="utf-8")
+    final_path.write_text(manifest._canonical(finalize()), encoding="utf-8")
+
+    assert manifest.main(["validate", "--manifest", str(candidate_path)]) == 0
+    assert manifest.main(["validate", "--manifest", str(final_path)]) == 0
+    assert manifest.main(["validate", "--manifest", str(candidate_path), "--final"]) == 2
+
+
 def test_runtime_proof_and_complete_runtime_checks_validate() -> None:
     value = runtime_final()
     assert manifest.validate(value, True) == value


### PR DESCRIPTION
### Motivation

Add a fail-closed, chart-only production maintenance path that upgrades DSPACE chart 3.0.2 to the reviewed immutable 3.0.3 chart while preserving the exact DSPACE 3.0.1 application, source, image, provider, replicas, routing, credentials, and historical evidence.

### Summary

- Add `docs/apps/dspace.prod-metrics-chart-target.json` with the exact reviewed chart 3.0.3 coordinates:
  - source revision `62da11005354e9f9a89c2e58584cdce4c8ec35aa`
  - chart digest `sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c`
  - unchanged DSPACE 3.0.1 application, source, image, and semantic-tag coordinates
- Advance `docs/apps/dspace.prod.version` from 3.0.2 to 3.0.3.
- Extend `dspace-prod-metrics-reconcile` with explicit `baseline_manifest` and `maintenance_target` inputs.
- Harden `scripts/dspace_manifest_rollback.py` to:
  - validate the exact finalized 3.0.2 production baseline and strict 3.0.3 target;
  - reject unknown fields or application, image, provider, environment, chart-source, or digest drift;
  - parse the comment-bearing production chart pin using the shared parser with redacted failures;
  - verify the production cluster, live Helm revision/chart, two Ready pods, image digest, stored values, Secret contract, render, and OCI provenance before mutation;
  - revalidate state immediately before one digest-qualified Helm upgrade;
  - require revision 9→10 for the verified baseline while deriving revision 9 from evidence;
  - preserve failed evidence and never automatically retry, uninstall, or roll back.
- Preserve the generic rollback requirement that Helm revisions advance while requiring exactly one increment for production configuration reconciliation.
- Keep the exact 3.0.2 and 3.0.3 application-identical tuples in the bounded legacy runtime identity allowlist.
- Preserve historical 3.0.2 recovery behavior by using an invocation-local 3.0.2 version pin rather than the advanced production pin.
- Allow release-manifest CLI validation to auto-detect candidate versus finalized records when `--final` is omitted; explicitly supplying `--final` still requires finalized evidence.
- Add deterministic regression coverage for:
  - malformed, schema-invalid, drifted, or unapproved maintenance records;
  - an unapproved finalized baseline tuple;
  - a mismatched production chart pin failing before reservation or external commands;
  - mixed or incomplete CLI maintenance coordinates;
  - forwarding complete baseline and maintenance-target coordinates;
  - the exact 3.0.2 revision-9 to 3.0.3 revision-10 path and revision-jump failures;
  - unchanged or lower revisions in generic rollback mode.

### Safety invariants

- `deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json` remains unchanged.
- `docs/apps/dspace.prod.tag` and staging coordinates remain unchanged.
- Application version `3.0.1`, source `1a31a569aff2dbeb238e8c2688b9e85140d2077d`, image `main-1a31a56`, image digest, provider `openai`, and two-replica runtime identity remain unchanged.
- Only the reviewed chart source/version/digest tuple changes.
- No Secret value is read, printed, or stored in evidence.
- No live Kubernetes, Helm, registry, tag, or Secret mutation was performed while developing this PR.

### Testing

- `pytest -q tests/test_manifest_rollback.py --cov=. --cov-report=xml --cov-report=term-missing` — 100 passed; all executable changed lines in `scripts/dspace_manifest_rollback.py` covered
- `coverage report -m scripts/dspace_manifest_rollback.py` — 89% total file coverage; no uncovered executable lines intersect the production-script diff
- `pytest -q tests/test_release_manifest.py` — 235 passed
- `pytest -q tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py` — passed
- `pytest -q tests/test_dspace_runtime_verifier.py` — passed
- `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json` — passed
- `python3 scripts/app_config.py json --app dspace --env prod` — passed
- `python3 -m compileall -q scripts/dspace_manifest_rollback.py tests/test_manifest_rollback.py` — passed
- `black --check tests/test_manifest_rollback.py` — passed
- `ruff check tests/test_manifest_rollback.py` — passed
- `git diff --check` — passed
- `git diff --cached | ./scripts/scan-secrets.py` — passed
- Verified no diff to the finalized production evidence or `docs/apps/dspace.prod.tag`.

### Post-merge operator command

~~~bash
just dspace-prod-metrics-reconcile \
  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
  evidence="$FRESH_NONEXISTING_EVIDENCE" \
  smoke_runner="$DSPACE_SMOKE_RUNNER" \
  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
~~~

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ccef7cd7c832fa2f1d6cf729839f7)