### PR TITLE
Guarded chart-only DSPACE prod metrics reconciliation (chart 3.0.3, app 3.0.1)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,12 +2,14 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
-## Production authenticated metrics at the existing release
+## Production authenticated metrics chart maintenance
 
-DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
-**3.0.2**. This repository change does not deploy application or chart code, and it is not a
-promotion. It supplies the reviewed values contract for an upgrade-only configuration
-reconciliation at the existing immutable coordinates.
+DSPACE production metrics are enabled by a chart-only maintenance upgrade from chart **3.0.2** to
+the immutable chart **3.0.3**. The application remains **3.0.1**, source revision
+`1a31a569aff2dbeb238e8c2688b9e85140d2077d`, and image `main-1a31a56` at its existing digest. This
+is not an application promotion. The finalized 3.0.2 evidence is historical provenance and must
+remain unchanged; the separately reviewed target is
+`docs/apps/dspace.prod-metrics-chart-target.json`.
 
 Run production operations from `sugarkube3` with the externally managed API tunnel listening on
 `127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
@@ -26,17 +28,19 @@ the check proves that the key is nonempty without reading it. Install and check 
 reconciliation. Never put the credential in an argument, environment variable, transcript, or
 evidence file.
 
-The reconciliation operator must supply the genuine existing finalized production evidence, the
-executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destination. Discover the
-current Helm revision immediately before the operation rather than assuming revision 9. Review the
-digest-qualified chart render and transient live-versus-desired values comparison: the only
-permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
-3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
+The operator must supply both the genuine finalized 3.0.2 baseline and the reviewed 3.0.3 target,
+plus the executable smoke runner and a fresh, nonexisting evidence destination. The expected
+transition for the currently verified baseline is revision 9 to 10, but the tool derives revision
+9 from the baseline and requires exactly one increment rather than hard-coding either revision.
+Review the digest-qualified target render and live-versus-desired values comparison: only the
+committed `metrics` and `serviceMonitor` contract may differ. Retain application 3.0.1, its exact
+image digest, provider, two replicas, routing, and credentials; never use
 `--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
 
 ```bash
 just dspace-prod-metrics-reconcile \
-  manifest="$GENUINE_FINALIZED_PROD_EVIDENCE" \
+  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
+  chart_maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
   evidence="$FRESH_NONEXISTING_EVIDENCE" \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$HOME/.kube/config-sugarkube-prod" \
@@ -54,7 +58,9 @@ Inspect the production dashboard manually. DSPACE HTTP, runtime, and feature pan
 populate. Release-integrity, blackbox, token.place, and alerting panels may remain `NO DATA` until
 those separate production integrations are deployed. A failure after mutation is not permission
 to rerun or roll back immediately: preserve and review the reserved failure evidence, discover the
-new live revision, and plan a deliberate reconciliation.
+new live revision, and plan a deliberate reconciliation. Any failure after evidence reservation
+requires evidence review before any further mutation; never automatically rerun, uninstall, roll
+back, delete, or rotate the metrics Secret.
 
 ## Production Helm reconciliation for application 3.0.1
 

--- a/docs/apps/dspace.prod-metrics-chart-target.json
+++ b/docs/apps/dspace.prod-metrics-chart-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "semanticTag": "v3.0.1",
+  "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+  "chartVersion": "3.0.3",
+  "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.2
+# DSPACE production chart pin. Chart-only maintenance; the application remains 3.0.1.
+3.0.3

--- a/justfile
+++ b/justfile
@@ -1794,8 +1794,8 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
     fi
     "${rollback_command[@]}"
 
-# Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
-dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+# Chart-only production DSPACE metrics reconciliation at reviewed immutable coordinates.
+dspace-prod-metrics-reconcile baseline_manifest chart_maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1805,7 +1805,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         value="${value#"${name}="}"
       else
         case "${value}" in
-          manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          baseline_manifest=*|chart_maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
             echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
             return 2
             ;;
@@ -1818,7 +1818,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       printf '%s' "${value}"
     }
 
-    manifest_path="$(normalize_argument manifest {{ quote(manifest) }} true)"
+    baseline_path="$(normalize_argument baseline_manifest {{ quote(baseline_manifest) }} true)"
+    target_path="$(normalize_argument chart_maintenance_target {{ quote(chart_maintenance_target) }} true)"
     evidence_path="$(normalize_argument evidence {{ quote(evidence) }} true)"
     smoke_path="$(normalize_argument smoke_runner {{ quote(smoke_runner) }} true)"
     kubeconfig_path="$(normalize_argument kubeconfig {{ quote(kubeconfig) }} true)"
@@ -1838,7 +1839,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+        baseline_manifest=*|chart_maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
           echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
           exit 2
           ;;
@@ -1850,7 +1851,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
       --configuration-reconciliation
       --environment prod
-      --manifest "${manifest_path}"
+      --manifest "${baseline_path}"
+      --chart-maintenance-target "${target_path}"
       --evidence "${evidence_path}"
       --smoke-runner "${smoke_path}"
       --kubeconfig "${kubeconfig_path}"

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -49,6 +49,26 @@ VERIFIER_FIELDS = (
 )
 POD_TIMEOUT = 60.0
 POLL_INTERVAL = 2.0
+METRICS_TARGET_FIELDS = (
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "semanticTag",
+    "chartSourceRevision",
+    "chartVersion",
+    "chartDigest",
+)
+APP_COORDINATE_FIELDS = (
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "semanticTag",
+)
 
 
 class RollbackError(ValueError):
@@ -84,6 +104,31 @@ def exact_fields(value: dict[str, Any], fields: tuple[str, ...], label: str) -> 
             f"{label} schema mismatch (missing={','.join(missing) or '-'}; "
             f"unknown={','.join(unknown) or '-'})"
         )
+
+
+def reviewed_metrics_target(path: Path, baseline: dict[str, Any]) -> dict[str, Any]:
+    """Validate the narrow chart-maintenance record and project a final target."""
+    try:
+        reviewed = release._object(path)
+    except release.ManifestError as exc:
+        raise RollbackError(f"reviewed chart target is invalid: {exc}") from exc
+    exact_fields(reviewed, METRICS_TARGET_FIELDS, "reviewed chart target")
+    if reviewed.get("schemaVersion") != 2 or reviewed.get("app") != "dspace":
+        raise RollbackError("reviewed chart target identity is invalid")
+    for field in APP_COORDINATE_FIELDS:
+        if reviewed.get(field) != baseline.get(field):
+            raise RollbackError(f"reviewed chart target changes application field {field}")
+    approved_chart = {
+        "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+        "chartVersion": "3.0.3",
+        "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+    }
+    if any(reviewed.get(field) != value for field, value in approved_chart.items()):
+        raise RollbackError("reviewed chart target is not the approved chart-only tuple")
+    target = copy.deepcopy(baseline)
+    target.update(approved_chart)
+    # The target is constructed, never obtained by mutating historical evidence.
+    return target
 
 
 def verifier_capabilities(
@@ -280,9 +325,7 @@ def helm_status(
     )
 
 
-def helm_history(
-    runner: Runner, kubeconfig: str, release_name: str, namespace: str
-) -> object:
+def helm_history(runner: Runner, kubeconfig: str, release_name: str, namespace: str) -> object:
     try:
         return json.loads(
             runner(
@@ -310,9 +353,7 @@ def helm_snapshot(
     namespace: str,
     *,
     require_deployed: bool = True,
-) -> tuple[
-    dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]
-]:
+) -> tuple[dict[str, Any], list[dict[str, Any]] | None, tuple[str, str, int]]:
     """Read a redaction-safe, revision-bound Helm release identity."""
     status = helm_status(runner, kubeconfig, release_name, namespace)
     history: list[dict[str, Any]] | None = None
@@ -348,9 +389,7 @@ def helm_snapshot(
             expected_version
         ):
             raise release.ManifestError("invalid Helm release identity")
-        identity = release.resolve_helm_identity(
-            status, history, release_name, expected_version
-        )
+        identity = release.resolve_helm_identity(status, history, release_name, expected_version)
     except release.ManifestError as exc:
         raise RollbackError("Helm release identity is invalid") from exc
     if status.get("name") != release_name or status.get("namespace") != namespace:
@@ -564,9 +603,7 @@ def application_image_id(pod: dict[str, Any]) -> str | None:
 
 
 def assert_production_target(kubeconfig: str, runner: Runner) -> None:
-    context = runner(
-        ["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]
-    ).strip()
+    context = runner(["kubectl", "--kubeconfig", kubeconfig, "config", "current-context"]).strip()
     if context != "sugar-prod":
         raise RollbackError("metrics configuration reconciliation requires sugar-prod")
     runner(
@@ -629,12 +666,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
     try:
-        target = release.validate(release._object(args.manifest), True)
+        baseline = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
-    if target["environment"] != args.environment:
+    if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    target = baseline
+    reviewed_reconciliation = configuration_reconciliation and hasattr(
+        args, "chart_maintenance_target"
+    )
+    if reviewed_reconciliation:
+        if args.chart_maintenance_target is None:
+            raise RollbackError("metrics reconciliation requires --chart-maintenance-target")
+        target = reviewed_metrics_target(args.chart_maintenance_target.expanduser(), baseline)
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -644,12 +689,22 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     approved = {field: target[field] for field in release.candidate_fields(target)}
     approved["recordType"] = "candidate"
     release.validate(approved, False)
+    baseline_approved = {field: baseline[field] for field in release.candidate_fields(baseline)}
+    baseline_approved["recordType"] = "candidate"
+    release.validate(baseline_approved, False)
     root = REPO_ROOT
     config = app_config.load_config("dspace", args.environment, args.config or None)
     if config["SUGARKUBE_CHART"] != f"oci://{release.CHART_REF}":
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
+    if reviewed_reconciliation:
+        try:
+            configured_version = app_chart.read_pin(config["SUGARKUBE_VERSION_FILE"])
+        except (OSError, ValueError) as exc:
+            raise RollbackError("configured production chart pin is invalid") from exc
+        if configured_version != target["chartVersion"]:
+            raise RollbackError("configured production chart pin does not match reviewed target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
@@ -704,7 +759,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != target["helmRevision"]:
+        if before_identity[2] != baseline["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -719,7 +774,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", target["chartVersion"]):
+        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -769,7 +824,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 args.kubeconfig,
                 "template",
                 "dspace",
-                coordinate,
+                release.chart_coordinate(baseline_approved),
                 "--namespace",
                 "dspace",
                 "--values",
@@ -794,10 +849,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             {"enabled": False},
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(
+        live_baseline, desired_baseline = configuration_comparison_baselines(
             live_values, desired_values
         )
-        if baseline != desired_baseline:
+        if live_baseline != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
@@ -829,8 +884,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             current_ids.clear()
             break
     if configuration_reconciliation and (
-        current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
-        or current_ids != {target["imageDigest"]}
+        current_images != {f"{release.IMAGE_REF}:{baseline['imageTag']}"}
+        or current_ids != {baseline["imageDigest"]}
     ):
         raise RollbackError("live image coordinate differs from finalized provenance")
     try:
@@ -1038,12 +1093,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if after_revision <= before_identity[2]:
-            raise RollbackError("Helm revision did not advance")
-        if (
-            after_identity[0] != "dspace"
-            or after_identity[1] != target["chartVersion"]
-        ):
+        if after_revision != before_identity[2] + 1:
+            raise RollbackError("Helm revision did not advance exactly once")
+        if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
         changed = configuration_reconciliation or (
             before_identity[1] != target["chartVersion"]
@@ -1252,8 +1304,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                     "status": observed_info.get("status"),
                     "chartName": observed_identity[0],
                     "chartVersion": observed_identity[1],
-                    "invocationDescriptionMatches": observed_info.get("description")
-                    == description,
+                    "invocationDescriptionMatches": observed_info.get("description") == description,
                 }
             except Exception:
                 diagnostics["helm"] = "unavailable"
@@ -1292,6 +1343,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--chart-maintenance-target", type=Path)
     args = parser.parse_args(argv)
     if args.kubeconfig is None and not args.configuration_reconciliation:
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,12 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_METRICS_CHART_COORDINATES = {
+    **LEGACY_RECOVERY_COORDINATES,
+    "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+    "chartVersion": "3.0.3",
+    "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+}
 LEGACY_310_COORDINATES = {
     "schemaVersion": 2,
     "applicationVersion": "3.1.0",
@@ -71,7 +77,11 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
-LEGACY_IDENTITY_COORDINATES = (LEGACY_RECOVERY_COORDINATES, LEGACY_310_COORDINATES)
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_METRICS_CHART_COORDINATES,
+    LEGACY_310_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,
@@ -449,10 +459,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
             fail("pod/replica identity")
         if metadata.get("deletionTimestamp") is not None or status.get("phase") != "Running":
             fail("pod/replica identity")
-        if not any(
-            c.get("type") == "Ready" and c.get("status") == "True"
-            for c in conditions
-        ):
+        if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
             fail("pod/replica identity")
         owner = controller_owner(metadata.get("ownerReferences", []), "ReplicaSet")
         replica_set_name, replica_set_uid = owner.get("name"), owner.get("uid")

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -151,7 +151,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2980,7 +2980,8 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
     tmp_path: Path,
 ) -> None:
     values = {
-        "manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "baseline_manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "chart_maintenance_target": str(tmp_path / "reviewed chart target=3.0.3.json"),
         "evidence": str(tmp_path / "fresh evidence=run-42.json"),
         "smoke_runner": str(tmp_path / "smoke runner=production"),
         "kubeconfig": str(tmp_path / "production kubeconfig=primary"),
@@ -3021,7 +3022,8 @@ def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_conf
     result, argv = _run_dspace_prod_metrics_reconcile(
         tmp_path,
         [
-            "manifest=/tmp/manifest.json",
+            "baseline_manifest=/tmp/manifest.json",
+            "chart_maintenance_target=/tmp/chart-target.json",
             "evidence=/tmp/evidence.json",
             "smoke_runner=/tmp/smoke-runner",
             "kubeconfig=/tmp/kubeconfig",
@@ -3042,6 +3044,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
         tmp_path,
         [
             "evidence=/tmp/manifest.json",
+            "/tmp/chart-target.json",
             "/tmp/evidence.json",
             "/tmp/smoke-runner",
             "/tmp/kubeconfig",
@@ -3049,7 +3052,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
     )
 
     assert result.returncode != 0
-    assert "manifest must be positional or use the manifest= prefix" in result.stderr
+    assert "baseline_manifest must be positional or use the baseline_manifest= prefix" in result.stderr
     assert argv == []
 
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -45,9 +45,7 @@ def target(environment: str = "staging", schema_version: int = 1) -> dict[str, o
     }
     if schema_version == 2:
         value["chartSourceRevision"] = "1234567890abcdef1234567890abcdef12345678"
-    checks = sorted(manifest.required_final_checks(value)) + [
-        "imagePlatformSourceRevision[0]"
-    ]
+    checks = sorted(manifest.required_final_checks(value)) + ["imagePlatformSourceRevision[0]"]
     value["verificationResults"] = [
         {"check": check, "passed": True, "details": "observed"} for check in checks
     ]
@@ -60,6 +58,51 @@ def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None
     projected["recordType"] = "candidate"
 
     assert manifest.validate(projected, False)["chartSourceRevision"] != projected["sourceRevision"]
+
+
+def test_reviewed_metrics_target_is_strict_and_changes_only_chart_tuple(tmp_path: Path) -> None:
+    baseline = json.loads(
+        (
+            rollback.REPO_ROOT
+            / "deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json"
+        ).read_text()
+    )
+    reviewed_path = rollback.REPO_ROOT / "docs/apps/dspace.prod-metrics-chart-target.json"
+
+    selected = rollback.reviewed_metrics_target(reviewed_path, baseline)
+
+    assert selected["chartVersion"] == "3.0.3"
+    assert selected["helmRevision"] == 9
+    for field in rollback.APP_COORDINATE_FIELDS:
+        assert selected[field] == baseline[field]
+
+    malformed = json.loads(reviewed_path.read_text())
+    malformed["provider"] = "openai"
+    path = tmp_path / "unknown.json"
+    path.write_text(json.dumps(malformed), encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="schema mismatch"):
+        rollback.reviewed_metrics_target(path, baseline)
+
+
+def test_reviewed_metrics_target_rejects_application_or_chart_drift(tmp_path: Path) -> None:
+    baseline = json.loads(
+        (
+            rollback.REPO_ROOT
+            / "deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json"
+        ).read_text()
+    )
+    reviewed = json.loads(
+        (rollback.REPO_ROOT / "docs/apps/dspace.prod-metrics-chart-target.json").read_text()
+    )
+    for field, value, message in (
+        ("imageTag", "main-wrong000", "application field"),
+        ("chartDigest", "sha256:" + "0" * 64, "approved chart-only tuple"),
+    ):
+        drifted = {**reviewed, field: value}
+        path = tmp_path / f"{field}.json"
+        path.write_text(json.dumps(drifted), encoding="utf-8")
+        with pytest.raises(rollback.RollbackError, match=message):
+            rollback.reviewed_metrics_target(path, baseline)
 
 
 def verifier_result(**changes: object) -> dict[str, object]:
@@ -461,9 +504,7 @@ def test_helm_319_snapshot_resolves_exact_current_history_without_leaking_raw_ou
 
     status = helm_319_status()
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
-    observed, history, identity = rollback.helm_snapshot(
-        runner, "kubeconfig", "dspace", "dspace"
-    )
+    observed, history, identity = rollback.helm_snapshot(runner, "kubeconfig", "dspace", "dspace")
 
     assert identity == ("dspace", "3.0.2", 9)
     assert observed is status
@@ -483,9 +524,7 @@ def test_helm_319_snapshot_resolves_exact_current_history_without_leaking_raw_ou
 def test_helm_snapshot_uses_status_metadata_without_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    status = helm_319_status(
-        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}
-    )
+    status = helm_319_status(chart={"metadata": {"name": "dspace", "version": "3.0.2"}})
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
     _status, history, identity = rollback.helm_snapshot(
         lambda _command: pytest.fail("history must not be queried"),
@@ -516,9 +555,7 @@ def test_helm_snapshot_rejects_non_object_status_metadata(
 
 def test_helm_history_rejects_invalid_json() -> None:
     with pytest.raises(rollback.RollbackError, match="valid JSON"):
-        rollback.helm_history(
-            lambda _command: "not-json", "kubeconfig", "dspace", "dspace"
-        )
+        rollback.helm_history(lambda _command: "not-json", "kubeconfig", "dspace", "dspace")
 
 
 @pytest.mark.parametrize(
@@ -531,9 +568,7 @@ def test_helm_history_rejects_invalid_json() -> None:
 def test_helm_snapshot_rejects_status_identity_or_state(
     monkeypatch: pytest.MonkeyPatch, changes: dict[str, object]
 ) -> None:
-    status = helm_319_status(
-        chart={"metadata": {"name": "dspace", "version": "3.0.2"}}, **changes
-    )
+    status = helm_319_status(chart={"metadata": {"name": "dspace", "version": "3.0.2"}}, **changes)
     monkeypatch.setattr(rollback, "helm_status", lambda *_args: status)
 
     with pytest.raises(rollback.RollbackError, match="identity"):


### PR DESCRIPTION
### Motivation

- Provide a fail-closed, chart-only production metrics reconciliation that upgrades the deployed DSPACE chart from 3.0.2 to the reviewed immutable chart 3.0.3 while preserving the exact DSPACE 3.0.1 application/image/source identity. 
- Represent the reviewed chart-maintenance target separately from historical finalized evidence so historical provenance remains byte-for-byte unchanged. 
- Enforce strict preflight, reservation, and post-upgrade proofs so any mismatch (wrong cluster, revision, image, values drift, provenance, render failures, missing metrics Secret, concurrent state changes, or revision jumps) fails closed. 

### Description

- Update the production pin to `3.0.3` by changing `docs/apps/dspace.prod.version` and add a reviewed chart-only target file `docs/apps/dspace.prod-metrics-chart-target.json` that records the exact schemaVersion 2 tuple with applicationVersion `3.0.1`, source revision, image tag/digest, and the approved chart tuple (chartSourceRevision `62da1100…`, chartVersion `3.0.3`, chartDigest `sha256:6ee6…f5c`).
- Extend `scripts/dspace_manifest_rollback.py` to accept `--chart-maintenance-target`, add `reviewed_metrics_target()` validation, split baseline vs target handling (baseline governs live provenance; target governs digest-qualified render/upgrade), require the production kube context `sugar-prod` for reconciliation, and tighten pre- and post-mutation assertions (including exactly one Helm revision increment and exact image digest preservation).
- Update the `just` recipe `dspace-prod-metrics-reconcile` to require both a `baseline_manifest` and a `chart_maintenance_target` positional argument and wire them through to the guarded reconciliation flow without changing other contracts (smoke-runner, verifier, kubeconfig, confirm, config, evidence); keep all sensitive secrets opaque.
- Add a metrics-aware identity tuple to `scripts/dspace_runtime_verifier.py` so the legacy identity set includes the reviewed chart-only coordinates while preserving the legacy selection rules; add focused unit tests and adjust existing tests to validate the new argument forms and strict reviewed-target behavior.

### Testing

- Ran the focused unit suites: `pytest -q tests/test_manifest_rollback.py` — 83 passed. 
- Ran the release manifest and broader suites: `pytest -q tests/test_release_manifest.py` — 234 passed, and `pytest -q tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py` — all tests passed for those suites. 
- Validated the finalized baseline evidence with `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json` which initially rejected final-only fields when invoked without `--final`, and succeeded when run as `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json --final`. 
- Confirmed config rendering: `python3 scripts/app_config.py json --app dspace --env prod` produced the expected production config values. 
- Documentation and link checks: `pyspelling -c .spellcheck.yaml` passed and `linkchecker --no-warnings README.md docs/` passed; `pre-commit run --all-files` flagged repository-wide YAML multi-document issues unrelated to the changed files (these were pre-existing and not introduced by this change). 
- Secret and diff checks: `git diff --cached | ./scripts/scan-secrets.py` and `git diff --cached --check` returned no findings, and the SHA-256 of the historical finalized evidence file is unchanged when compared to the repository copy. 

Changed files (summary): `docs/apps/dspace.prod.version`, `docs/apps/dspace.prod-metrics-chart-target.json`, `docs/apps/dspace.md` (runbook text), `scripts/dspace_manifest_rollback.py`, `scripts/dspace_runtime_verifier.py`, `justfile`, and focused test updates under `tests/` to exercise the new form and validation.

Post-merge operator command shape (also recorded in the runbook):

```bash
just dspace-prod-metrics-reconcile \
  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
  chart_maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
  evidence="$FRESH_NONEXISTING_EVIDENCE" \
  smoke_runner="$DSPACE_SMOKE_RUNNER" \
  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
```

Residual notes and risks: the change introduces a separate reviewed target file and extra CLI argument; CI `pre-commit` reported pre-existing YAML multi-document warnings in other files (not modified here) which remain to be addressed independently; exact OCI pulls/renders were not performed in CI (tests are deterministic and offline by design).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ccf033a08832fb33605dbe938f830)