### PR TITLE
Support DSPACE chart 3.0.3 ServiceMonitor contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -227,6 +227,11 @@
               },
               {
                 "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
                 "targetLabel": "release",
                 "replacement": "dspace"
               },

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -414,12 +414,22 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     )
                     auth = endpoint.get("bearerTokenSecret")
                     relabelings = endpoint.get("relabelings")
+                    effective_namespace = (
+                        metadata.get("namespace")
+                        if "namespace" in metadata
+                        else inputs.namespace
+                    )
                     expected_relabelings = [
                         {"action": "replace", "targetLabel": "app", "replacement": "dspace"},
                         {
                             "action": "replace",
                             "targetLabel": "environment",
                             "replacement": "prod",
+                        },
+                        {
+                            "action": "replace",
+                            "targetLabel": "namespace",
+                            "replacement": "dspace",
                         },
                         {
                             "action": "replace",
@@ -434,7 +444,7 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     ]
                     if (
                         metadata.get("name") != "dspace"
-                        or metadata.get("namespace") != "dspace"
+                        or effective_namespace != "dspace"
                         or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
                         or spec.get("selector")
                         != {
@@ -443,6 +453,7 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                                 "app.kubernetes.io/name": "dspace",
                             }
                         }
+                        or spec.get("namespaceSelector") != {"matchNames": ["dspace"]}
                         or auth != {"name": "dspace-prod-metrics-token", "key": "token"}
                         or endpoint.get("path") != "/metrics"
                         or endpoint.get("interval") != "30s"

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -278,18 +278,6 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
-            if not isinstance(relabelings, list) or len(relabelings) != 4:
-                fail("serviceMonitor.relabelings must contain exactly four entries")
-            for idx, relabeling in enumerate(relabelings):
-                expect_keys(
-                    relabeling,
-                    {"action", "targetLabel", "replacement"},
-                    f"serviceMonitor.relabelings[{idx}]",
-                )
-                if relabeling["action"] != "replace":
-                    fail("serviceMonitor.relabelings action must be replace")
-                prometheus_label(relabeling["targetLabel"], "relabeling targetLabel")
-                nonempty(relabeling["replacement"], "relabeling replacement")
             labels = cfg["targetLabels"]
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
@@ -307,21 +295,25 @@ def validate_inventory(doc):
                 or labels["namespace"] != cfg["namespace"]
             ):
                 fail("targetLabels must match ServiceMonitor and namespace")
