### PR TITLE
Onboard immutable DSPACE recovery chart 3.0.3

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -4,10 +4,10 @@ This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugark
 
 ## Production authenticated metrics at the existing release
 
-DSPACE production metrics are supported by the already deployed application **3.0.1** and chart
-**3.0.2**. This repository change does not deploy application or chart code, and it is not a
-promotion. It supplies the reviewed values contract for an upgrade-only configuration
-reconciliation at the existing immutable coordinates.
+DSPACE production currently runs application **3.0.1** with the historical chart **3.0.2**.
+The newly approved recovery target is chart **3.0.3**, retaining application **3.0.1** and image
+`main-1a31a56`. This repository change only onboards that immutable target and its validation
+contract; it does not deploy or promote anything.
 
 Run production operations from `sugarkube3` with the externally managed API tunnel listening on
 `127.0.0.1:16443`. Use the explicit production kubeconfig and context; **do not** run
@@ -31,7 +31,7 @@ executable DSPACE runtime smoke runner, and a fresh, nonexisting evidence destin
 current Helm revision immediately before the operation rather than assuming revision 9. Review the
 digest-qualified chart render and transient live-versus-desired values comparison: the only
 permitted difference is the committed `metrics` and `serviceMonitor` contract. Retain application
-3.0.1, chart 3.0.2, their immutable image/chart digests, and both replicas; never use
+3.0.1, select approved target chart 3.0.3 at its immutable digest, and retain both replicas; never use
 `--reuse-values`, a semantic or mutable tag, raw `helm upgrade`, or `helm rollback`.
 
 ```bash
@@ -66,6 +66,13 @@ revision in `chartSourceRevision`. The `v3.0.1` semantic tag is corroborating me
 pass it to Helm, publish it, or use it as an image coordinate. The chart OCI manifest digest is not
 the downloaded chart archive's SHA-256.
 
+Publication provenance for this target: upstream PR `democratizedspace/dspace#4816`, tag
+`chart-v3.0.3`, chart source revision `62da11005354e9f9a89c2e58584cdce4c8ec35aa`, and successful
+[workflow run 31632262039, attempt 2, job 94238380995](https://github.com/democratizedspace/dspace/actions/runs/31632262039).
+The packaged archive SHA-256 is
+`2b6528eefd487be8a52db8ea44f118310351976ee32b29fb6115c8081916280a`; it independently checks the
+downloaded archive and is not the OCI manifest digest recorded in the release manifest.
+
 ### 1. Repository preparation (already performed by this change)
 
 Review the recovery input, production chart pin, production values chain, and immutable image pin.
@@ -82,11 +89,11 @@ test -x "$DSPACE_SMOKE_RUNNER"
 python3 scripts/app_config.py json --app dspace --env prod
 jq -e '.schemaVersion == 2 and .applicationVersion == "3.0.1" and
   .sourceRevision == "1a31a569aff2dbeb238e8c2688b9e85140d2077d" and
-  .chartSourceRevision == "63063e287adb92a4158ce2c8e7d378b73f52c1c5" and
+  .chartSourceRevision == "62da11005354e9f9a89c2e58584cdce4c8ec35aa" and
   .imageTag == "main-1a31a56" and
   .imageDigest == "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401" and
-  .chartVersion == "3.0.2" and
-  .chartDigest == "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575"' "$RECOVERY"
+  .chartVersion == "3.0.3" and
+  .chartDigest == "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"' "$RECOVERY"
 ```
 
 Before encoding approval, inspect the immutable DSPACE 3.0.1 application contract at revision
@@ -106,7 +113,7 @@ APPROVED_BY='<operator-or-review-record>'
 EXPECTED_PROVIDER=openai
 mkdir -p deployment-candidates/dspace
 # Keep the shared staging pin unchanged while selecting the independently
-# approved 3.0.2 production pin for this recovery only.
+# approved 3.0.3 production pin for this recovery only.
 RECOVERY_CONFIG=$(mktemp)
 trap 'rm -f "$RECOVERY_CONFIG"' EXIT
 python3 - "$RECOVERY_CONFIG" <<'PY'
@@ -206,13 +213,13 @@ eval "$(python3 scripts/app_config.py shell --app dspace --env prod \
   --config docs/examples/apps/dspace.env --tag main-1a31a56 --require-tag)"
 CHART_VERSION=$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' \
   "$SUGARKUBE_VERSION_FILE" | head -n1)
-test "$CHART_VERSION" = 3.0.2
+test "$CHART_VERSION" = 3.0.3
 CHART_COORDINATE=$(python3 scripts/dspace_release_manifest.py preflight \
   --manifest deployment-candidates/dspace/recovery-prod.json --environment prod \
   --image-tag "$SUGARKUBE_TAG" --chart-version "$CHART_VERSION" \
   --chart-ref "$SUGARKUBE_CHART" --print-chart-coordinate)
 test "$CHART_COORDINATE" = \
-  'oci://ghcr.io/democratizedspace/charts/dspace@sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575'
+  'oci://ghcr.io/democratizedspace/charts/dspace@sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c'
 PROD_HOST=$(python3 scripts/app_chart.py resolve-host --values "$SUGARKUBE_VALUES")
 python3 scripts/app_chart.py preflight \
   --app "$SUGARKUBE_APP" --env "$SUGARKUBE_ENV" --tag "$SUGARKUBE_TAG" \
@@ -222,7 +229,7 @@ python3 scripts/app_chart.py preflight \
   --host "$PROD_HOST" --pull-policy Always
 ```
 
-This must prove chart 3.0.2 at the approved OCI digest and the immutable application image while
+This must prove chart 3.0.3 at the approved OCI digest and the immutable application image while
 rejecting staging metrics, the staging metrics Secret reference, ServiceMonitor leakage, or literal
 Secret material. Review that the resolved values chain is exactly the dev base plus production
 overlay. Legitimate production `secretKeyRef`/`existingSecret` names are allowed, but never print
@@ -247,7 +254,7 @@ python3 scripts/dspace_release_manifest.py validate --final --manifest "$PROD_EV
 
 Review the finalized record together with fresh bounded Helm status/history and Deployment/pod
 capture. All serving pods and Helm stored image values must use `main-1a31a56` and the approved
-image digest; installed chart version and OCI provenance must be 3.0.2 and its chart revision/digest.
+image digest; installed chart version and OCI provenance must be 3.0.3 and its chart revision/digest.
 Application, runtime, and frontend identity must remain the application revision, not the chart
 revision. Public and direct identity, replica agreement, health paths, configuration/provider, and
 `/chat` must all pass. Preserve candidate, finalized records, command exit statuses, timestamps, and
@@ -290,9 +297,9 @@ child output, browser artifacts, headers, cookies, credentials, and request payl
 The sole exception is the complete coordinate tuple in
 `docs/apps/dspace.prod-recovery-coordinates.json`, augmented by candidate provider `openai`: schema
 2, application `3.0.1`, source revision `1a31a569aff2dbeb238e8c2688b9e85140d2077d`, chart source
-revision `63063e287adb92a4158ce2c8e7d378b73f52c1c5`, image tag `main-1a31a56`, image digest
-`sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`, chart `3.0.2` with digest
-`sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575`, and semantic tag
+revision `62da11005354e9f9a89c2e58584cdce4c8ec35aa`, image tag `main-1a31a56`, image digest
+`sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401`, chart `3.0.3` with digest
+`sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c`, and semantic tag
 `v3.0.1`. Only that exact candidate uses `legacy-build-meta-v1`. The verifier proves identical
 `gitSha`, valid non-empty `generatedAt`, and non-empty `source` through public and every direct
 `/build-meta.json`, while still validating bounded non-empty root documents, and passes the legacy
@@ -380,7 +387,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.2`) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.3`) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 
@@ -408,7 +415,7 @@ Use these links before changing a deployment so the workflow runs, package versi
 - `env=staging`: HA staging on the staging Sugarkube cluster with host `staging.democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml`.
   The configured staging target injects `DSPACE_TOKEN_PLACE_URL=https://staging.token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=qwen3-8b-instruct`, uses provenance-bearing chart `3.1.1` for DSPACE application `3.1.0`, and persists the authenticated metrics ServiceMonitor configuration discovered by kube-prometheus-stack. The live staging release is Helm revision 28 from the immutable DSPACE `3.1.0` staging image `main-018687f`, with finalized evidence recorded at `deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json`; operators can use that final record as the promotion and reconciliation proof instead of creating a replacement candidate/evidence path for this deployment. The metrics bearer value is not committed; operators manage the existing `dspace-staging-metrics-token` Secret out of band.
 - `env=prod`: HA production on the production Sugarkube cluster with host `democratized.space` and values `docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.prod.yaml`.
