### PR TITLE
Fix DSPACE pullPolicy regression and add guarded one-time recovery path

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -40,6 +40,42 @@ Any failure after reservation preserves failed evidence. Review that evidence an
 before any further mutation; never automatically rerun, uninstall, roll back, delete, or rotate the
 Secret.
 
+## One-time production pull-policy recovery (revision 10 to 11)
+
+The reviewed metrics reconciliation reached Helm revision 10 but correctly failed finalization
+because chart 3.0.3 computed `image.pullPolicy: IfNotPresent`. The original failed evidence is an
+immutable failure record: **do not edit it, mark it successful, or rerun
+`dspace-prod-metrics-reconcile`**. The normal reconciliation now sets `Always` in both its render and
+upgrade commands.
+
+The following is a one-time, separately authorized production recovery, not a general retry path.
+It accepts only that invocation's `ownership-and-finalization-proof` failure, revision 10/chart
+3.0.3 with the invocation-bound Helm description, two Ready pods at the approved tag and digest,
+and a complete desired-values match whose sole delta is `IfNotPresent` instead of `Always`. All
+cluster identity, Secret metadata, OCI provenance, strict render, runtime, public journey, remote
+chat, ownership, metrics, Prometheus, and Grafana checks remain mandatory. It reserves a new private
+record and performs at most one digest-qualified, bounded Helm upgrade without `--reuse-values`.
+Any failure preserves the recovery record and stops without retry, rollback, uninstall, or Secret
+mutation.
+
+After this change is merged and separate production authorization is recorded, run exactly once
+with an absolute production kubeconfig and fresh, nonexistent recovery evidence path (do not run
+this command during development):
+
+```bash
+just dspace-prod-metrics-pull-policy-recover \
+  failed_evidence="$PRESERVED_FAILED_RECONCILIATION_EVIDENCE" \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
+  evidence="$FRESH_NONEXISTING_RECOVERY_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
+  confirm="dspace:prod:recover-pull-policy:revision-10-to-11"
+```
+
+A success record links to the failed invocation by its non-secret invocation ID and evidence
+fingerprint and proves exactly revision 10 to 11 while retaining chart 3.0.3 and the approved image
+digest. Preserve both records; the recovery never rewrites the original evidence.
+
 ## Production Helm reconciliation for application 3.0.1
 
 This section **prepares but does not execute** the incident reconciliation tracked by

--- a/justfile
+++ b/justfile
@@ -1862,6 +1862,43 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
     )
     "${reconciliation_command[@]}"
 
+# One-time, separately authorized recovery for the failed revision-10 pull-policy incident.
+dspace-prod-metrics-pull-policy-recover failed_evidence maintenance_target evidence smoke_runner kubeconfig confirm verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    failed_path={{ quote(failed_evidence) }}
+    target_path={{ quote(maintenance_target) }}
+    evidence_path={{ quote(evidence) }}
+    smoke_path={{ quote(smoke_runner) }}
+    kubeconfig_path={{ quote(kubeconfig) }}
+    confirmation={{ quote(confirm) }}
+    verifier_path={{ quote(verifier) }}
+    config_path={{ quote(config) }}
+    for assignment in failed_evidence maintenance_target evidence smoke_runner kubeconfig confirm verifier config; do
+      variable="${assignment}_path"
+      case "${assignment}" in
+        failed_evidence) variable=failed_path ;;
+        maintenance_target) variable=target_path ;;
+        evidence) variable=evidence_path ;;
+        smoke_runner) variable=smoke_path ;;
+        kubeconfig) variable=kubeconfig_path ;;
+        confirm) variable=confirmation ;;
+        verifier) variable=verifier_path ;;
+        config) variable=config_path ;;
+      esac
+      value="${!variable}"
+      value="${value#${assignment}=}"
+      printf -v "${variable}" '%s' "${value}"
+    done
+    [ -n "${failed_path}" ] && [ -n "${target_path}" ] && [ -n "${evidence_path}" ] && \
+      [ -n "${smoke_path}" ] && [ -n "${kubeconfig_path}" ] && [ -n "${confirmation}" ]
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --pull-policy-recovery --environment prod \
+      --failed-evidence "${failed_path}" --maintenance-target "${target_path}" \
+      --evidence "${evidence_path}" --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" --verifier "${verifier_path}" \
+      --confirm "${confirmation}" --config "${config_path}"
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -23,12 +23,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import app_config  # noqa: E402
 from scripts import app_chart  # noqa: E402
