### PR TITLE
Support DSPACE chart 3.0.3 ServiceMonitor contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -227,6 +227,11 @@
               },
               {
                 "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
                 "targetLabel": "release",
                 "replacement": "dspace"
               },

--- a/scripts/app_chart.py
+++ b/scripts/app_chart.py
@@ -403,6 +403,11 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     metadata = (
                         monitor.get("metadata") if isinstance(monitor.get("metadata"), dict) else {}
                     )
+                    effective_namespace = (
+                        metadata.get("namespace")
+                        if "namespace" in metadata
+                        else inputs.namespace
+                    )
                     spec = monitor.get("spec") if isinstance(monitor.get("spec"), dict) else {}
                     endpoints = spec.get("endpoints")
                     endpoint = (
@@ -423,6 +428,11 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                         },
                         {
                             "action": "replace",
+                            "targetLabel": "namespace",
+                            "replacement": "dspace",
+                        },
+                        {
+                            "action": "replace",
                             "targetLabel": "release",
                             "replacement": "dspace",
                         },
@@ -434,8 +444,9 @@ def validate_rendered_manifest(manifest: str, inputs: ReleaseInputs) -> list[str
                     ]
                     if (
                         metadata.get("name") != "dspace"
-                        or metadata.get("namespace") != "dspace"
+                        or effective_namespace != "dspace"
                         or metadata.get("labels", {}).get("release") != "kube-prometheus-stack"
+                        or spec.get("namespaceSelector") != {"matchNames": ["dspace"]}
                         or spec.get("selector")
                         != {
                             "matchLabels": {

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -278,18 +278,6 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
-            if not isinstance(relabelings, list) or len(relabelings) != 4:
-                fail("serviceMonitor.relabelings must contain exactly four entries")
-            for idx, relabeling in enumerate(relabelings):
-                expect_keys(
-                    relabeling,
-                    {"action", "targetLabel", "replacement"},
-                    f"serviceMonitor.relabelings[{idx}]",
-                )
-                if relabeling["action"] != "replace":
-                    fail("serviceMonitor.relabelings action must be replace")
-                prometheus_label(relabeling["targetLabel"], "relabeling targetLabel")
-                nonempty(relabeling["replacement"], "relabeling replacement")
             labels = cfg["targetLabels"]
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
@@ -307,21 +295,29 @@ def validate_inventory(doc):
                 or labels["namespace"] != cfg["namespace"]
             ):
                 fail("targetLabels must match ServiceMonitor and namespace")
-            mapping = {r["targetLabel"]: r["replacement"] for r in relabelings}
-            if len(mapping) != len(relabelings):
-                fail("serviceMonitor.relabelings target labels must be unique")
-            required_mapping = {
-                "app": app,
-                "environment": env,
-                "release": cfg["serviceMonitorName"],
-                "cluster": labels.get("cluster"),
-            }
-            if mapping != required_mapping:
-                fail(
-                    "serviceMonitor.relabelings must map app, environment, release, and cluster exactly"
-                )
-            if "namespace" in mapping:
-                fail("namespace must be supplied by discovery, not relabel replacement")
+            canonical_relabelings = [
+                {"action": "replace", "targetLabel": "app", "replacement": app},
+                {"action": "replace", "targetLabel": "environment", "replacement": env},
+                {
+                    "action": "replace",
+                    "targetLabel": "release",
+                    "replacement": cfg["serviceMonitorName"],
+                },
+                {
+                    "action": "replace",
+                    "targetLabel": "cluster",
+                    "replacement": labels["cluster"],
+                },
+            ]
+            canonical_with_namespace = canonical_relabelings[:2] + [
+                {
+                    "action": "replace",
+                    "targetLabel": "namespace",
+                    "replacement": cfg["namespace"],
+                }
+            ] + canonical_relabelings[2:]
+            if relabelings not in (canonical_relabelings, canonical_with_namespace):
+                fail("serviceMonitor.relabelings must match a canonical ordered contract exactly")
             pm = cfg["publicMetrics"]
             expect_keys(pm, {"url", "expectedUnauthenticatedStatus"}, "publicMetrics")
             public_metrics_url(pm["url"])
@@ -1001,10 +997,11 @@ def validate_render(
             named_sms.append(doc)
     sms = []
     for candidate in named_sms:
-        rendered_ns = candidate.get("metadata", {}).get("namespace")
-        if rendered_ns == cfg["namespace"] or (
-            rendered_ns is None and release_namespace == cfg["namespace"]
-        ):
+        metadata = candidate["metadata"]
+        rendered_ns = (
+            metadata.get("namespace") if "namespace" in metadata else release_namespace
+        )
+        if rendered_ns == cfg["namespace"]:
             sms.append(candidate)
     if len(sms) != 1:
         fail("rendered manifests must include exactly one configured ServiceMonitor")
@@ -1027,9 +1024,6 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
-    for relabeling in cfg["serviceMonitor"].get("relabelings", []):
-        if relabeling.get("targetLabel") == "namespace":
-            fail("namespace must be supplied by discovery, not relabel replacement")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -433,7 +433,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
@@ -460,6 +459,9 @@ spec:
         - action: replace
           targetLabel: environment
           replacement: prod
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
         - action: replace
           targetLabel: release
           replacement: dspace
@@ -1394,38 +1396,8 @@ data:
     )
 
 
-@pytest.mark.parametrize(
-    "mutation",
-    [
-        lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
-        lambda manifest: manifest.replace(
-            "replacement: dspace\n        - action: replace\n          targetLabel: environment",
-            "replacement: other\n        - action: replace\n          targetLabel: environment",
-            1,
-        ),
-        lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
-        lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
-    ],
-)
-def test_dspace_production_requires_exact_metrics_path_and_relabelings(
-    tmp_path: Path, mutation
-) -> None:
-    values = tmp_path / "prod.yaml"
-    values.write_text(
-        (REPO_ROOT / "docs/examples/dspace.values.prod.yaml").read_text(encoding="utf-8"),
-        encoding="utf-8",
-    )
-    inputs = app_chart.ReleaseInputs(
-        "dspace",
-        "prod",
-        "dspace",
-        "dspace",
-        "chart",
-        "3.0.2",
-        (str(values),),
-        "main-deadbee",
-    )
-    monitor = """kind: Deployment
+def _dspace_chart_303_service_monitor_manifest() -> str:
+    return """kind: Deployment
 metadata:
   name: dspace
   namespace: dspace
@@ -1462,11 +1434,13 @@ spec:
 kind: ServiceMonitor
 metadata:
   name: dspace
-  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
     release: kube-prometheus-stack
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace
@@ -1486,6 +1460,9 @@ spec:
           targetLabel: environment
           replacement: prod
         - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
           targetLabel: release
           replacement: dspace
         - action: replace
@@ -1493,11 +1470,76 @@ spec:
           replacement: sugarkube-prod
 """
 
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda manifest: manifest.replace("path: /metrics", "path: /healthz"),
+        lambda manifest: manifest.replace(
+            "replacement: dspace\n        - action: replace\n          targetLabel: environment",
+            "replacement: other\n        - action: replace\n          targetLabel: environment",
+            1,
+        ),
+        lambda manifest: manifest.replace("replacement: prod", "replacement: staging"),
+        lambda manifest: manifest.replace("targetLabel: release", "targetLabel: namespace"),
+        lambda manifest: manifest.replace("      - dspace", "      - wrong", 1),
+    ],
+)
+def test_dspace_production_requires_exact_metrics_path_and_relabelings(
+    tmp_path: Path, mutation
+) -> None:
+    values = tmp_path / "prod.yaml"
+    values.write_text(
+        (REPO_ROOT / "docs/examples/dspace.values.prod.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    inputs = app_chart.ReleaseInputs(
+        "dspace",
+        "prod",
+        "dspace",
+        "dspace",
+        "chart",
+        "3.0.3",
+        (str(values),),
+        "main-deadbee",
+    )
+    monitor = _dspace_chart_303_service_monitor_manifest()
+
     assert app_chart.validate_rendered_manifest(monitor, inputs) == []
+    explicit_namespace = monitor.replace(
+        "metadata:\n  name: dspace\n  labels:\n    app.kubernetes.io/instance: dspace\n    release:",
+        "metadata:\n  name: dspace\n  namespace: dspace\n  labels:\n"
+        "    app.kubernetes.io/instance: dspace\n    release:",
+    )
+    assert app_chart.validate_rendered_manifest(explicit_namespace, inputs) == []
     mutated = mutation(monitor)
     assert mutated != monitor
     assert "DSPACE production ServiceMonitor contract mismatch" in (
         app_chart.validate_rendered_manifest(mutated, inputs)
+    )
+
+
+@pytest.mark.parametrize("namespace", [None, "", "wrong"])
+def test_dspace_production_rejects_present_invalid_service_monitor_namespace(
+    tmp_path: Path, namespace
+) -> None:
+    values = tmp_path / "prod.yaml"
+    values.write_text(
+        (REPO_ROOT / "docs/examples/dspace.values.prod.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    inputs = app_chart.ReleaseInputs(
+        "dspace", "prod", "dspace", "dspace", "chart", "3.0.3", (str(values),), "main-deadbee"
+    )
+    manifest = _dspace_chart_303_service_monitor_manifest()
+    rendered_namespace = "null" if namespace is None else json.dumps(namespace)
+    manifest = manifest.replace(
+        "metadata:\n  name: dspace\n  labels:\n    app.kubernetes.io/instance: dspace\n    release:",
+        f"metadata:\n  name: dspace\n  namespace: {rendered_namespace}\n  labels:\n    app.kubernetes.io/instance: dspace\n    release:",
+    )
+
+    assert "DSPACE production ServiceMonitor contract mismatch" in (
+        app_chart.validate_rendered_manifest(manifest, inputs)
     )
 
 
@@ -5839,11 +5881,60 @@ spec:
 """
 
 
+def _dspace_chart_like_service_monitor(namespace_entry: str = "") -> str:
+    manifest = _dspace_chart_303_service_monitor_manifest().split("---\n")[-1]
+    if namespace_entry:
+        manifest = manifest.replace(
+            "metadata:\n  name: dspace\n",
+            f"metadata:\n  name: dspace\n  namespace: {namespace_entry}\n",
+        )
+    return manifest
+
+
 def test_observability_app_metrics_validate_render_accepts_chart_like_service_monitor(tmp_path: Path):
     rendered = tmp_path / "rendered.yaml"
     rendered.write_text(_tokenplace_chart_like_service_monitor(), encoding="utf-8")
 
     app_metrics.validate_render("tokenplace", "staging", str(rendered), "tokenplace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["", "dspace"])
+def test_observability_app_metrics_validate_render_accepts_dspace_chart_303_namespace_forms(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(
+        _dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8"
+    )
+
+    app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+
+@pytest.mark.parametrize("namespace_entry", ["null", "''", "wrong"])
+def test_observability_app_metrics_validate_render_rejects_present_invalid_dspace_namespace(
+    tmp_path: Path, namespace_entry: str
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(
+        _dspace_chart_like_service_monitor(namespace_entry), encoding="utf-8"
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_render("dspace", "prod", str(rendered), "dspace")
+
+    assert "exactly one configured ServiceMonitor" in str(excinfo.value)
+
+
+def test_observability_app_metrics_validate_render_omission_requires_matching_release_namespace(
+    tmp_path: Path,
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_chart_like_service_monitor(), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_render("dspace", "prod", str(rendered), "wrong")
+
+    assert "exactly one configured ServiceMonitor" in str(excinfo.value)
 
 
 def test_observability_app_metrics_validate_render_uses_configured_workload_name_not_release_name(tmp_path: Path):
@@ -5995,6 +6086,49 @@ def test_observability_app_metrics_inventory_relabelings_match_rendered_replace_
         {"action": "replace", "targetLabel": "cluster", "replacement": "sugarkube-int"},
     ]
     assert "namespace" not in {r["targetLabel"] for r in relabelings}
+
+
+def test_observability_app_metrics_inventory_accepts_both_canonical_relabeling_forms():
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+
+    app_metrics.validate_inventory(doc)
+    assert doc["applications"]["dspace"]["environments"]["prod"]["serviceMonitor"][
+        "relabelings"
+    ] == [
+        {"action": "replace", "targetLabel": "app", "replacement": "dspace"},
+        {"action": "replace", "targetLabel": "environment", "replacement": "prod"},
+        {"action": "replace", "targetLabel": "namespace", "replacement": "dspace"},
+        {"action": "replace", "targetLabel": "release", "replacement": "dspace"},
+        {"action": "replace", "targetLabel": "cluster", "replacement": "sugarkube-prod"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda rules: rules.pop(),
+        lambda rules: rules.__setitem__(slice(0, 2), reversed(rules[:2])),
+        lambda rules: rules.__setitem__(1, rules[0].copy()),
+        lambda rules: rules[0].update({"targetLabel": "wrong"}),
+        lambda rules: rules[0].update({"replacement": "wrong"}),
+        lambda rules: rules[0].update({"action": "keep"}),
+        lambda rules: rules[0].update({"extra": "wrong"}),
+        lambda rules: rules.append(
+            {"action": "replace", "targetLabel": "extra", "replacement": "wrong"}
+        ),
+    ],
+)
+def test_observability_app_metrics_inventory_rejects_noncanonical_relabelings(mutator):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    rules = doc["applications"]["dspace"]["environments"]["prod"]["serviceMonitor"][
+        "relabelings"
+    ]
+    mutator(rules)
+
+    with pytest.raises(SystemExit) as excinfo:
+        app_metrics.validate_inventory(doc)
+
+    assert "canonical ordered contract exactly" in str(excinfo.value)
 
 
 def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_401(monkeypatch):


### PR DESCRIPTION
### Motivation

- Ensure Sugarkube validators accept the immutable DSPACE chart 3.0.3 ServiceMonitor contract without weakening fail-closed checks.  
- Treat an omitted ServiceMonitor `metadata.namespace` as inheriting the Helm release namespace only when the key is absent, and reject explicitly present `null`, `""`, or wrong values.  
- Allow the observability inventory to express the two canonical relabeling shapes (four-rule discovery form or five-rule explicit-namespace form) and verify exact ordered equality.

### Description

- Update `scripts/app_chart.py` to compute an `effective_namespace` using key-presence semantics and to require DSPACE ServiceMonitor `namespaceSelector.matchNames == ["dspace"]` and the exact ordered five-entry relabelings `app, environment, namespace, release, cluster` when metrics are enabled.  
- Update `scripts/observability_app_metrics.py` to accept exactly two canonical relabeling lists derived from inventory fields (four-rule discovery form or five-rule explicit-namespace form), to validate relabelings by exact ordered equality, and to treat `metadata.namespace` presence/omission correctly when matching rendered ServiceMonitors to inventory.  
- Add the explicit DSPACE inventory relabeling entry for `namespace:dspace` into `platform/observability/app-metrics.json` without changing schema version or token.place contract.  
- Add and update focused tests in `tests/test_generic_app_just_recipes.py` that exercise DSPACE 3.0.3 behavior and the new inventory/render branches, including omitted namespace acceptance, null/empty/wrong namespace rejection, exact `namespaceSelector.matchNames`, five-rule success, and many malformed/reordering/duplication failure cases.

Files changed: `scripts/app_chart.py`, `scripts/observability_app_metrics.py`, `platform/observability/app-metrics.json`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Ran `python3 -m compileall scripts/app_chart.py scripts/observability_app_metrics.py` and `python3 scripts/observability_app_metrics.py validate`, both succeeded.  
- Focused pytest selection covering the new DSPACE and inventory branches: `pytest -q tests/test_generic_app_just_recipes.py -k "dspace_production_requires_exact_metrics_path_and_relabelings or observability_app_metrics_inventory or observability_app_metrics_validate_render"` — 50 tests passed.  
- Broader regression selection including dependent suites: `pytest -q tests/test_generic_app_just_recipes.py tests/test_manifest_rollback.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py tests/test_release_manifest.py` — 955 tests passed.  
- Coverage run for the affected modules: `pytest -q tests/test_generic_app_just_recipes.py --cov=scripts.app_chart --cov=scripts.observability_app_metrics --cov-report=term-missing` reported 443 tests passed and module coverage ~93% for `scripts.app_chart` and ~92% for `scripts.observability_app_metrics`.  
- Per-repo checks: `git diff --check` and `git diff origin/main...HEAD | ./scripts/scan-secrets.py` passed; `linkchecker --no-warnings README.md docs/` passed; `pre-commit run --all-files` was attempted but failed due to pre-existing repository-wide hooks (unrelated files were auto-fixed and then restored); `pyspelling -c .spellcheck.yaml` could not run because the environment lacks the system `aspell` binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d25f14138832fa3902a5032dee34a)