-  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. Production is pinned to recovery chart `3.0.2` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
+  The production overlay injects `DSPACE_TOKEN_PLACE_URL=https://token.place` and `DSPACE_TOKEN_PLACE_CHAT_MODEL=llama-3.1-8b-instruct`. The approved production target is recovery chart `3.0.3` and image `ghcr.io/democratizedspace/dspace:main-1a31a56`; it does not enable metrics or ServiceMonitor settings.
 - Optional legacy/canary host `prod.democratized.space` uses `docs/examples/dspace.values.prod-subdomain.yaml`. The `dspace-oci-deploy-prod-subdomain` compatibility command selects the secret-free `docs/examples/apps/dspace-prod-subdomain.env` config, preserving that overlay while routing through the same manifest validation, OCI preflight, Helm deployment, and evidence finalization as the generic production path.
 
 ## Find or publish GHCR image
@@ -658,7 +665,7 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 
 ## Promote production
 
-This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.2` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
+This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.3` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
 just app-promote-prod app=dspace tag="$APP_TAG" \

--- a/docs/apps/dspace.prod-recovery-coordinates.json
+++ b/docs/apps/dspace.prod-recovery-coordinates.json
@@ -3,10 +3,10 @@
   "app": "dspace",
   "applicationVersion": "3.0.1",
   "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
