### PR TITLE
Support DSPACE chart 3.0.3 ServiceMonitor contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -227,6 +227,11 @@
               },
               {
                 "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
                 "targetLabel": "release",
                 "replacement": "dspace"
               },

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -423,6 +423,11 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                         },
                         {
                             "action": "replace",
+                            "targetLabel": "namespace",
+                            "replacement": "dspace",
+                        },
+                        {
+                            "action": "replace",
                             "targetLabel": "release",
                             "replacement": "dspace",
                         },
@@ -432,10 +437,14 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                             "replacement": "sugarkube-prod",
                         },
                     ]
+                    effective_namespace = (
+                        metadata["namespace"] if "namespace" in metadata else inputs.namespace
+                    )
                     if (
                         metadata.get("name") != "dspace"
-                        or metadata.get("namespace") != "dspace"
+                        or effective_namespace != "dspace"
                         or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        or spec.get("namespaceSelector") != {"matchNames": ["dspace"]}
                         or spec.get("selector")
                         != {
                             "matchLabels": {

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -278,24 +278,13 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
-            if not isinstance(relabelings, list) or len(relabelings) != 4:
-                fail("serviceMonitor.relabelings must contain exactly four entries")
-            for idx, relabeling in enumerate(relabelings):
-                expect_keys(
-                    relabeling,
-                    {"action", "targetLabel", "replacement"},
-                    f"serviceMonitor.relabelings[{idx}]",
-                )
-                if relabeling["action"] != "replace":
-                    fail("serviceMonitor.relabelings action must be replace")
-                prometheus_label(relabeling["targetLabel"], "relabeling targetLabel")
-                nonempty(relabeling["replacement"], "relabeling replacement")
             labels = cfg["targetLabels"]
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
             if set(labels) != {"app", "environment", "release", "cluster", "namespace"}:
                 fail(
-                    "targetLabels must contain exactly app, environment, release, cluster, and namespace"
+                    "targetLabels must contain exactly app, environment, release, cluster, "
+                    "and namespace"
                 )
             for k, v in labels.items():
                 prometheus_label(k, "target label name")
@@ -307,21 +296,30 @@ def validate_inventory(doc):
                 or labels["namespace"] != cfg["namespace"]
             ):
                 fail("targetLabels must match ServiceMonitor and namespace")
-            mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
-            if len(mapping) != len(relabelings):
-                fail("serviceMonitor.relabelings target labels must be unique")
-            required_mapping = {
-                "app": app,
-                "environment": env,
-                "release": cfg["serviceMonitorName"],
-                "cluster": labels.get("cluster"),
-            }
-            if mapping != required_mapping:
-                fail(
-                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
-                )
-            if "namespace" in mapping:
-                fail("namespace must be supplied by discovery, not relabel replacement")
+            expected_relabelings = [
+                {"action": "replace", "targetLabel": "app", "replacement": app},
+                {"action": "replace", "targetLabel": "environment", "replacement": env},
+                {
+                    "action": "replace",
+                    "targetLabel": "release",
+                    "replacement": cfg["serviceMonitorName"],
+                },
+                {
+                    "action": "replace",
+                    "targetLabel": "cluster",
+                    "replacement": labels["cluster"],
+                },
+            ]
+            expected_relabelings_with_namespace = expected_relabelings[:2] + [
+                {
+                    "action": "replace",
+                    "targetLabel": "namespace",
+                    "replacement": cfg["namespace"],
+                },
+                *expected_relabelings[2:],
+            ]
+            if relabelings not in (expected_relabelings, expected_relabelings_with_namespace):
+                fail("serviceMonitor.relabelings must match a canonical ordered contract exactly")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
@@ -1001,10 +999,11 @@ def validate_render(
             named_sms.append(doc)
     sms = []
     for candidate in named_sms:
-        rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (
-            rendered_ns is None and release_namespace == cfg["namespace"]
-        ):
+        metadata = candidate["metadata"]
+        effective_namespace = (
+            metadata["namespace"] if "namespace" in metadata else release_namespace
+        )
+        if effective_namespace == cfg["namespace"]:
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -1027,9 +1026,6 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
-    for relabeling in cfg["serviceMonitor"].get("relabelings", []):
-        if relabeling.get("targetLabel") == "namespace":
-            fail("namespace must be supplied by discovery, not relabel replacement")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -433,7 +433,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -460,6 +459,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -1421,7 +1423,7 @@ def test_dspace_production_requires_exact_metrics_path_and_relabelings(
         "dspace",
         "dspace",
         "chart",
-        "3.0.2",
+        "3.0.3",
         (str(values),),
         "main-deadbee",
     )
@@ -1462,11 +1464,13 @@ spec:
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace
@@ -1486,6 +1490,9 @@ spec:
           targetLabel: environment
           replacement: prod
         - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
           targetLabel: release
           replacement: dspace
         - action: replace
@@ -1494,6 +1501,25 @@ spec:
 """
 
     assert app_chart.validate_rendered_manifest(monitor, inputs) == []
+    assert (
+        app_chart.validate_rendered_manifest(
+            monitor.replace(
+                "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  labels:\n",
+                "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  namespace: dspace\n  labels:\n",
+            ),
+            inputs,
+        )
+        == []
+    )
+    for namespace in ("null", "''", "wrong"):
+        invalid = monitor.replace(
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  labels:\n",
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n"
+            f"  namespace: {namespace}\n  labels:\n",
+        )
+        assert "DSPACE production ServiceMonitor contract mismatch" in (
+            app_chart.validate_rendered_manifest(invalid, inputs)
+        )
     mutated = mutation(monitor)
     assert mutated != monitor
     assert "DSPACE production ServiceMonitor contract mismatch" in (
@@ -5731,6 +5757,49 @@ def test_observability_app_metrics_inventory_tokenplace_contract_is_strict_and_c
     assert "token" in cfg["forbiddenApplicationLabels"]
 
 
+def test_observability_app_metrics_inventory_accepts_both_canonical_relabeling_forms():
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+
+    app_metrics.validate_inventory(doc)
+
+    tokenplace = doc["applications"]["tokenplace"]["environments"]["staging"]
+    dspace = doc["applications"]["dspace"]["environments"]["prod"]
+    assert [rule["targetLabel"] for rule in tokenplace["serviceMonitor"]["relabelings"]] == [
+        "app", "environment", "release", "cluster"
+    ]
+    assert [rule["targetLabel"] for rule in dspace["serviceMonitor"]["relabelings"]] == [
+        "app", "environment", "namespace", "release", "cluster"
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda rules: rules.pop(),
+        lambda rules: rules.__setitem__(slice(1, 3), reversed(rules[1:3])),
+        lambda rules: rules.insert(2, dict(rules[2])),
+        lambda rules: rules[2].__setitem__("targetLabel", "other"),
+        lambda rules: rules[2].__setitem__("replacement", "wrong"),
+        lambda rules: rules[2].__setitem__("action", "keep"),
+        lambda rules: rules[2].__setitem__("extra", "value"),
+        lambda rules: rules.append(
+            {"action": "replace", "targetLabel": "extra", "replacement": "value"}
+        ),
+    ],
+)
+def test_observability_app_metrics_inventory_rejects_noncanonical_relabelings(mutator):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    rules = doc["applications"]["dspace"]["environments"]["prod"]["serviceMonitor"][
+        "relabelings"
+    ]
+    mutator(rules)
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_inventory(doc)
+
+    assert "canonical ordered contract" in str(excinfo.value)
+
+
 def test_observability_app_metrics_inventory_rejects_unknown_keys_duplicates_and_bad_status():
     doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
     doc["applications"]["tokenplace"]["environments"]["staging"]["extra"] = True
@@ -5839,11 +5908,88 @@ spec:
 """
 
 
+def _dspace_chart_like_service_monitor(namespace_entry: str = "") -> str:
+    namespace = f"  namespace: {namespace_entry}\n" if namespace_entry else ""
+    return f"""apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dspace
+{namespace}  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
+  endpoints:
+    - path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-prod
+"""
+
+
 def test_observability_app_metrics_validate_render_accepts_chart_like_service_monitor(tmp_path: Path):
     rendered = tmp_path / "rendered.yaml"
     rendered.write_text(_tokenplace_chart_like_service_monitor(), encoding="utf-8")
 
     app_metrics.validate_render("tokenplace", "staging", str(rendered), "tokenplace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["", "dspace"])
+def test_observability_app_metrics_validate_render_accepts_dspace_namespace_forms(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8")
+
+    app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["null", "''", "wrong"])
+def test_observability_app_metrics_validate_render_rejects_explicit_invalid_dspace_namespace(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+    assert "exactly one configured ServiceMonitor" in str(excinfo.value)
+
+
+def test_observability_app_metrics_validate_render_omitted_namespace_requires_matching_release(
+    tmp_path: Path,
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_render("dspace", "prod", str(rendered), "wrong")
+
+    assert "exactly one configured ServiceMonitor" in str(excinfo.value)
 
 
 def test_observability_app_metrics_validate_render_uses_configured_workload_name_not_release_name(tmp_path: Path):


### PR DESCRIPTION
### Motivation

- Make Sugarkube’s strict render and inventory validators accept the exact immutable DSPACE chart 3.0.3 ServiceMonitor contract while remaining fail-closed for any explicit null/empty/wrong namespace values. 
- Keep token.place and other existing contracts unchanged and add focused tests that exercise every new branch so validator patch coverage is complete.

### Description

- Update `scripts/app_chart.py` to treat an omitted `ServiceMonitor.metadata.namespace` as resolved to `inputs.namespace`, reject explicit null/empty/wrong namespaces, require `namespaceSelector.matchNames == ["dspace"]`, and require the exact ordered five-entry relabelings (app, environment, namespace, release, cluster) for DSPACE while preserving all other DSPACE checks. 
- Update `scripts/observability_app_metrics.py` inventory and render checks to accept exactly two canonical ordered relabeling forms (four-entry discovery-driven or five-entry explicit-namespace), compare ordered lists for equality, and use key-presence semantics for `metadata.namespace` where omission may inherit `release_namespace` but explicit falsey or wrong values fail. 
- Add the DSPACE explicit `namespace` relabeling entry into `platform/observability/app-metrics.json` between `environment` and `release` (no schema version or unrelated fields changed). 
- Extend `tests/test_generic_app_just_recipes.py` with focused fixture updates and tests exercising: omitted namespace (accepted via release namespace), explicit null/empty/wrong (rejected), exact `namespaceSelector.matchNames`, canonical four- and five-rule inventory forms, and a matrix of mutation-based negative tests to ensure ordering/duplicates/shape/values are strictly validated.

### Testing

- `python3 -m compileall scripts/app_chart.py scripts/observability_app_metrics.py` — OK. 
- `python3 scripts/observability_app_metrics.py validate` — inventory validation passed. 
- Focused validator selection run: `pytest -q tests/test_generic_app_just_recipes.py -k "dspace_production_requires_exact_metrics_path_and_relabelings or observability_app_metrics_inventory or observability_app_metrics_validate_render"` — 49 passed, 390 deselected. 
- Broader focused regression suite requested in the prompt: `pytest -q tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py tests/test_release_manifest.py` — test suite passed (951 passed). 
- Coverage run with `pytest-cov`: focused coverage run completed; `scripts.app_chart` ≈ 93% and `scripts.observability_app_metrics` ≈ 92% and the changed executable branches are covered by tests. 
- `linkchecker --no-warnings README.md docs/` — OK (no link errors). 
- `pre-commit run --all-files` was attempted but the repository contains unrelated tracked pre-existing YAML/lint issues and hooks that auto-fixed unrelated files; those unrelated auto-fixes were reverted and the repo-wide pre-commit gate cannot be used to certify these focused changes here. 
- `pyspelling -c .spellcheck.yaml` could not complete in this environment because the system `aspell` binary is not available. 

Files changed: `scripts/app_chart.py`, `scripts/observability_app_metrics.py`, `platform/observability/app-metrics.json`, and `tests/test_generic_app_just_recipes.py`.

Behavioral guarantees added: omitted DSPACE ServiceMonitor namespace is accepted only when resolved from the Helm release namespace; explicit null/empty/wrong namespaces fail; DSPACE requires the exact ordered five-rule relabeling contract; generic inventory validator accepts only the exact canonical four- or five-rule ordered relabeling forms; token.place’s four-rule contract is unchanged; all new/changed executable lines are exercised by tests.

If you want, I can prepare the PR description body for GitHub (title + the contents above) or split the changes into smaller follow-ups, but the diff here was intentionally minimal and focused to meet the acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d25e14f48832fbfde9499f0e3eab9)