### PR TITLE
Add guarded chart-only DSPACE production metrics upgrade (chart 3.0.3)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,59 +2,51 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
-## Production authenticated metrics at the existing release
+## Production authenticated metrics chart maintenance
 
-DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
-**3.0.2**. This repository change does not deploy application or chart code, and it is not a
-promotion. It supplies the reviewed values contract for an upgrade-only configuration
-reconciliation at the existing immutable coordinates.
+This is a **chart-only maintenance upgrade** from DSPACE chart 3.0.2 to the immutable,
+digest-qualified chart 3.0.3. It enables the committed authenticated metrics and ServiceMonitor
+contract without promoting the application: application 3.0.1, source revision `1a31a569...`, image
+`main-1a31a56` at its existing digest, OpenAI provider, two replicas, routing, and credentials remain
+unchanged. Historical finalized evidence remains unchanged.
 
 Run production operations from `sugarkube3` with the externally managed API tunnel listening on
-`127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
-`just kubeconfig-env env=prod` on that host:
+`127.0.0.1:16443`. Use the explicit production kubeconfig and context. The metrics Secret must
+already exist; this reconciliation checks only its contract and never reads, prints, or rotates its
+value.
 
 ```bash
 export KUBECONFIG="$HOME/.kube/config-sugarkube-prod"
 test "$(kubectl config current-context)" = sugar-prod
 python3 scripts/cluster_identity.py assert --kubeconfig "$KUBECONFIG" --env prod
-just observability-app-metrics-secret-install app=dspace env=prod
 just observability-app-metrics-secret-check app=dspace env=prod
 ```
 
-The hidden-input installer creates or rotates only `dspace/dspace-prod-metrics-token` key `token`;
-the check proves that the key is nonempty without reading it. Install and check it before any
-reconciliation. Never put the credential in an argument, environment variable, transcript, or
-evidence file.
-
-The reconciliation operator must supply the genuine existing finalized production evidence, the
-executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destination. Discover the
-current Helm revision immediately before the operation rather than assuming revision 9. Review the
-digest-qualified chart render and transient live-versus-desired values comparison: the only
-permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
-3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
-`--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
+Supply both the genuine finalized 3.0.2 baseline and the separately reviewed 3.0.3 target. The
+expected live transition for that verified baseline is revision 9 to revision 10, but the tooling
+derives revision 9 from the baseline and requires exactly one revision advance rather than
+hard-coding either revision.
 
 ```bash
 just dspace-prod-metrics-reconcile \
-  manifest="$GENUINE_FINALIZED_PROD_EVIDENCE" \
+  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
   evidence="$FRESH_NONEXISTING_EVIDENCE" \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$HOME/.kube/config-sugarkube-prod" \
-  confirm="dspace:prod:<40-character-application-SHA>"
+  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
 ```
 
-After rollout, run the DSPACE runtime and `/chat` verification, then run:
+The guard proves the exact live baseline, two Ready pods and their resolved image digest, strict
+application identity equality, the production chart pin, fresh OCI chart provenance, bounded
+values drift, the baseline render, the target render, and the authenticated metrics render before
+using the exact chart digest without `--reuse-values`. Afterward it proves chart 3.0.3, exactly one
+Helm revision, replacement pods with the unchanged image, runtime/frontend/provider and remote
+`/chat` identity, and production metrics.
 
-```bash
-just observability-app-metrics-verify app=dspace env=prod
-just observability-dashboard-verify env=prod
-```
-
-Inspect the production dashboard manually. DSPACE HTTP, runtime, and feature panels should
-populate. Release-integrity, blackbox, token.place, and alerting panels may remain `NO DATA` until
-those separate production integrations are deployed. A failure after mutation is not permission
-to rerun or roll back immediately: preserve and review the reserved failure evidence, discover the
-new live revision, and plan a deliberate reconciliation.
+A failure after evidence reservation is not permission to rerun, uninstall, roll back, delete or
+rotate the Secret. Preserve and review the failed evidence and live revision before any further
+mutation.
 
 ## Production Helm reconciliation for application 3.0.1
 