+from scripts import app_config  # noqa: E402
 from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
 OPERATION = "dspaceManifestRollback"
+RECOVERY_OPERATION = "dspaceProductionMetricsPullPolicyRecovery"
+RECOVERY_CONFIRMATION = "dspace:prod:recover-pull-policy:revision-10-to-11"
+PRODUCTION_BASELINE = (
+    REPO_ROOT / "deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json"
+)
 REQUIRED_CAPABILITIES = (
     "applicationVersion",
     "runtimeSourceRevision",
@@ -617,6 +622,69 @@ def configuration_comparison_baselines(
     return baseline, desired_baseline
 
 
+def merge_value_documents(earlier: object, later: object) -> object:
+    """Apply Helm-style recursive mapping precedence without exposing values."""
+    if not isinstance(earlier, dict) or not isinstance(later, dict):
+        return copy.deepcopy(later)
+    merged = copy.deepcopy(earlier)
+    for key, value in later.items():
+        merged[key] = (
+            merge_value_documents(merged[key], value) if key in merged else copy.deepcopy(value)
+        )
+    return merged
+
+
+def validate_pull_policy_recovery_evidence(path: Path, target: dict[str, Any]) -> dict[str, Any]:
+    """Accept only the preserved failure produced by the reviewed 9 -> 10 operation."""
+    try:
+        failed = json.loads(path.read_bytes())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RollbackError("failed reconciliation evidence is unreadable or invalid") from exc
+    if not isinstance(failed, dict):
+        raise RollbackError("failed reconciliation evidence must be an object")
+    expected = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "clusterMayHaveChanged": True,
+        "environment": "prod",
+        "release": "dspace",
+        "namespace": "dspace",
+    }
+    if any(failed.get(key) != value for key, value in expected.items()):
+        raise RollbackError("failed evidence is not the authorized post-mutation failure")
+    invocation = failed.get("invocationId")
+    if not isinstance(invocation, str) or not re.fullmatch(r"[0-9a-f]{32}", invocation):
+        raise RollbackError("failed evidence invocation is invalid")
+    before = failed.get("before")
+    if not isinstance(before, dict) or (
+        before.get("helmRevision"),
+        before.get("chartName"),
+        before.get("chartVersion"),
+    ) != (9, "dspace", "3.0.2"):
+        raise RollbackError("failed evidence before state is not revision 9/chart 3.0.2")
+    wanted_target = {
+        key: target[key]
+        for key in (
+            "chartVersion",
+            "chartDigest",
+            "imageTag",
+            "imageDigest",
+            "sourceRevision",
+            "chartSourceRevision",
+            "applicationVersion",
+            "expectedDefaultChatProvider",
+        )
+    }
+    if failed.get("target") != wanted_target:
+        raise RollbackError("failed evidence target differs from approved coordinates")
+    fingerprint = failed.get("targetManifestFingerprint")
+    expected_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
+    if fingerprint != expected_fingerprint:
+        raise RollbackError("failed evidence target fingerprint is invalid")
+    return failed
+
+
 def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, Any]:
     """Apply a strict reviewed chart tuple without rewriting finalized evidence."""
     if (
@@ -679,7 +747,9 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
 
 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
-    if getattr(args, "configuration_reconciliation", False):
+    if getattr(args, "configuration_reconciliation", False) or getattr(
+        args, "pull_policy_recovery", False
+    ):
         if not args.kubeconfig or ":" in args.kubeconfig:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
@@ -707,7 +777,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
     if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
-    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    recovery = getattr(args, "pull_policy_recovery", False)
+    configuration_reconciliation = getattr(args, "configuration_reconciliation", False) or recovery
     target = baseline
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
         target = chart_maintenance_target(baseline, args.maintenance_target)
@@ -780,6 +851,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
         ]
     )
     before_helm, _before_history, before_identity = helm_snapshot(
@@ -789,7 +862,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != baseline["helmRevision"]:
+        expected_before_revision = 10 if recovery else baseline["helmRevision"]
+        if before_identity[2] != expected_before_revision:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -804,29 +878,45 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
+        expected_live_chart = target["chartVersion"] if recovery else baseline["chartVersion"]
+        if before_identity[:2] != ("dspace", expected_live_chart):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
+        live_values_command = [
+            "helm",
+            "--kubeconfig",
+            args.kubeconfig,
+            "get",
+            "values",
+            "dspace",
+            "--namespace",
+            "dspace",
+        ]
+        if recovery:
+            live_values_command.append("--all")
+        live_values_command.extend(("-o", "json"))
         live_values = json_command(
             runner,
-            [
-                "helm",
-                "--kubeconfig",
-                args.kubeconfig,
-                "get",
-                "values",
-                "dspace",
-                "--namespace",
-                "dspace",
-                "-o",
-                "json",
-            ],
+            live_values_command,
             "Helm stored values",
         )
         desired_values = app_chart.merged_values_document(tuple(str(path) for path in values))
         if not isinstance(desired_values, dict):
             raise RollbackError("desired values are structurally invalid")
+        if recovery:
+            defaults_text = runner(
+                [
+                    "helm",
+                    "show",
+                    "values",
+                    coordinate,
+                ]
+            )
+            documents = app_chart.safe_yaml_documents(defaults_text)
+            if len(documents) != 1 or not isinstance(documents[0], dict):
+                raise RollbackError("approved chart defaults are structurally invalid")
+            desired_values = merge_value_documents(documents[0], desired_values)
         desired_values["image"] = {
             "repository": release.IMAGE_REF,
             "tag": target["imageTag"],
@@ -857,8 +947,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 release.chart_coordinate(
                     {
                         **approved,
-                        "chartVersion": baseline["chartVersion"],
-                        "chartDigest": baseline["chartDigest"],
+                        "chartVersion": expected_live_chart,
+                        "chartDigest": (
+                            target["chartDigest"] if recovery else baseline["chartDigest"]
+                        ),
                     }
                 ),
                 "--namespace",
@@ -878,16 +970,32 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         except release.ManifestError as exc:
             raise RollbackError("desired production metrics contract is invalid") from exc
 
-        live_metrics = live_values.get("metrics")
-        live_monitor = live_values.get("serviceMonitor")
-        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
-            None,
-            {"enabled": False},
-        ):
-            raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
-        if baseline != desired_baseline:
-            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+        if recovery:
+            failed = validate_pull_policy_recovery_evidence(args.failed_evidence, target)
+            expected_description = (
+                f"sugarkube-dspace-metrics-reconciliation:{failed['invocationId']}"
+            )
+            if before_helm.get("info", {}).get("description") != expected_description:
+                raise RollbackError("live release is not bound to the failed invocation")
+            allowed_live = copy.deepcopy(desired_values)
+            allowed_live["image"]["pullPolicy"] = "IfNotPresent"
+            if live_values != allowed_live:
+                raise RollbackError("live values differ from the sole approved pull-policy delta")
+        else:
+            live_metrics = live_values.get("metrics")
+            live_monitor = live_values.get("serviceMonitor")
+            if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
+                None,
+                {"enabled": False},
+            ):
+                raise RollbackError("live metrics values are not the approved disabled baseline")
+            baseline, desired_baseline = configuration_comparison_baselines(
+                live_values, desired_values
+            )
+            if baseline != desired_baseline:
+                raise RollbackError(
+                    "unrelated Helm values drift blocks configuration reconciliation"
+                )
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -963,7 +1071,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
-    confirmation(args.environment, args.confirm, target)
+    if recovery:
+        if args.confirm != RECOVERY_CONFIRMATION:
+            raise RollbackError(f"confirmation must exactly equal {RECOVERY_CONFIRMATION}")
+    else:
+        confirmation(args.environment, args.confirm, target)
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
@@ -976,7 +1088,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "operation": (
-            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+            RECOVERY_OPERATION
+            if recovery
+            else (
+                "dspaceProductionMetricsReconciliation"
+                if configuration_reconciliation
+                else OPERATION
+            )
         ),
         "state": "reserved",
         "invocationId": invocation,
