### PR TITLE
Support DSPACE chart 3.0.3 ServiceMonitor contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -227,6 +227,11 @@
               },
               {
                 "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
                 "targetLabel": "release",
                 "replacement": "dspace"
               },

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -414,12 +414,20 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     )
                     auth = endpoint.get("bearerTokenSecret")
                     relabelings = endpoint.get("relabelings")
+                    effective_namespace = (
+                        metadata["namespace"] if "namespace" in metadata else inputs.namespace
+                    )
                     expected_relabelings = [
                         {"action": "replace", "targetLabel": "app", "replacement": "dspace"},
                         {
                             "action": "replace",
                             "targetLabel": "environment",
                             "replacement": "prod",
+                        },
+                        {
+                            "action": "replace",
+                            "targetLabel": "namespace",
+                            "replacement": "dspace",
                         },
                         {
                             "action": "replace",
@@ -434,8 +442,9 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     ]
                     if (
                         metadata.get("name") != "dspace"
-                        or metadata.get("namespace") != "dspace"
+                        or effective_namespace != "dspace"
                         or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        or spec.get("namespaceSelector") != {"matchNames": ["dspace"]}
                         or spec.get("selector")
                         != {
                             "matchLabels": {

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -278,8 +278,8 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
-            if not isinstance(relabelings, list) or len(relabelings) != 4:
-                fail("serviceMonitor.relabelings must contain exactly four entries")
+            if not isinstance(relabelings, list):
+                fail("serviceMonitor.relabelings must be a list")
             for idx, relabeling in enumerate(relabelings):
                 expect_keys(
                     relabeling,
@@ -307,21 +307,30 @@ def validate_inventory(doc):
                 or labels["namespace"] != cfg["namespace"]
             ):
                 fail("targetLabels must match ServiceMonitor and namespace")
-            mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
-            if len(mapping) != len(relabelings):
-                fail("serviceMonitor.relabelings target labels must be unique")
-            required_mapping = {
-                "app": app,
-                "environment": env,
-                "release": cfg["serviceMonitorName"],
-                "cluster": labels.get("cluster"),
-            }
-            if mapping != required_mapping:
-                fail(
-                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
-                )
-            if "namespace" in mapping:
-                fail("namespace must be supplied by discovery, not relabel replacement")
+            canonical_four = [
+                {"action": "replace", "targetLabel": "app", "replacement": app},
+                {"action": "replace", "targetLabel": "environment", "replacement": env},
+                {
+                    "action": "replace",
+                    "targetLabel": "release",
+                    "replacement": cfg["serviceMonitorName"],
+                },
+                {
+                    "action": "replace",
+                    "targetLabel": "cluster",
+                    "replacement": labels["cluster"],
+                },
+            ]
+            canonical_five = canonical_four[:2] + [
+                {
+                    "action": "replace",
+                    "targetLabel": "namespace",
+                    "replacement": cfg["namespace"],
+                },
+                *canonical_four[2:],
+            ]
+            if relabelings not in (canonical_four, canonical_five):
+                fail("serviceMonitor.relabelings must match a canonical ordered contract exactly")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
@@ -1001,10 +1010,9 @@ def validate_render(
             named_sms.append(doc)
     sms = []
     for candidate in named_sms:
-        rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (
-            rendered_ns is None and release_namespace == cfg["namespace"]
-        ):
+        metadata = candidate["metadata"]
+        rendered_ns = metadata["namespace"] if "namespace" in metadata else release_namespace
+        if rendered_ns == cfg["namespace"]:
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -1027,9 +1035,6 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
-    for relabeling in cfg["serviceMonitor"].get("relabelings", []):
-        if relabeling.get("targetLabel") == "namespace":
-            fail("namespace must be supplied by discovery, not relabel replacement")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -433,7 +433,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -460,6 +459,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -1398,13 +1400,46 @@ data:
     "mutation",
     [
         lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
+        lambda manifest: manifest.replace("matchNames:\n      - dspace", "matchNames:\n      - wrong"),
+        lambda manifest: manifest.replace(
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n",
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  namespace:\n",
+        ),
+        lambda manifest: manifest.replace(
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n",
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  namespace: ''\n",
+        ),
+        lambda manifest: manifest.replace(
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n",
+            "kind: ServiceMonitor\nmetadata:\n  name: dspace\n  namespace: wrong\n",
+        ),
         lambda manifest: manifest.replace(
             "replacement: dspace\n        - action: replace\n          targetLabel: environment",
             "replacement: other\n        - action: replace\n          targetLabel: environment",
             1,
         ),
         lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
-        lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
+        lambda manifest: manifest.replace("targetLabel: release", "targetLabel: other"),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: namespace\n          replacement: dspace\n",
+        ),
+        lambda manifest: manifest.replace(
+            "        - action: replace\n          targetLabel: app\n          replacement: dspace\n"
+            "        - action: replace\n          targetLabel: environment\n          replacement: prod\n",
+            "        - action: replace\n          targetLabel: environment\n          replacement: prod\n"
+            "        - action: replace\n          targetLabel: app\n          replacement: dspace\n",
+        ),
+        lambda manifest: manifest.replace(
+            "          replacement: sugarkube-prod\n",
+            "          replacement: sugarkube-prod\n"
+            "        - action: replace\n          targetLabel: extra\n          replacement: value\n",
+        ),
     ],
 )
 def test_dspace_production_requires_exact_metrics_path_and_relabelings(
@@ -1421,7 +1456,7 @@ def test_dspace_production_requires_exact_metrics_path_and_relabelings(
         "dspace",
         "dspace",
         "chart",
-        "3.0.2",
+        "3.0.3",
         (str(values),),
         "main-deadbee",
     )
@@ -1462,11 +1497,13 @@ spec:
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace
@@ -1485,6 +1522,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -5731,6 +5771,35 @@ def test_observability_app_metrics_inventory_tokenplace_contract_is_strict_and_c
     assert "token" in cfg["forbiddenApplicationLabels"]
 
 
+def test_observability_app_metrics_inventory_accepts_both_canonical_relabeling_forms():
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    app_metrics.validate_inventory(doc)
+    assert [r["targetLabel"] for r in doc["applications"]["dspace"]["environments"]["prod"]["serviceMonitor"]["relabelings"]] == [
+        "app", "environment", "namespace", "release", "cluster"
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda rules: rules[:-1],
+        lambda rules: [rules[1], rules[0], *rules[2:]],
+        lambda rules: [rules[0], *rules],
+        lambda rules: [*rules, {"action": "replace", "targetLabel": "extra", "replacement": "x"}],
+        lambda rules: [{**rules[0], "action": "keep"}, *rules[1:]],
+        lambda rules: [{**rules[0], "targetLabel": "other"}, *rules[1:]],
+        lambda rules: [{**rules[0], "replacement": "other"}, *rules[1:]],
+        lambda rules: [{**rules[0], "unexpected": "value"}, *rules[1:]],
+    ],
+)
+def test_observability_app_metrics_inventory_rejects_noncanonical_relabelings(mutation):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    cfg = doc["applications"]["dspace"]["environments"]["prod"]
+    cfg["serviceMonitor"]["relabelings"] = mutation(cfg["serviceMonitor"]["relabelings"])
+    with pytest.raises(SystemExit):
+        app_metrics.validate_inventory(doc)
+
+
 def test_observability_app_metrics_inventory_rejects_unknown_keys_duplicates_and_bad_status():
     doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
     doc["applications"]["tokenplace"]["environments"]["staging"]["extra"] = True
@@ -5839,11 +5908,67 @@ spec:
 """
 
 
+def _dspace_chart_like_service_monitor(namespace_entry: str = "") -> str:
+    return f"""apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dspace
+{namespace_entry}  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames: [dspace]
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
+  endpoints:
+    - path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: dspace-prod-metrics-token
+        key: token
+      relabelings:
+        - {{action: replace, targetLabel: app, replacement: dspace}}
+        - {{action: replace, targetLabel: environment, replacement: prod}}
+        - {{action: replace, targetLabel: namespace, replacement: dspace}}
+        - {{action: replace, targetLabel: release, replacement: dspace}}
+        - {{action: replace, targetLabel: cluster, replacement: sugarkube-prod}}
+"""
+
+
 def test_observability_app_metrics_validate_render_accepts_chart_like_service_monitor(tmp_path: Path):
     rendered = tmp_path / "rendered.yaml"
     rendered.write_text(_tokenplace_chart_like_service_monitor(), encoding="utf-8")
 
     app_metrics.validate_render("tokenplace", "staging", str(rendered), "tokenplace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["", "  namespace: dspace\n"])
+def test_observability_app_metrics_validate_render_accepts_dspace_namespace_forms(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8")
+    app_metrics.validate_render("dspace", "prod", str(rendered), "dspace", "dspace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["  namespace:\n", "  namespace: ''\n", "  namespace: wrong\n"])
+def test_observability_app_metrics_validate_render_rejects_explicit_invalid_namespace(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        app_metrics.validate_render("dspace", "prod", str(rendered), "dspace", "dspace")
+
+
+def test_observability_app_metrics_validate_render_omission_requires_release_namespace(tmp_path: Path):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        app_metrics.validate_render("dspace", "prod", str(rendered), "wrong", "dspace")
 
 
 def test_observability_app_metrics_validate_render_uses_configured_workload_name_not_release_name(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Accept the immutable DSPACE chart 3.0.3 `ServiceMonitor` contract (explicit namespace semantics and a five-entry ordered relabeling list) without weakening the repository's fail-closed validators.
- Keep generic inventory and render validation strict while allowing the one precise DSPACE canonical form required by production.

### Description
- Update `scripts/app_chart.py` to treat an omitted `ServiceMonitor.metadata.namespace` as inherited from the release namespace only when the key is absent, require `namespaceSelector.matchNames == ["dspace"]`, and require the exact ordered five-entry relabeling list (app, environment, namespace, release, cluster) for DSPACE prod checks while preserving all other authentication/selector/timeouts/etc checks.
- Update `scripts/observability_app_metrics.py` to validate inventory relabelings against two canonical ordered lists (four-entry discovery-based and five-entry explicit-namespace) derived from surrounding inventory fields, and to use key-presence semantics in `validate_render()` so that only omission inherits `release_namespace` while explicit null/empty/wrong values fail closed.
- Add the exact DSPACE `namespace` relabeling entry to `platform/observability/app-metrics.json` (inserted between `environment` and `release`) and leave token.place unchanged.
- Extend `tests/test_generic_app_just_recipes.py` with focused fixtures and tests that cover omitted/explicit/null/empty/wrong namespace cases, `namespaceSelector.matchNames` exactness, exact ordered five-rule success and all failure modes (missing, reordered, duplicate, altered, extra relabelings), acceptance of both canonical inventory forms, and both sides of the new namespace key-presence branch to ensure full branch coverage for the changed logic.

### Testing
- Compiled validators with `python3 -m compileall scripts/app_chart.py scripts/observability_app_metrics.py` and ran `python3 scripts/observability_app_metrics.py validate`; both succeeded and reported the inventory valid.
- Ran focused pytest selection `pytest -q tests/test_generic_app_just_recipes.py -k "dspace_production_requires_exact_metrics_path_and_relabelings or observability_app_metrics_inventory or observability_app_metrics_validate_render"` and observed all selected tests pass (58 passed).
- Ran the required focused suites `pytest -q tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py tests/test_release_manifest.py` and observed success (959 passed overall).
- Ran coverage for the focused tests and observed the combined statement coverage for the modified modules at ~92% (`scripts/app_chart.py` ~93%, `scripts/observability_app_metrics.py` ~92%).
- Performed `git diff --check`, staged secret scan, and a `pre-commit` run attempt; `git diff --check` and secret scans were clean, and `pre-commit` was attempted but the repository contains unrelated, pre-existing repository-wide hook findings (YAML/whitespace/lint issues) that were not introduced by this PR and were not relaxed to make CI pass.

Files changed: `scripts/app_chart.py`, `scripts/observability_app_metrics.py`, `platform/observability/app-metrics.json`, and `tests/test_generic_app_just_recipes.py`.

Behavioral guarantees added: omitted `ServiceMonitor.metadata.namespace` is accepted only by exact release-namespace inheritance, explicit null/empty/wrong namespaces fail closed, `namespaceSelector.matchNames` must be exactly `["dspace"]`, DSPACE requires an exact ordered five-rule relabeling contract, and the generic inventory validator only accepts the canonical four- or five-rule ordered forms while preserving the token.place four-rule contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d25eea2ac832fbdb6bd053e4d4c04)