-  "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+  "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
   "imageTag": "main-1a31a56",
   "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
-  "chartVersion": "3.0.2",
-  "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+  "chartVersion": "3.0.3",
+  "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
   "semanticTag": "v3.0.1"
 }

--- a/docs/apps/dspace.prod.version
+++ b/docs/apps/dspace.prod.version
@@ -1,2 +1,2 @@
-# DSPACE production chart pin. Keep aligned with the recovered production deployment.
-3.0.2
+# Production/recovery chart pin; intentionally independent from shared/dev and staging.
+3.0.3

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -227,6 +227,11 @@
               },
               {
                 "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
                 "targetLabel": "release",
                 "replacement": "dspace"
               },

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -213,7 +213,7 @@ def dspace_production_metrics_token_is_unsafe(
                 and secret_ref == {"name": "dspace-prod-metrics-token", "key": "token"}
             ):
                 safe_entries.add(id(entry))
-            # Chart 3.0.2 uses the pod UID as a safe, unpredictable token when metrics are off.
+            # DSPACE charts use the pod UID as a safe, unpredictable token when metrics are off.
             if (
                 not metrics_enabled
                 and set(entry) == {"name", "valueFrom"}
@@ -423,6 +423,11 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                         },
                         {
                             "action": "replace",
+                            "targetLabel": "namespace",
+                            "replacement": "dspace",
+                        },
+                        {
+                            "action": "replace",
                             "targetLabel": "release",
                             "replacement": "dspace",
                         },