@@ -1010,11 +1128,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "ociPreflight": oci,
     }
+    if recovery:
+        evidence["recoveryOf"] = {
+            "invocationId": failed["invocationId"],
+            "evidenceFingerprint": hashlib.sha256(args.failed_evidence.read_bytes()).hexdigest(),
+        }
     reserve(args.evidence, evidence)
     mutated = False
     production_target_verified = not configuration_reconciliation
     failed_stage = "pre-mutation-revalidation"
-    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    operation = (
+        "metrics-pull-policy-recovery"
+        if recovery
+        else ("metrics-reconciliation" if configuration_reconciliation else "manifest-rollback")
+    )
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
         if configuration_reconciliation:
@@ -1032,22 +1159,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             current_pods = pods(runner, args.kubeconfig, "dspace", "dspace")
             if current_pods != before_pods:
                 raise RollbackError("DSPACE pods changed before mutation")
-            current_values = json_command(
-                runner,
-                [
-                    "helm",
-                    "--kubeconfig",
-                    args.kubeconfig,
-                    "get",
-                    "values",
-                    "dspace",
-                    "--namespace",
-                    "dspace",
-                    "-o",
-                    "json",
-                ],
-                "Helm stored values",
-            )
+            current_values = json_command(runner, live_values_command, "Helm stored values")
             if current_values != live_values:
                 raise RollbackError("Helm values changed before mutation")
             runner(
@@ -1082,6 +1194,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
             "--wait",
             "--timeout",
             args.timeout,
@@ -1381,8 +1495,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--pull-policy-recovery", action="store_true")
+    parser.add_argument("--failed-evidence", type=Path)
     args = parser.parse_args(argv)
-    if args.configuration_reconciliation:
+    if args.pull_policy_recovery:
+        if (
+            args.environment != "prod"
+            or args.manifest is not None
+            or args.baseline_manifest is not None
+            or args.maintenance_target is None
+            or args.failed_evidence is None
+            or args.configuration_reconciliation
+        ):
+            parser.error(
+                "pull-policy recovery requires prod, --failed-evidence, and "
+                "--maintenance-target only"
+            )
+        args.manifest = PRODUCTION_BASELINE
+    elif args.configuration_reconciliation:
         if (
             args.manifest is not None
             or args.baseline_manifest is None
@@ -1399,7 +1529,9 @@ def main(argv: list[str] | None = None) -> int:
         or args.maintenance_target is not None
     ):
         parser.error("rollback requires --manifest and does not accept maintenance coordinates")
-    if args.kubeconfig is None and not args.configuration_reconciliation:
+    if args.kubeconfig is None and not (
+        args.configuration_reconciliation or args.pull_policy_recovery
+    ):
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:
         rollback(args)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -7783,3 +7783,22 @@ def test_observability_app_metrics_strict_inventory_boundaries_are_controlled(
     with pytest.raises(app_metrics.Error) as excinfo:
         app_metrics.validate_inventory(doc)
     assert message in str(excinfo.value)
+
+
+def test_dspace_pull_policy_recovery_recipe_is_separately_guarded() -> None:
+    source = Path("justfile").read_text(encoding="utf-8")
+    recipe = source.split("dspace-prod-metrics-pull-policy-recover", 1)[1].split(
+        "# Read-only DSPACE runtime", 1
+    )[0]
+    for required in (
+        "--pull-policy-recovery",
+        "--failed-evidence",
+        "--maintenance-target",
+        "--evidence",
+        "--smoke-runner",
+        "--kubeconfig",
+        "--verifier",
+        "--confirm",
+    ):
+        assert required in recipe
+    assert "--configuration-reconciliation" not in recipe

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from argparse import Namespace
 from pathlib import Path
@@ -1788,3 +1789,52 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
     assert written["targetManifestFingerprint"] == result["targetManifestFingerprint"]
     assert written["helm"]["beforeRevision"] == 7
     assert written["helm"]["afterRevision"] == 8
+
+
+def test_pull_policy_recovery_evidence_is_narrowly_bound(tmp_path: Path) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    target = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    failed = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "clusterMayHaveChanged": True,
+        "environment": "prod",
+        "release": "dspace",
+        "namespace": "dspace",
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": hashlib.sha256(manifest._canonical(target).encode()).hexdigest(),
+        "before": {"helmRevision": 9, "chartName": "dspace", "chartVersion": "3.0.2"},
+        "target": {
+            key: target[key]
+            for key in (
+                "chartVersion",
+                "chartDigest",
+                "imageTag",
+                "imageDigest",
+                "sourceRevision",
+                "chartSourceRevision",
+                "applicationVersion",
+                "expectedDefaultChatProvider",
+            )
+        },
+    }
+    evidence = tmp_path / "failed.json"
+    evidence.write_text(json.dumps(failed), encoding="utf-8")
+    assert rollback.validate_pull_policy_recovery_evidence(evidence, target) == failed
+
+    for field, replacement in (
+        ("failedStage", "runtime-verification"),
+        ("state", "succeeded"),
+        ("clusterMayHaveChanged", False),
+    ):
+        rejected = dict(failed)
+        rejected[field] = replacement
+        evidence.write_text(json.dumps(rejected), encoding="utf-8")
+        with pytest.raises(rollback.RollbackError, match="authorized post-mutation"):
+            rollback.validate_pull_policy_recovery_evidence(evidence, target)
+
+
+def test_reconciliation_render_and_upgrade_pin_approved_pull_policy() -> None:
+    source = Path("scripts/dspace_manifest_rollback.py").read_text(encoding="utf-8")
+    assert source.count('"image.pullPolicy=Always"') == 2


### PR DESCRIPTION
### Motivation

- Prevent the reviewed reconciliation from failing finalization when the chart computes `image.pullPolicy` to `IfNotPresent` by ensuring the repo-approved `Always` value is explicitly passed to all Helm render and mutate paths. 
- Provide a narrowly-scoped, fail-closed recovery path for the exact post-mutation failure that preserves the original failed evidence and allows a single authorized, audit-bound digest-qualified upgrade to repair the cluster state.

### Description

- Ensure both the `helm template` and `helm upgrade` invocations explicitly set `image.pullPolicy=Always` so rendered/desire-value comparisons, upgrade, and post-upgrade stored-values validation remain aligned (`scripts/dspace_manifest_rollback.py`).
- Add a new recovery mode and CLI flags (`--pull-policy-recovery`, `--failed-evidence`) and a one-time operation name/confirmation token for the guarded flow; validate the preserved failed evidence before any mutation and link new recovery evidence to the original invocation without editing it (`scripts/dspace_manifest_rollback.py`).
- Tighten preflight checks for the recovery flow to require `sugar-prod` context, live Helm revision 10/chart 3.0.3, exactly two Ready DSPACE pods with the approved tag+digest, complete desired-values agreement except for the single allowed delta (`image.pullPolicy=IfNotPresent`), OCI provenance, and all existing ownership/finalizer/metrics/runtime/verifier checks before permitting a single revision increment to 11 with explicit `image.repository`, `image.tag`, and `image.pullPolicy=Always` and without `--reuse-values` (`scripts/dspace_manifest_rollback.py`).
- Add a dedicated `just` recipe `dspace-prod-metrics-pull-policy-recover` that calls the new recovery mode and requires the preserved failed-evidence, maintenance target, fresh non-existent recovery evidence path, smoke runner, absolute production kubeconfig, verifier, and the exact confirmation string `dspace:prod:recover-pull-policy:revision-10-to-11` (`justfile`).
- Document the one-time, separately authorized recovery procedure and the exact command in the DSPACE runbook and operator notes while stressing the immutability of the original failed evidence (`docs/apps/dspace.md`).
- Add focused tests that assert the new narrow evidence validation and that both render and upgrade invocations include the explicit pull-policy `Always`, and a just-recipe guard test (`tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`).

Exact separately-authorized recovery command (do not run without approval):

`just dspace-prod-metrics-pull-policy-recover \`
`  failed_evidence="$PRESERVED_FAILED_RECONCILIATION_EVIDENCE" \`
`  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \`
`  evidence="$FRESH_NONEXISTING_RECOVERY_EVIDENCE" \`
`  smoke_runner="$DSPACE_SMOKE_RUNNER" \`
`  kubeconfig="$HOME/.kube/config-sugarkube-prod" \`
`  confirm="dspace:prod:recover-pull-policy:revision-10-to-11"

### Testing

- Ran the focused test suite and repository checks: `pytest -q tests/test_manifest_rollback.py tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py` and full project tests behaved as in CI (local run showed the targeted tests pass and larger suite passed in this environment). 
- Verified Python compile and manifest validation with `python3 -m compileall -q scripts` and `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json --final` (both succeeded).
- Verified `python3 scripts/app_config.py json --app dspace --env prod >/dev/null`, `git diff --check`, and `git diff --exit-code HEAD -- deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json docs/apps/dspace.prod.tag docs/apps/dspace.prod-metrics-chart-target.json` to ensure historical identity files were not modified (all passed).
- Linted and docs checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` ran in the environment (linkcheck/spellcheck completed), and targeted `pre-commit` hooks for the changed files passed; repository-wide `pre-commit run --all-files` surfaced unrelated pre-existing style issues which were not introduced by this change and were preserved/restored as part of formatting steps.

Files changed: `scripts/dspace_manifest_rollback.py`, `justfile`, `docs/apps/dspace.md`, `tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`.

Safety invariants preserved: the original failed evidence is never modified; `verify_helm_stored_values()` remains strict; no chart/image coordinates or provenance were changed or republished; the recovery flow is separately gated, audited, and requires explicit confirmation and an absolute production kubeconfig before any mutation.

If you want, I can open the PR on GitHub if you provide an authenticated `gh` session or review the diffs for an immediate code review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e17e77d84832fac54f8c92f89fafc)