@@ -380,7 +372,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.3`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 

--- a/docs/apps/dspace.prod-metrics-chart-target.json
+++ b/docs/apps/dspace.prod-metrics-chart-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "chartVersion": "3.0.3",
+  "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+  "semanticTag": "v3.0.1"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.2
+# DSPACE production chart pin. Keep aligned with the reviewed chart-only target.
+3.0.3

--- a/justfile
+++ b/justfile
@@ -1794,8 +1794,8 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
     fi
     "${rollback_command[@]}"
 
-# Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
-dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+# Chart-only production DSPACE metrics reconciliation from finalized baseline to reviewed target.
+dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1805,7 +1805,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         value="${value#"${name}="}"
       else
         case "${value}" in
-          manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
             echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
             return 2
             ;;
@@ -1818,7 +1818,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       printf '%s' "${value}"
     }
 
-    manifest_path="$(normalize_argument manifest {{ quote(manifest) }} true)"
+    baseline_path="$(normalize_argument baseline_manifest {{ quote(baseline_manifest) }} true)"
+    target_path="$(normalize_argument maintenance_target {{ quote(maintenance_target) }} true)"
     evidence_path="$(normalize_argument evidence {{ quote(evidence) }} true)"
     smoke_path="$(normalize_argument smoke_runner {{ quote(smoke_runner) }} true)"
     kubeconfig_path="$(normalize_argument kubeconfig {{ quote(kubeconfig) }} true)"
@@ -1838,7 +1839,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+        baseline_manifest=*|maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
           echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
           exit 2
           ;;
@@ -1850,7 +1851,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
       --configuration-reconciliation
       --environment prod
-      --manifest "${manifest_path}"
+      --baseline-manifest "${baseline_path}"
+      --maintenance-target "${target_path}"
       --evidence "${evidence_path}"
       --smoke-runner "${smoke_path}"
       --kubeconfig "${kubeconfig_path}"

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -280,9 +280,7 @@ def helm_status(
     )
 
 
-def helm_history(
-    runner: Runner, kubeconfig: str, release_name: str, namespace: str
-) -> object:
+def helm_history(runner: Runner, kubeconfig: str, release_name: str, namespace: str) -> object:
     try:
         return json.loads(
             runner(
@@ -310,9 +308,7 @@ def helm_snapshot(
     namespace: str,
     *,
     require_deployed: bool = True,
-) -> tuple[
-    dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]
-]:
+) -> tuple[dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]]:
     """Read a redaction-safe, revision-bound Helm release identity."""
     status = helm_status(runner, kubeconfig, release_name, namespace)
     history: list[dict[str, Any]] | None = None
@@ -348,9 +344,7 @@ def helm_snapshot(
             expected_version
         ):
             raise release.ManifestError("invalid Helm release identity")
-        identity = release.resolve_helm_identity(
-            status, history, release_name, expected_version
-        )
+        identity = release.resolve_helm_identity(status, history, release_name, expected_version)
     except release.ManifestError as exc:
         raise RollbackError("Helm release identity is invalid") from exc
     if status.get("name") != release_name or status.get("namespace") != namespace:
@@ -564,9 +558,7 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
 
 
 def assert_production_target(kubeconfig: str, runner: Runner) -> None:
-    context = runner(
-        ["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]
-    ).strip()
+    context = runner(["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]).strip()
     if context != "sugar-prod":
         raise RollbackError("metrics configuration reconciliation requires sugar-prod")
     runner(
@@ -605,6 +597,40 @@ def configuration_comparison_baselines(
     return baseline, desired_baseline
 
 
+def maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, Any]:
+    """Validate and apply a chart-only maintenance tuple to finalized evidence."""
+    try:
+        coordinates = release._object(path)
+        release._exact_fields(coordinates, release.UPSTREAM_FIELDS_V2)
+        release._validate_upstream(coordinates)
+    except release.ManifestError as exc:
+        raise RollbackError(f"chart maintenance target is invalid: {exc}") from exc
+    if coordinates["schemaVersion"] != 2:
+        raise RollbackError("chart maintenance target schemaVersion must be 2")
+    application_fields = (
+        "app",
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "semanticTag",
+    )
+    if any(coordinates[field] != baseline[field] for field in application_fields):
+        raise RollbackError("chart maintenance target changes application or image identity")
+    baseline_chart = tuple(
+        baseline[field] for field in ("chartSourceRevision", "chartVersion", "chartDigest")
+    )
+    target_chart = tuple(
+        coordinates[field] for field in ("chartSourceRevision", "chartVersion", "chartDigest")
+    )
+    if baseline_chart == target_chart:
+        raise RollbackError("chart maintenance target does not change the chart tuple")
+    target = copy.deepcopy(baseline)
+    for field in ("chartSourceRevision", "chartVersion", "chartDigest"):
+        target[field] = coordinates[field]
+    return target
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -625,16 +651,28 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
 
 def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) -> dict[str, Any]:
     started = timestamp()
-    args.manifest = args.manifest.expanduser()
+    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    explicit_maintenance_target = getattr(args, "maintenance_target", None)
+    manifest_path = (
+        getattr(args, "baseline_manifest", None).expanduser()
+        if configuration_reconciliation and getattr(args, "baseline_manifest", None) is not None
+        else args.manifest.expanduser()
+    )
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
     try:
-        target = release.validate(release._object(args.manifest), True)
+        baseline = release.validate(release._object(manifest_path), True)
     except release.ManifestError as exc:
-        raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
-    if target["environment"] != args.environment:
+        raise RollbackError(f"baseline must be finalized DSPACE release evidence: {exc}") from exc
+    if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
-    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    target = baseline
+    verifier_manifest = manifest_path
+    if configuration_reconciliation and explicit_maintenance_target is not None:
+        target = maintenance_target(baseline, explicit_maintenance_target.expanduser())
+        verifier_manifest = staged_directory / "approved-target.json"
+        verifier_manifest.write_text(release._canonical(target), encoding="utf-8")
+        os.chmod(verifier_manifest, 0o600)
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -650,6 +688,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
+    if configuration_reconciliation and explicit_maintenance_target is not None:
+        configured_chart_version = (
+            (root / config["SUGARKUBE_VERSION_FILE"])
+            .read_text(encoding="utf-8")
+            .splitlines()[-1]
+            .strip()
+        )
+        if configured_chart_version != target["chartVersion"]:
+            raise RollbackError("configured DSPACE chart pin does not match the approved target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
@@ -670,7 +717,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     extended_verifier = verifier_accepts_runtime_arguments(
         args.verifier,
         args.environment,
-        args.manifest,
+        verifier_manifest,
         getattr(args, "smoke_runner", None),
         args.kubeconfig,
         args.config,
@@ -704,7 +751,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != target["helmRevision"]:
+        if before_identity[2] != baseline["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -719,7 +766,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", target["chartVersion"]):
+        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -769,7 +816,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 args.kubeconfig,
                 "template",
                 "dspace",
-                coordinate,
+                (
+                    release.chart_coordinate({**approved, "chartDigest": baseline["chartDigest"]})
+                    if explicit_maintenance_target is not None
+                    else coordinate
+                ),
                 "--namespace",
                 "dspace",
                 "--values",
@@ -794,9 +845,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             {"enabled": False},
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(
-            live_values, desired_values
-        )
+        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
         if baseline != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
@@ -1038,12 +1087,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= before_identity[2]:
+        if explicit_maintenance_target is not None:
+            if after_revision != before_identity[2] + 1:
+                raise RollbackError("Helm revision did not advance exactly once")
+        elif after_revision <= before_identity[2]:
             raise RollbackError("Helm revision did not advance")
-        if (
-            after_identity[0] != "dspace"
-            or after_identity[1] != target["chartVersion"]
-        ):
+        if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
             before_identity[1] != target["chartVersion"]
@@ -1158,7 +1207,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         # original verify contract for compatible third-party verifiers rather
         # than discovering that they reject new flags after Helm has mutated.
         if extended_verifier:
-            verifier_command.extend(("--manifest", str(args.manifest)))
+            verifier_command.extend(("--manifest", str(verifier_manifest)))
             smoke_runner = getattr(args, "smoke_runner", None)
             if smoke_runner:
                 verifier_command.extend(("--smoke-runner", str(smoke_runner)))
@@ -1252,8 +1301,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                     "status": observed_info.get("status"),
                     "chartName": observed_identity[0],
                     "chartVersion": observed_identity[1],
-                    "invocationDescriptionMatches": observed_info.get("description")
-                    == description,
+                    "invocationDescriptionMatches": observed_info.get("description") == description,
                 }
             except Exception:
                 diagnostics["helm"] = "unavailable"
@@ -1282,7 +1330,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
-    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--baseline-manifest", type=Path)
+    parser.add_argument("--maintenance-target", type=Path)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--verifier", type=Path, required=True)
     parser.add_argument("--smoke-runner", type=Path)
@@ -1293,6 +1343,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
     args = parser.parse_args(argv)
+    if args.configuration_reconciliation:
+        if args.baseline_manifest is None or args.maintenance_target is None:
+            parser.error("--baseline-manifest and --maintenance-target are required")
+    elif args.baseline_manifest is not None or args.maintenance_target is not None:
+        parser.error("maintenance coordinates require --configuration-reconciliation")
+    elif args.manifest is None:
+        parser.error("--manifest is required")
     if args.kubeconfig is None and not args.configuration_reconciliation:
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -71,7 +71,17 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
-LEGACY_IDENTITY_COORDINATES = (LEGACY_RECOVERY_COORDINATES, LEGACY_310_COORDINATES)
+LEGACY_METRICS_CHART_COORDINATES = {
+    **LEGACY_RECOVERY_COORDINATES,
+    "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+    "chartVersion": "3.0.3",
+    "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+}
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_METRICS_CHART_COORDINATES,
+    LEGACY_310_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -449,10 +459,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
-        if not any(
-            c.get("type") == "Ready" and c.get("status") == "True"
-            for c in conditions
-        ):
+        if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
             fail("pod/replica identity")
         owner = controller_owner(metadata.get("ownerReferences", []), "ReplicaSet")
         replica_set_name, replica_set_uid = owner.get("name"), owner.get("uid")

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -151,7 +151,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2980,7 +2980,8 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
     tmp_path: Path,
 ) -> None:
     values = {
-        "manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "baseline_manifest": str(tmp_path / "finalized baseline=approved.json"),
+        "maintenance_target": str(tmp_path / "reviewed target=approved.json"),
         "evidence": str(tmp_path / "fresh evidence=run-42.json"),
         "smoke_runner": str(tmp_path / "smoke runner=production"),
         "kubeconfig": str(tmp_path / "production kubeconfig=primary"),
@@ -3021,7 +3022,8 @@ def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_conf
     result, argv = _run_dspace_prod_metrics_reconcile(
         tmp_path,
         [
-            "manifest=/tmp/manifest.json",
+            "baseline_manifest=/tmp/baseline.json",
+            "maintenance_target=/tmp/target.json",
             "evidence=/tmp/evidence.json",
             "smoke_runner=/tmp/smoke-runner",
             "kubeconfig=/tmp/kubeconfig",
@@ -3045,11 +3047,12 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
             "/tmp/evidence.json",
             "/tmp/smoke-runner",
             "/tmp/kubeconfig",
+            "/tmp/verifier",
         ],
     )
 
     assert result.returncode != 0
-    assert "manifest must be positional or use the manifest= prefix" in result.stderr
+    assert "baseline_manifest must be positional or use the baseline_manifest= prefix" in result.stderr
     assert argv == []
 
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1518,3 +1518,32 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
     assert written["targetManifestFingerprint"] == result["targetManifestFingerprint"]
     assert written["helm"]["beforeRevision"] == 7
     assert written["helm"]["afterRevision"] == 8
+
+
+def test_chart_maintenance_target_is_strict_and_chart_only(tmp_path: Path) -> None:
+    baseline = target("prod", schema_version=2)
+    reviewed = {field: baseline[field] for field in manifest.UPSTREAM_FIELDS_V2}
+    reviewed.update(
+        chartSourceRevision="3" * 40,
+        chartVersion="3.2.1",
+        chartDigest="sha256:" + "4" * 64,
+    )
+    path = tmp_path / "maintenance.json"
+    path.write_text(manifest._canonical(reviewed), encoding="utf-8")
+    combined = rollback.maintenance_target(baseline, path)
+    assert combined["helmRevision"] == baseline["helmRevision"]
+    assert combined["expectedDefaultChatProvider"] == baseline["expectedDefaultChatProvider"]
+    assert combined["chartVersion"] == "3.2.1"
+    assert baseline["chartVersion"] == "3.2.0"
+
+    reviewed["unknown"] = True
+    path.write_text(manifest._canonical(reviewed), encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="unknown fields"):
+        rollback.maintenance_target(baseline, path)
+
+    reviewed.pop("unknown")
+    reviewed["imageTag"] = "main-0000000"
+    reviewed["sourceRevision"] = "0" * 40
+    path.write_text(manifest._canonical(reviewed), encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="application or image"):
+        rollback.maintenance_target(baseline, path)

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1890,3 +1890,19 @@ def test_finalize_rejects_noncanonical_image_id() -> None:
     item["status"]["containerStatuses"][0]["imageID"] = "not-a-digest"
     with pytest.raises(manifest.ManifestError, match="non-canonical pod imageID"):
         finalize(pods_json={"items": [item]})
+
+
+def test_production_metrics_chart_target_is_exact_chart_only_coordinate() -> None:
+    target_path = Path(__file__).parents[1] / "docs/apps/dspace.prod-metrics-chart-target.json"
+    assert json.loads(target_path.read_text(encoding="utf-8")) == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "chartVersion": "3.0.3",
+        "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+        "semanticTag": "v3.0.1",
+    }


### PR DESCRIPTION
### Motivation

- Provide a fail-closed, chart-only production reconciliation path that upgrades the deployed DSPACE Helm chart from 3.0.2 to the reviewed, digest-qualified chart 3.0.3 while preserving the exact application 3.0.1, image tag and digest, provider, replicas and historical evidence.
- Keep historical finalized evidence immutable and express the reviewed maintenance target separately so the operator can prove baseline provenance and apply only a chart tuple change.

### Description

- Add a reviewed production chart-only target file `docs/apps/dspace.prod-metrics-chart-target.json` that records schemaVersion 2 and the exact application, image, sourceRevision and the new chart tuple (chartSourceRevision / chartVersion / chartDigest).
- Update production chart pin to `3.0.3` in `docs/apps/dspace.prod.version` and update runbook text in `docs/apps/dspace.md` to document the chart-only maintenance flow and exact operator command.
- Extend `scripts/dspace_manifest_rollback.py` with a new `maintenance_target()` validator and refactor `_rollback` to treat a finalized baseline separately from a reviewed chart-only target, adding explicit CLI flags `--baseline-manifest` and `--maintenance-target` and preserving the original manifest flows for rollbacks.
- Enforce fail-closed guards: require baseline proof for live Helm revision/chart/image/pods, require the maintenance target to change only the chart tuple and no application/image/provider fields, require the configured production pin to match the target chart when applicable, require exactly one Helm revision advance for the verified baseline, and maintain all pre-/post-mutation verification and evidence reservation semantics.
- Update `justfile` recipe `dspace-prod-metrics-reconcile` to accept `baseline_manifest` + `maintenance_target` and forward unambiguous named args to the Python reconciler script.
- Add the reviewed 3.0.3 tuple into the runtime verifier legacy identity set so the bounded legacy runtime identity contract continues to accept both the 3.0.2 and 3.0.3 chart tuples for the unchanged application artifact.
- Add and update focused tests: `tests/test_manifest_rollback.py` (chart-only target handling), `tests/test_release_manifest.py` (target file assertion), `tests/test_generic_app_just_recipes.py` (just recipe arg normalization), `tests/test_dspace_runtime_values.py` (prod pin update), and related small adjustments to maintain existing behavior.

### Testing

- Ran `pytest -q tests/test_manifest_rollback.py` — all tests passed (82 passed).
- Ran `pytest -q tests/test_release_manifest.py` — all tests passed (235 passed).
- Ran `pytest -q tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py` — all tests passed (177 passed across those suites after formatting fixes).
- Ran `pytest -q tests/test_generic_app_just_recipes.py -k dspace_prod_metrics_reconcile` — tests for the recipe invocation passed; overall `tests/test_generic_app_just_recipes.py` targeted runs passed (234/234 in combined runs).
- Executed `python3 scripts/dspace_release_manifest.py validate --final --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json` — validation passed.
- Executed `python3 scripts/app_config.py json --app dspace --env prod` — succeeded and produced expected config.
- Ran `linkchecker --no-warnings README.md docs/` — completed with no errors.
- Ran `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` — no secrets or staged diff-check failures detected.

Environment notes and residual checks

- `pre-commit run --all-files` could not be fully relied on in this run (hooks installed and reformatted some unrelated historical files during CI environment install; unrelated changes were reverted to keep the PR focused). Operators should run `pre-commit run --all-files` locally before merging.
- `pyspelling -c .spellcheck.yaml` was not fully exercisable here because the `aspell` binary was missing in the environment.
- The helper `make_pr` tool was not available in this environment, so the branch was committed locally (commit 3e2818b0) but a PR was not created by automation.

Changed files (high level)

- docs/apps/dspace.prod-metrics-chart-target.json (new strict chart-only target)
- docs/apps/dspace.prod.version (chart pin -> 3.0.3)
- docs/apps/dspace.md (runbook updates documenting chart-only maintenance)
- scripts/dspace_manifest_rollback.py (maintenance_target validator, baseline/target handling, CLI args, guards)
- scripts/dspace_runtime_verifier.py (add metrics-chart tuple to legacy identity coordinates)
- justfile (recipe argument normalization and forwarding)
- tests/* (focused tests added/updated to exercise the new flow)

Operator command (post-merge)

just dspace-prod-metrics-reconcile \
  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
  evidence="$FRESH_NONEXISTING_EVIDENCE" \
  smoke_runner="$DSPACE_SMOKE_RUNNER" \
  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"

No live Kubernetes, Helm, image, chart registry, Secret, or tag mutations were performed by this change; historical finalized evidence remains byte-for-byte unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ccf020e60832fb172ac0d1b584ae0)