### PR TITLE
Guarded chart-only DSPACE prod metrics reconciliation: pin chart 3.0.3 while preserving app 3.0.1

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,12 +2,15 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
-## Production authenticated metrics at the existing release
+## Production authenticated metrics chart maintenance
 
-DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
-**3.0.2**. This repository change does not deploy application or chart code, and it is not a
-promotion. It supplies the reviewed values contract for an upgrade-only configuration
-reconciliation at the existing immutable coordinates.
+DSPACE production metrics are supported by deployed application **3.0.1**. The guarded
+reconciliation upgrades only its chart from **3.0.2** to **3.0.3** at the reviewed immutable OCI
+digest, enabling authenticated metrics and the corrected ServiceMonitor contract. This is not an
+application promotion: source revision, semantic version, image tag and digest, provider, two
+replicas, routing, and credentials remain unchanged. Historical finalized 3.0.2 evidence remains
+unchanged; the chart-maintenance target is stored separately in
+`docs/apps/dspace.prod-metrics-chart-target.json`.
 
 Run production operations from `sugarkube3` with the externally managed API tunnel listening on
 `127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
@@ -26,17 +29,18 @@ the check proves that the key is nonempty without reading it. Install and check 
 reconciliation. Never put the credential in an argument, environment variable, transcript, or
 evidence file.
 
-The reconciliation operator must supply the genuine existing finalized production evidence, the
-executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destination. Discover the
-current Helm revision immediately before the operation rather than assuming revision 9. Review the
-digest-qualified chart render and transient live-versus-desired values comparison: the only
-permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
-3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
+The operator must supply both the genuine finalized production baseline and reviewed 3.0.3 target,
+plus the executable runtime smoke runner and a fresh, nonexisting evidence destination. For the
+currently verified baseline, the expected transition is revision 9 to 10. Tooling derives the
+revision from the baseline and requires exactly one increment rather than blindly hard-coding it.
+The only permitted values difference is the committed `metrics` and `serviceMonitor` contract.
+Retain application 3.0.1, its immutable image, provider, and both replicas; never use
 `--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
 
 ```bash
 just dspace-prod-metrics-reconcile \
-  manifest="$GENUINE_FINALIZED_PROD_EVIDENCE" \
+  baseline_manifest="deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json" \
+  chart_maintenance_target="docs/apps/dspace.prod-metrics-chart-target.json" \
   evidence="$FRESH_NONEXISTING_EVIDENCE" \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$HOME/.kube/config-sugarkube-prod" \
@@ -52,9 +56,10 @@ just observability-dashboard-verify env=prod
 
 Inspect the production dashboard manually. DSPACE HTTP, runtime, and feature panels should
 populate. Release-integrity, blackbox, token.place, and alerting panels may remain `NO DATA` until
-those separate production integrations are deployed. A failure after mutation is not permission
-to rerun or roll back immediately: preserve and review the reserved failure evidence, discover the
-new live revision, and plan a deliberate reconciliation.
+those separate production integrations are deployed. A failure after evidence reservation is not
+permission to rerun or roll back: review the preserved failure evidence before further mutation,
+discover the new live revision, and plan a deliberate reconciliation. The tool never automatically
+retries, uninstalls, rolls back, deletes, or rotates the metrics Secret.
 
 ## Production Helm reconciliation for application 3.0.1
 

--- a/docs/apps/dspace.prod-metrics-chart-target.json
+++ b/docs/apps/dspace.prod-metrics-chart-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.0.1",
+  "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+  "imageTag": "main-1a31a56",
+  "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+  "semanticTag": "v3.0.1",
+  "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+  "chartVersion": "3.0.3",
+  "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+}

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.2
+# DSPACE production chart pin. Application/image remain at the approved 3.0.1 artifact.
+3.0.3

--- a/justfile
+++ b/justfile
@@ -1795,7 +1795,7 @@ dspace-manifest-rollback env manifest evidence verifier="{{ justfile_directory()
     "${rollback_command[@]}"
 
 # Values-only production DSPACE metrics reconciliation at finalized immutable coordinates.
-dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+dspace-prod-metrics-reconcile baseline_manifest chart_maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
@@ -1805,7 +1805,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         value="${value#"${name}="}"
       else
         case "${value}" in
-          manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+          baseline_manifest=*|chart_maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
             echo "ERROR: ${name} must be positional or use the ${name}= prefix." >&2
             return 2
             ;;
@@ -1818,7 +1818,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       printf '%s' "${value}"
     }
 
-    manifest_path="$(normalize_argument manifest {{ quote(manifest) }} true)"
+    baseline_path="$(normalize_argument baseline_manifest {{ quote(baseline_manifest) }} true)"
+    target_path="$(normalize_argument chart_maintenance_target {{ quote(chart_maintenance_target) }} true)"
     evidence_path="$(normalize_argument evidence {{ quote(evidence) }} true)"
     smoke_path="$(normalize_argument smoke_runner {{ quote(smoke_runner) }} true)"
     kubeconfig_path="$(normalize_argument kubeconfig {{ quote(kubeconfig) }} true)"
@@ -1838,7 +1839,7 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
         verifier=*) verifier_path="$(normalize_argument verifier "${value}" true)" ;;
         confirm=*) confirmation="$(normalize_argument confirm "${value}" false)" ;;
         config=*) config_path="$(normalize_argument config "${value}" false)" ;;
-        manifest=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
+        baseline_manifest=*|chart_maintenance_target=*|evidence=*|smoke_runner=*|kubeconfig=*|verifier=*|confirm=*|config=*)
           echo "ERROR: unexpected argument prefix in ${value%%=*}=." >&2
           exit 2
           ;;
@@ -1850,7 +1851,8 @@ dspace-prod-metrics-reconcile manifest evidence smoke_runner kubeconfig verifier
       python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py"
       --configuration-reconciliation
       --environment prod
-      --manifest "${manifest_path}"
+      --baseline-manifest "${baseline_path}"
+      --chart-maintenance-target "${target_path}"
       --evidence "${evidence_path}"
       --smoke-runner "${smoke_path}"
       --kubeconfig "${kubeconfig_path}"

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -49,6 +49,28 @@ VERIFIER_FIELDS = (
 )
 POD_TIMEOUT = 60.0
 POLL_INTERVAL = 2.0
+MAINTENANCE_TARGET_FIELDS = (
+    "schemaVersion",
+    "app",
+    "applicationVersion",
+    "sourceRevision",
+    "imageTag",
+    "imageDigest",
+    "semanticTag",
+    "chartSourceRevision",
+    "chartVersion",
+    "chartDigest",
+)
+APPROVED_PRODUCTION_BASELINE = {
+    "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+    "chartVersion": "3.0.2",
+    "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+}
+APPROVED_PRODUCTION_TARGET = {
+    "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+    "chartVersion": "3.0.3",
+    "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+}
 
 
 class RollbackError(ValueError):
@@ -605,6 +627,43 @@ def configuration_comparison_baselines(
     return baseline, desired_baseline
 
 
+def production_chart_maintenance_target(
+    baseline: dict[str, Any], path: Path
+) -> dict[str, Any]:
+    """Validate a strict chart-only record and construct a candidate without altering evidence."""
+    try:
+        reviewed = release._object(path)
+    except release.ManifestError as exc:
+        raise RollbackError(f"reviewed chart-maintenance target is invalid: {exc}") from exc
+    exact_fields(reviewed, MAINTENANCE_TARGET_FIELDS, "chart-maintenance target")
+    application_fields = (
+        "schemaVersion",
+        "app",
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "semanticTag",
+    )
+    if any(reviewed[field] != baseline[field] for field in application_fields):
+        raise RollbackError("chart-maintenance target changes the approved application artifact")
+    if any(baseline[field] != value for field, value in APPROVED_PRODUCTION_BASELINE.items()):
+        raise RollbackError("baseline is not the approved production 3.0.2 chart tuple")
+    if any(reviewed[field] != value for field, value in APPROVED_PRODUCTION_TARGET.items()):
+        raise RollbackError("chart-maintenance target is not the approved production 3.0.3 tuple")
+    candidate = {
+        field: baseline[field] for field in release.candidate_fields(baseline)
+    }
+    candidate.update(
+        {field: reviewed[field] for field in ("chartSourceRevision", "chartVersion", "chartDigest")}
+    )
+    candidate["recordType"] = "candidate"
+    try:
+        return release.validate(candidate, False)
+    except release.ManifestError as exc:
+        raise RollbackError(f"reviewed chart-maintenance target is invalid: {exc}") from exc
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     if getattr(args, "configuration_reconciliation", False):
         if not args.kubeconfig or ":" in args.kubeconfig:
@@ -629,12 +688,18 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
     try:
-        target = release.validate(release._object(args.manifest), True)
+        baseline = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
-    if target["environment"] != args.environment:
+    if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    target = baseline
+    if configuration_reconciliation:
+        target_path = getattr(args, "chart_maintenance_target", None)
+        if target_path is None:
+            raise RollbackError("metrics reconciliation requires --chart-maintenance-target")
+        target = production_chart_maintenance_target(baseline, target_path.expanduser())
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -650,6 +715,22 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
+    if configuration_reconciliation:
+        version_file = Path(config["SUGARKUBE_VERSION_FILE"])
+        version_file = version_file if version_file.is_absolute() else root / version_file
+        try:
+            configured_version = next(
+                (
+                    line.split("#", 1)[0].strip()
+                    for line in version_file.read_text().splitlines()
+                    if line.split("#", 1)[0].strip()
+                ),
+                "",
+            )
+        except OSError as exc:
+            raise RollbackError("configured production chart pin is unreadable") from exc
+        if configured_version != target["chartVersion"]:
+            raise RollbackError("configured production chart pin differs from reviewed target")
     values, values_proof = stage_values(config, root, staged_directory)
     environment = cluster_environment(runner, args.kubeconfig)
     if environment != args.environment:
@@ -704,7 +785,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != target["helmRevision"]:
+        if before_identity[2] != baseline["helmRevision"]:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -719,7 +800,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", target["chartVersion"]):
+        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -769,7 +850,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 args.kubeconfig,
                 "template",
                 "dspace",
-                coordinate,
+                release.chart_coordinate({
+                    **approved,
+                    "chartVersion": baseline["chartVersion"],
+                    "chartDigest": baseline["chartDigest"],
+                    "chartSourceRevision": baseline["chartSourceRevision"],
+                }),
                 "--namespace",
                 "dspace",
                 "--values",
@@ -1158,7 +1244,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         # original verify contract for compatible third-party verifiers rather
         # than discovering that they reject new flags after Helm has mutated.
         if extended_verifier:
-            verifier_command.extend(("--manifest", str(args.manifest)))
+            verifier_manifest = args.manifest
+            if configuration_reconciliation:
+                verifier_manifest = staged_directory / "approved-target.json"
+                verifier_manifest.write_text(release._canonical(approved), encoding="utf-8")
+                os.chmod(verifier_manifest, 0o600)
+            verifier_command.extend(("--manifest", str(verifier_manifest)))
             smoke_runner = getattr(args, "smoke_runner", None)
             if smoke_runner:
                 verifier_command.extend(("--smoke-runner", str(smoke_runner)))
@@ -1282,7 +1373,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment", choices=("staging", "prod"), required=True)
-    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--manifest", "--baseline-manifest", dest="manifest", type=Path, required=True
+    )
+    parser.add_argument("--chart-maintenance-target", type=Path)
     parser.add_argument("--evidence", type=Path, required=True)
     parser.add_argument("--verifier", type=Path, required=True)
     parser.add_argument("--smoke-runner", type=Path)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1146,7 +1146,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             _write_new(args.output, result)
         elif args.command == "validate":
-            result = validate(_object(args.manifest), args.final)
+            result = validate(_object(args.manifest), True if args.final else None)
             sys.stdout.write(_canonical(result))
         elif args.command == "preflight":
             source = _object(args.manifest)

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -59,6 +59,12 @@ LEGACY_RECOVERY_COORDINATES = {
     "semanticTag": "v3.0.1",
     "expectedDefaultChatProvider": "openai",
 }
+LEGACY_METRICS_CHART_COORDINATES = {
+    **LEGACY_RECOVERY_COORDINATES,
+    "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+    "chartVersion": "3.0.3",
+    "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+}
 LEGACY_310_COORDINATES = {
     "schemaVersion": 2,
     "applicationVersion": "3.1.0",
@@ -71,7 +77,11 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
-LEGACY_IDENTITY_COORDINATES = (LEGACY_RECOVERY_COORDINATES, LEGACY_310_COORDINATES)
+LEGACY_IDENTITY_COORDINATES = (
+    LEGACY_RECOVERY_COORDINATES,
+    LEGACY_METRICS_CHART_COORDINATES,
+    LEGACY_310_COORDINATES,
+)
 META_RE = re.compile(
     r'<meta\s+[^>]*name=["\']dspace-build-revision["\'][^>]*content=["\']([^"\']+)',
     re.IGNORECASE,

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -151,7 +151,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -2980,7 +2980,8 @@ def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_form
     tmp_path: Path,
 ) -> None:
     values = {
-        "manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "baseline_manifest": str(tmp_path / "finalized manifest=approved.json"),
+        "chart_maintenance_target": str(tmp_path / "reviewed target=approved.json"),
         "evidence": str(tmp_path / "fresh evidence=run-42.json"),
         "smoke_runner": str(tmp_path / "smoke runner=production"),
         "kubeconfig": str(tmp_path / "production kubeconfig=primary"),
@@ -3021,7 +3022,8 @@ def test_dspace_prod_metrics_reconcile_preserves_default_verifier_and_empty_conf
     result, argv = _run_dspace_prod_metrics_reconcile(
         tmp_path,
         [
-            "manifest=/tmp/manifest.json",
+            "baseline_manifest=/tmp/manifest.json",
+            "chart_maintenance_target=/tmp/target.json",
             "evidence=/tmp/evidence.json",
             "smoke_runner=/tmp/smoke-runner",
             "kubeconfig=/tmp/kubeconfig",
@@ -3042,6 +3044,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
         tmp_path,
         [
             "evidence=/tmp/manifest.json",
+            "/tmp/target.json",
             "/tmp/evidence.json",
             "/tmp/smoke-runner",
             "/tmp/kubeconfig",
@@ -3049,7 +3052,7 @@ def test_dspace_prod_metrics_reconcile_rejects_wrong_prefix_before_python(tmp_pa
     )
 
     assert result.returncode != 0
-    assert "manifest must be positional or use the manifest= prefix" in result.stderr
+    assert "baseline_manifest must be positional or use the baseline_manifest= prefix" in result.stderr
     assert argv == []
 
 
@@ -3061,10 +3064,12 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     staging_pin = "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.staging.version"
     assert source.count(staging_pin) == 1
     recovery_config = tmp_path / "recovery-staging.env"
+    recovery_version = tmp_path / "recovery.version"
+    recovery_version.write_text("3.0.2\n", encoding="utf-8")
     recovery_config.write_text(
         source.replace(
             staging_pin,
-            "SUGARKUBE_VERSION_FILE_STAGING=docs/apps/dspace.prod.version",
+            f"SUGARKUBE_VERSION_FILE_STAGING={recovery_version}",
         ),
         encoding="utf-8",
     )
@@ -3690,12 +3695,15 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     )
     assert staged.returncode == 0, staged.stderr + staged.stdout
     staging_record = json.loads(staging_evidence.read_text(encoding="utf-8"))
-    staging_record["chartVersion"] = "3.0.2"
+    staging_record["chartVersion"] = "3.0.3"
     staging_evidence.write_text(json.dumps(staging_record) + "\n", encoding="utf-8")
     _write_dspace_candidate(prod_manifest, "prod")
+    prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
+    prod_record["chartVersion"] = "3.0.3"
+    prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
     env["SUGARKUBE_STUB_PROD_VERIFIER_FAIL"] = "1"
     for name in ("helm.log", "commands.log", "runtime-verifier.log"):
         (tmp_path / name).write_text("", encoding="utf-8")

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -62,6 +62,40 @@ def test_schema_v2_final_target_projects_split_provenance_for_rollback() -> None
     assert manifest.validate(projected, False)["chartSourceRevision"] != projected["sourceRevision"]
 
 
+def test_chart_maintenance_target_changes_only_reviewed_chart_tuple(tmp_path: Path) -> None:
+    baseline = target("prod", schema_version=2)
+    baseline.update(rollback.APPROVED_PRODUCTION_BASELINE)
+    reviewed = {field: baseline[field] for field in rollback.MAINTENANCE_TARGET_FIELDS}
+    reviewed.update(
+        chartSourceRevision="62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+        chartVersion="3.0.3",
+        chartDigest="sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+    )
+    path = tmp_path / "reviewed.json"
+    path.write_text(manifest._canonical(reviewed), encoding="utf-8")
+
+    approved = rollback.production_chart_maintenance_target(baseline, path)
+
+    assert approved["chartVersion"] == "3.0.3"
+    assert approved["imageDigest"] == baseline["imageDigest"]
+    assert baseline["chartVersion"] == "3.0.2"
+
+
+@pytest.mark.parametrize("change", ({"unknown": True}, {"imageTag": "main-0000000"}))
+def test_chart_maintenance_target_rejects_unknown_fields_and_application_drift(
+    tmp_path: Path, change: dict[str, object]
+) -> None:
+    baseline = target("prod", schema_version=2)
+    baseline.update(rollback.APPROVED_PRODUCTION_BASELINE)
+    reviewed = {field: baseline[field] for field in rollback.MAINTENANCE_TARGET_FIELDS}
+    reviewed.update(change)
+    path = tmp_path / "reviewed.json"
+    path.write_text(manifest._canonical(reviewed), encoding="utf-8")
+
+    with pytest.raises(rollback.RollbackError, match="schema mismatch|application artifact"):
+        rollback.production_chart_maintenance_target(baseline, path)
+
+
 def verifier_result(**changes: object) -> dict[str, object]:
     value = {
         "schemaVersion": 1,
@@ -584,7 +618,27 @@ def pre_reservation_case(
     evidence_path = tmp_path / "rollback.json"
     verifier = tmp_path / "verifier"
     values = tmp_path / "values.yaml"
-    manifest_path.write_text(manifest._canonical(target(environment)), encoding="utf-8")
+    selected = target(environment, schema_version=2)
+    monkeypatch.setattr(
+        rollback,
+        "APPROVED_PRODUCTION_BASELINE",
+        {field: selected[field] for field in rollback.APPROVED_PRODUCTION_BASELINE},
+    )
+    monkeypatch.setattr(
+        rollback,
+        "APPROVED_PRODUCTION_TARGET",
+        {field: selected[field] for field in rollback.APPROVED_PRODUCTION_TARGET},
+    )
+    manifest_path.write_text(manifest._canonical(selected), encoding="utf-8")
+    maintenance_path = tmp_path / "maintenance-target.json"
+    maintenance_path.write_text(
+        manifest._canonical(
+            {field: selected[field] for field in rollback.MAINTENANCE_TARGET_FIELDS}
+        ),
+        encoding="utf-8",
+    )
+    version_file = tmp_path / "version"
+    version_file.write_text(selected["chartVersion"] + "\n", encoding="utf-8")
     verifier.write_text("#!/bin/sh\n", encoding="utf-8")
     verifier.chmod(0o755)
     values.write_text("environment: test\n", encoding="utf-8")
@@ -596,6 +650,7 @@ def pre_reservation_case(
             "SUGARKUBE_RELEASE": "dspace",
             "SUGARKUBE_NAMESPACE": "dspace",
             "SUGARKUBE_VALUES": str(values),
+            "SUGARKUBE_VERSION_FILE": str(version_file),
         },
     )
     monkeypatch.setattr(rollback, "REPO_ROOT", tmp_path)
@@ -630,6 +685,7 @@ def pre_reservation_case(
         kubeconfig="kubeconfig",
         oras="oras",
         timeout="10m",
+        chart_maintenance_target=maintenance_path,
     )
     return args, commands, evidence_path, verifier
 


### PR DESCRIPTION
### Motivation

- Add a fail‑closed, chart‑only production reconciliation that upgrades only the installed DSPACE Helm chart from `3.0.2` to the reviewed immutable chart `3.0.3` while preserving the exact deployed application `3.0.1` and its image identity. 
- Keep historical finalized production evidence untouched and store the reviewed maintenance target separately so baseline provenance continues to control live-state assertions.

### Description

- Introduce a strict reviewed chart‑maintenance target file `docs/apps/dspace.prod-metrics-chart-target.json` that records schemaVersion `2` and the exact application/image fields plus the reviewed chart tuple for `3.0.3`, and update the production pin file `docs/apps/dspace.prod.version` to `3.0.3` while explicitly stating the application remains `3.0.1`.
- Extend and refactor the guarded reconciliation flow in `scripts/dspace_manifest_rollback.py` to accept both a `--baseline-manifest` (finalized evidence) and a `--chart-maintenance-target` (reviewed target), validate both separately, construct a candidate that preserves all application/image fields, and fail closed on any unknown fields, application drift, or mismatched pins.
- Enforce a narrow, read-only preflight and strict render/values comparison model that requires explicit production kubeconfig/context, proves the live Helm identity against the baseline, proves exactly two Ready pods using the approved image digest, verifies the metrics Secret contract, performs digest-qualified OCI preflight, renders the digest chart with the committed values, and uses a single digest‑qualified `helm upgrade` with immediate revalidation and reserved evidence.
- Update `justfile` recipe `dspace-prod-metrics-reconcile`, the runtime verifier list in `scripts/dspace_runtime_verifier.py`, and add focused unit tests in `tests/test_manifest_rollback.py` and `tests/test_generic_app_just_recipes.py` to cover the new baseline+target invocation, strict target validation, and the chart‑only maintenance invariants.

Modified files (high level): `docs/apps/dspace.prod-metrics-chart-target.json`, `docs/apps/dspace.prod.version`, `docs/apps/dspace.md`, `justfile`, `scripts/dspace_manifest_rollback.py`, `scripts/dspace_runtime_verifier.py`, and focused tests under `tests/`.

Enforced baseline→target invariants:
- Baseline (finalized evidence) controls all live assertions: Helm revision, installed chart version (3.0.2), pods, image tag/digest, and stored values.
- Target controls only the digest‑qualified chart coordinate for the upgrade (3.0.3) and the digest‑qualified render/provenance evidence.
- The candidate used for the upgrade preserves every application/image/provider/environment field from the baseline; only the `chartSourceRevision`/`chartVersion`/`chartDigest` tuple is allowed to change.
- Configuration reconciliation requires explicit production kubeconfig and `sugar‑prod` context and fails closed on any mismatch, drift, or malformed target.

### Testing

- Ran `pytest -q tests/test_manifest_rollback.py` and it passed: `81` tests plus the added focused chart‑target tests succeeded.
- Ran `pytest -q tests/test_release_manifest.py` and `pytest -q tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py` and they all passed (focused suites exercised the new just recipe shapes and runtime/value expectations).
- Validated the existing finalized evidence with `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json` and ran `python3 scripts/app_config.py json --app dspace --env prod`; both succeeded and the finalized evidence file remained byte‑for‑byte unchanged.
- Ran docs/tools checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed for this change, and `git diff --cached | ./scripts/scan-secrets.py` reported no secret leakage.
- Attempted `pre-commit run --all-files`; this was executed but a repository-wide pre-existing set of unrelated YAML/multi-document and lint issues prevented a fully clean pre-commit pass; only the focused files in this change were staged and committed and unrelated hook-made whitespace fixes were handled and reverted as part of the preparation.
- OCI pull/render by digest was not performed in this environment because `oras`/`helm` are not available here, however the code adds deterministic, offline tests and strict render validation that mock the chart/OCI interactions so CI remains deterministic without network access.

Post-merge operator command shape (documented in the runbook):

`just dspace-prod-metrics-reconcile \`
`  baseline_manifest="deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json" \`
`  chart_maintenance_target="docs/apps/dspace.prod-metrics-chart-target.json" \`
`  evidence="$FRESH_NONEXISTING_EVIDENCE" \`
`  smoke_runner="$DSPACE_SMOKE_RUNNER" \`
`  kubeconfig="$HOME/.kube/config-sugarkube-prod" \`
`  confirm="dspace:prod:<40-character-application-SHA>"`

Residual notes and risks:
- `pre-commit run --all-files` failed due to unrelated repository lint/YAML issues; these are not introduced by this PR and the focused tests for the change passed.
- Exact OCI artifact pull/render was not executed in this environment; the reconciliation code performs digest‑qualified preflight checks and the test suite mocks OCI responses to keep CI deterministic and offline.

If you want, I can open a PR with this branch metadata and include the concise operator checklist in the PR description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ccf05e5ec832fbd1a7db178a871e4)