@@ -434,7 +439,12 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     ]
                     if (
                         metadata.get("name") != "dspace"
-                        or metadata.get("namespace") != "dspace"
+                        or (
+                            metadata.get("namespace")
+                            if "namespace" in metadata
+                            else inputs.namespace
+                        )
+                        != "dspace"
                         or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
                         or spec.get("selector")
                         != {

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -278,8 +278,8 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
-            if not isinstance(relabelings, list) or len(relabelings) != 4:
-                fail("serviceMonitor.relabelings must contain exactly four entries")
+            if not isinstance(relabelings, list) or not relabelings:
+                fail("serviceMonitor.relabelings must be a nonempty list")
             for idx, relabeling in enumerate(relabelings):
                 expect_keys(
                     relabeling,
@@ -310,18 +310,13 @@ def validate_inventory(doc):
             mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
             if len(mapping) != len(relabelings):
                 fail("serviceMonitor.relabelings target labels must be unique")
-            required_mapping = {
-                "app": app,
-                "environment": env,
-                "release": cfg["serviceMonitorName"],
-                "cluster": labels.get("cluster"),
-            }
-            if mapping != required_mapping:
+            discovery_mapping = {key: value for key, value in labels.items() if key != "namespace"}
+            explicit_namespace_mapping = dict(labels)
+            if mapping not in (discovery_mapping, explicit_namespace_mapping):
                 fail(
-                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
+                    "serviceMonitor.relabelings must exactly match targetLabels, with namespace "
+                    "either explicit or supplied by discovery"
                 )
-            if "namespace" in mapping:
-                fail("namespace must be supplied by discovery, not relabel replacement")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
@@ -1027,9 +1022,6 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
-    for relabeling in cfg["serviceMonitor"].get("relabelings", []):
-        if relabeling.get("targetLabel") == "namespace":
-            fail("namespace must be supplied by discovery, not relabel replacement")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -151,7 +151,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
     assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
-    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.2"
+    assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 
 
 def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -461,6 +461,9 @@ spec:
           targetLabel: environment
           replacement: prod
         - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
           targetLabel: release
           replacement: dspace
         - action: replace
@@ -1399,12 +1402,35 @@ data:
     [
         lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
         lambda manifest: manifest.replace(
+            "  labels:\n    app.kubernetes.io/instance: dspace\n    release: kube-prometheus-stack",
+            "  namespace: wrong\n  labels:\n    app.kubernetes.io/instance: dspace\n    release: kube-prometheus-stack",
+        ),
+        lambda manifest: manifest.replace(
             "replacement: dspace\n        - action: replace\n          targetLabel: environment",
             "replacement: other\n        - action: replace\n          targetLabel: environment",
             1,
         ),
         lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
         lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "        - action: replace\n          targetLabel: extra\n          replacement: dspace\n",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: environment\n          replacement: prod\n"
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: environment\n          replacement: prod\n",
+        ),
     ],
 )
 def test_dspace_production_requires_exact_metrics_path_and_relabelings(
@@ -1421,7 +1447,7 @@ def test_dspace_production_requires_exact_metrics_path_and_relabelings(
         "dspace",
         "dspace",
         "chart",
-        "3.0.2",
+        "3.0.3",
         (str(values),),
         "main-deadbee",
     )
@@ -1462,7 +1488,6 @@ spec:
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -1485,6 +1510,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -2928,7 +2956,7 @@ def _write_dspace_candidate(
         "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
         "imageTag": "main-abcdef0",
         "imageDigest": image_digest or "sha256:" + "1" * 64,
-        "chartVersion": "3.1.1" if environment == "staging" else "3.0.2",
+        "chartVersion": "3.1.1" if environment == "staging" else "3.0.3",
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "candidate",
@@ -3072,10 +3100,10 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     evidence = tmp_path / "recovery-staging-evidence.json"
     _write_dspace_candidate(manifest, "staging")
     candidate = json.loads(manifest.read_text(encoding="utf-8"))
-    candidate["chartVersion"] = "3.0.2"
+    candidate["chartVersion"] = "3.0.3"
     manifest.write_text(json.dumps(candidate) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
 
     result = _run_just(
         [
@@ -3095,7 +3123,7 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8")
     assert "release-manifest preflight" in commands
     assert "helm template " in commands
-    assert "charts/dspace:3.0.2" in commands
+    assert "charts/dspace:3.0.3" in commands
     assert "docs/examples/dspace.values.staging.yaml" in commands
     assert "main-abcdef0" in commands
 
@@ -3690,12 +3718,12 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     )
     assert staged.returncode == 0, staged.stderr + staged.stdout
     staging_record = json.loads(staging_evidence.read_text(encoding="utf-8"))
-    staging_record["chartVersion"] = "3.0.2"
+    staging_record["chartVersion"] = "3.0.3"
     staging_evidence.write_text(json.dumps(staging_record) + "\n", encoding="utf-8")
     _write_dspace_candidate(prod_manifest, "prod")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.2"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.0.3"
     env["SUGARKUBE_STUB_PROD_VERIFIER_FAIL"] = "1"
     for name in ("helm.log", "commands.log", "runtime-verifier.log"):
         (tmp_path / name).write_text("", encoding="utf-8")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -111,11 +111,11 @@ def test_versioned_recovery_coordinates_are_exact_and_candidate_consumable() -> 
         "app": "dspace",
         "applicationVersion": "3.0.1",
         "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
-        "chartSourceRevision": "63063e287adb92a4158ce2c8e7d378b73f52c1c5",
+        "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
         "imageTag": "main-1a31a56",
         "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
-        "chartVersion": "3.0.2",
-        "chartDigest": "sha256:8b862135e52146f301a41259d6dabb053ed891d798fc1c8c95ca775b2b8e9575",
+        "chartVersion": "3.0.3",
+        "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
         "semanticTag": "v3.0.1",
     }
     made = manifest.candidate(value, "prod", "openai", "2026-07-31T12:00:00Z", "operator")
@@ -696,9 +696,7 @@ def test_committed_production_values_pass_stored_values_contract() -> None:
     recovery = json.loads(
         Path("docs/apps/dspace.prod-recovery-coordinates.json").read_text(encoding="utf-8")
     )
-    approved = manifest.candidate(
-        recovery, "prod", "openai", "2026-07-31T12:00:00Z", "operator"
-    )
+    approved = manifest.candidate(recovery, "prod", "openai", "2026-07-31T12:00:00Z", "operator")
     values["image"] = {
         "repository": manifest.IMAGE_REF,
         "tag": approved["imageTag"],
@@ -714,9 +712,7 @@ def test_helm_stored_values_accept_chart_defaults_and_safe_references() -> None:
     stored["env"] = [
         {
             "name": "METRICS_TOKEN",
-            "valueFrom": {
-                "secretKeyRef": {"name": "dspace-prod-metrics-token", "key": "token"}
-            },
+            "valueFrom": {"secretKeyRef": {"name": "dspace-prod-metrics-token", "key": "token"}},
         }
     ]
     assert manifest.verify_helm_stored_values(value, stored, "prod")["passed"] is True


### PR DESCRIPTION
### Motivation

- Onboard the newly published immutable DSPACE recovery chart `3.0.3` with its verified OCI manifest digest and source revision while preserving the existing immutable application/image coordinates and the staging pin. 
- Make the render/observability validation compatible with chart 3.0.3's omission of `ServiceMonitor.metadata.namespace` by treating an omitted namespace as the requested Helm release namespace, and reject explicit wrong namespaces. 
- Strengthen and codify the DSPACE production ServiceMonitor relabeling contract so monitoring discovery and the declarative inventory remain strict and unambiguous.

### Description

- Update machine-readable production recovery coordinates in `docs/apps/dspace.prod-recovery-coordinates.json` to `chartVersion: "3.0.3"`, `chartDigest: "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"`, and `chartSourceRevision: "62da11005354e9f9a89c2e58584cdce4c8ec35aa"`, and update `docs/apps/dspace.prod.version` to `3.0.3` while preserving `applicationVersion`, `imageTag`, `imageDigest`, and `semanticTag`.
- Record upstream publication provenance in the runbook (`docs/apps/dspace.md`) including upstream PR `democratizedspace/dspace#4816`, `chart-v3.0.3`, workflow run `31632262039` (attempt 2 / job `94238380995`) and the packaged archive SHA-256 `2b6528eefd487be8a52db8ea44f118310351976ee32b29fb6115c8081916280a` while clearly stating this PR only onboards the target and performs no deployment.
- Adjust DSPACE render validation in `scripts/app_chart.py` to accept an omitted `ServiceMonitor.metadata.namespace` as `inputs.namespace` (and to explicitly reject a mismatched namespace) and to require the exact ordered five relabelings for production: `app=dspace`, `environment=prod`, `namespace=dspace`, `release=dspace`, `cluster=sugarkube-prod` in that order, while keeping the existing checks for selector, `/metrics`, interval, timeout, and bearer-token Secret reference.
- Make the generic observability inventory validator in `scripts/observability_app_metrics.py` strict and app-agnostic by requiring relabelings to exactly match `targetLabels` with unique target labels and by accepting either discovery-supplied namespace (no explicit namespace relabeling) or an explicit namespace replacement, but rejecting other variants or lax rules.
- Add DSPACE namespace relabeling to the declarative inventory (`platform/observability/app-metrics.json`) and update tests/fixtures to cover the production target; keep staging pin (`3.1.1`) unchanged and preserve historical 3.0.2 records and tests that intentionally exercise legacy behavior.
- Update and add regression tests in `tests/*` (notably `tests/test_generic_app_just_recipes.py`, `tests/test_dspace_runtime_values.py`, and `tests/test_release_manifest.py`) to prove: production resolves `3.0.3` at the exact OCI digest; application/image coordinates are unchanged; omitted ServiceMonitor namespace uses release-namespace semantics; explicit wrong namespace fails; and missing/reordered/duplicated/altered/extra relabelings fail.
- Commit landed on branch `codex/dspace-chart-3-0-3` as `Onboard immutable DSPACE chart 3.0.3` (local commit `42debadc`), and an attempt to push/create the PR failed due to missing GitHub credentials so the branch is ready for review and push from an environment with credentials.

### Testing

- `python3 -m py_compile scripts/app_chart.py scripts/observability_app_metrics.py scripts/dspace_release_manifest.py` — PASS.
- `python3 scripts/observability_app_metrics.py validate` — PASS (inventory validator reports valid).
- `pytest -q tests/test_app_config.py tests/test_dspace_runtime_values.py tests/test_dspace_runtime_verifier.py tests/test_generic_app_just_recipes.py tests/test_release_manifest.py tests/test_manifest_rollback.py` — PASS (`973` tests passed in the run performed here).
- `git diff --check` and `git diff | ./scripts/scan-secrets.py` and `git diff --cached | ./scripts/scan-secrets.py` — PASS.
- Not-run / environment-limited checks: `pre-commit run --all-files` (tool unavailable), `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` (tools unavailable), and a read-only `helm pull` / OCI archive verification (Helm not available in this environment) were not executed; the PR records the verified upstream coordinates the task supplied and preserves the archive checksum in the runbook for an operator to independently verify.
- `git push` / `gh pr create` was attempted but failed due to missing GitHub credentials: `fatal: could not read Username for 'https://github.com': No such device or address`.

This PR only onboards the immutable chart target and the validation contract; no Helm installs, upgrades, Kubernetes mutations, tag creations, workflow reruns, package publications, Secret accesses, or evidence fabrications were performed here, and the operational follow-up must be a separately authorized guarded staging rehearsal and finalized evidence gate before any production rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cf5a24288832f900a12bedc9ff516)