-            mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
-            if len(mapping) != len(relabelings):
-                fail("serviceMonitor.relabelings target labels must be unique")
-            required_mapping = {
-                "app": app,
-                "environment": env,
-                "release": cfg["serviceMonitorName"],
-                "cluster": labels.get("cluster"),
-            }
-            if mapping != required_mapping:
-                fail(
-                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
-                )
-            if "namespace" in mapping:
-                fail("namespace must be supplied by discovery, not relabel replacement")
+            def replacement(target_label, replacement):
+                return {
+                    "action": "replace",
+                    "targetLabel": target_label,
+                    "replacement": replacement,
+                }
+
+            canonical_four = [
+                replacement("app", app),
+                replacement("environment", env),
+                replacement("release", cfg["serviceMonitorName"]),
+                replacement("cluster", labels["cluster"]),
+            ]
+            canonical_five = canonical_four[:2] + [
+                replacement("namespace", cfg["namespace"]),
+                *canonical_four[2:],
+            ]
+            if relabelings not in (canonical_four, canonical_five):
+                fail("serviceMonitor.relabelings must match a canonical ordered contract exactly")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
@@ -1001,10 +993,11 @@ def validate_render(
             named_sms.append(doc)
     sms = []
     for candidate in named_sms:
-        rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (
-            rendered_ns is None and release_namespace == cfg["namespace"]
-        ):
+        metadata = candidate["metadata"]
+        rendered_ns = (
+            metadata.get("namespace") if "namespace" in metadata else release_namespace
+        )
+        if rendered_ns == cfg["namespace"]:
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -1027,9 +1020,6 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
-    for relabeling in cfg["serviceMonitor"].get("relabelings", []):
-        if relabeling.get("targetLabel") == "namespace":
-            fail("namespace must be supplied by discovery, not relabel replacement")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -433,7 +433,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -460,6 +459,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -1398,6 +1400,10 @@ data:
     "mutation",
     [
         lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
+        lambda manifest: manifest.replace("matchNames:\n      - dspace", "matchNames:\n      - wrong"),
+        lambda manifest: manifest.replace("name: dspace\n  labels:", "name: dspace\n  namespace:\n  labels:", 1),
+        lambda manifest: manifest.replace('name: dspace\n  labels:', 'name: dspace\n  namespace: ""\n  labels:', 1),
+        lambda manifest: manifest.replace("name: dspace\n  labels:", "name: dspace\n  namespace: wrong\n  labels:", 1),
         lambda manifest: manifest.replace(
             "replacement: dspace\n        - action: replace\n          targetLabel: environment",
             "replacement: other\n        - action: replace\n          targetLabel: environment",
@@ -1405,6 +1411,26 @@ data:
         ),
         lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
         lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+        ),
+        lambda manifest: manifest.replace(
+            "          targetLabel: namespace\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: release",
+            "          targetLabel: release\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: namespace",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: cluster\n          replacement: sugarkube-prod\n",
+            "        - action: replace\n          targetLabel: cluster\n          replacement: sugarkube-prod\n"
+            "        - action: replace\n          targetLabel: extra\n          replacement: value\n",
+        ),
     ],
 )
 def test_dspace_production_requires_exact_metrics_path_and_relabelings(
@@ -1421,7 +1447,7 @@ def test_dspace_production_requires_exact_metrics_path_and_relabelings(
         "dspace",
         "dspace",
         "chart",
-        "3.0.2",
+        "3.0.3",
         (str(values),),
         "main-deadbee",
     )
@@ -1462,11 +1488,13 @@ spec:
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace
@@ -1485,6 +1513,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -5731,6 +5762,47 @@ def test_observability_app_metrics_inventory_tokenplace_contract_is_strict_and_c
     assert "token" in cfg["forbiddenApplicationLabels"]
 
 
+def test_observability_app_metrics_inventory_accepts_both_canonical_relabeling_forms():
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+
+    app_metrics.validate_inventory(doc)
+
+    tokenplace = doc["applications"]["tokenplace"]["environments"]["staging"]
+    dspace = doc["applications"]["dspace"]["environments"]["prod"]
+    assert [rule["targetLabel"] for rule in tokenplace["serviceMonitor"]["relabelings"]] == [
+        "app", "environment", "release", "cluster"
+    ]
+    assert [rule["targetLabel"] for rule in dspace["serviceMonitor"]["relabelings"]] == [
+        "app", "environment", "namespace", "release", "cluster"
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda rules: rules.pop(),
+        lambda rules: rules.__setitem__(slice(1, 3), reversed(rules[1:3])),
+        lambda rules: rules.insert(2, dict(rules[2])),
+        lambda rules: rules[2].update(targetLabel="other"),
+        lambda rules: rules[2].update(replacement="other"),
+        lambda rules: rules[2].update(action="keep"),
+        lambda rules: rules[2].update(extra="value"),
+        lambda rules: rules.append(
+            {"action": "replace", "targetLabel": "extra", "replacement": "value"}
+        ),
+    ],
+)
+def test_observability_app_metrics_inventory_rejects_noncanonical_relabelings(mutation):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    rules = doc["applications"]["dspace"]["environments"]["prod"]["serviceMonitor"][
+        "relabelings"
+    ]
+    mutation(rules)
+
+    with pytest.raises(SystemExit, match="canonical ordered contract"):
+        app_metrics.validate_inventory(doc)
+
+
 def test_observability_app_metrics_inventory_rejects_unknown_keys_duplicates_and_bad_status():
     doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
     doc["applications"]["tokenplace"]["environments"]["staging"]["extra"] = True
@@ -5837,6 +5909,83 @@ spec:
           targetLabel: cluster
           replacement: sugarkube-int
 """
+
+
+def _dspace_303_chart_like_service_monitor(namespace_entry: str = "") -> str:
+    return f"""apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dspace
+{namespace_entry}  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
+  endpoints:
+    - path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-prod
+"""
+
+
+def test_observability_app_metrics_validate_render_accepts_dspace_303_omitted_namespace(
+    tmp_path: Path,
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_303_chart_like_service_monitor(), encoding="utf-8")
+
+    app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+
+@pytest.mark.parametrize(
+    "namespace_entry",
+    ["  namespace:\n", '  namespace: ""\n', "  namespace: wrong\n"],
+)
+def test_observability_app_metrics_validate_render_rejects_present_invalid_namespace(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(
+        _dspace_303_chart_like_service_monitor(namespace_entry), encoding="utf-8"
+    )
+
+    with pytest.raises(SystemExit, match="exactly one configured ServiceMonitor"):
+        app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+
+def test_observability_app_metrics_validate_render_accepts_explicit_configured_namespace(
+    tmp_path: Path,
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(
+        _dspace_303_chart_like_service_monitor("  namespace: dspace\n"), encoding="utf-8"
+    )
+
+    app_metrics.validate_render("dspace", "prod", str(rendered), "wrong")
 
 
 def test_observability_app_metrics_validate_render_accepts_chart_like_service_monitor(tmp_path: Path):


### PR DESCRIPTION
### Motivation

- Accept the immutable DSPACE chart 3.0.3 ServiceMonitor contract while preserving fail-closed validation semantics for namespaces and relabelings. 
- Make the generic inventory and rendered-manifest validators accept the two canonical relabeling forms (4-rule discovery and 5-rule explicit-namespace) without weakening shape, order, or value checks.

### Description

- Update `scripts/app_chart.py` to treat an omitted ServiceMonitor `metadata.namespace` as inheriting the release namespace only when the key is absent (not for explicit null/empty/wrong values), require exact `namespaceSelector.matchNames: ["dspace"]`, and require the exact ordered five-entry relabeling contract for DSPACE prod (app, environment, namespace, release, cluster). 
- Update `scripts/observability_app_metrics.py` inventory validation to accept only two canonical ordered relabeling lists (four-rule or five-rule), derive each replacement from inventory fields, and reject missing, reordered, duplicate, malformed, or extra entries; also change `validate_render()` to use key-presence semantics for `metadata.namespace` and allow the valid five-rule rendered relabelings when namespace is explicit. 
- Add the explicit DSPACE namespace relabeling to `platform/observability/app-metrics.json` (insert namespace between environment and release) while leaving token.place unchanged. 
- Extend and update focused tests in `tests/test_generic_app_just_recipes.py` to model DSPACE chart 3.0.3, exercise omitted/explicit/null/empty/wrong namespace handling, both canonical inventory forms, and all failure cases for relabeling order, duplicates, altered shape, and extras so the modified branches are fully covered.

### Testing

- Ran `python3 -m compileall scripts/app_chart.py scripts/observability_app_metrics.py` which succeeded. 
- Ran `python3 scripts/observability_app_metrics.py validate` which reported the application metrics inventory is valid. 
- Ran focused pytest selection: `pytest -q tests/test_generic_app_just_recipes.py -k "dspace_production_requires_exact_metrics_path_and_relabelings or observability_app_metrics_inventory or observability_app_metrics_validate_render"` and observed the focused tests passed (56 passed). 
- Ran the broader regression suite: `pytest -q tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py tests/test_release_manifest.py` and observed all tests passed (958 passed); `--cov` was not run because `pytest-cov`/coverage flags are unavailable in the environment. 

Files changed: `scripts/app_chart.py`, `scripts/observability_app_metrics.py`, `platform/observability/app-metrics.json`, `tests/test_generic_app_just_recipes.py`.

Notes and unavailable checks: `pre-commit` is not installed in this environment so `pre-commit run --all-files` could not be executed, `pytest --cov`/`pytest-cov` was unavailable so coverage collection with `--cov` was skipped, and creating a remote PR/pushing from this environment failed due to missing GitHub authentication (no authenticated GH host).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d25bfc0d4832f93e98d24e7cf0c89)