### PR TITLE
Fix DSPACE image.pullPolicy handling and add one‑time guarded recovery for revision‑10 incident

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -246,6 +246,33 @@ and reviewers accept the bounded pre/post capture. Otherwise the freeze remains.
 
 ### 5. Failure reconciliation and immutable recovery
 
+#### One-time revision-10 pull-policy recovery
+
+The production metrics reconciliation that created Helm revision 10 is preserved as a failed
+operation. Chart 3.0.3 defaulted `image.pullPolicy` to `IfNotPresent` because the render and upgrade
+commands did not override it, while finalization correctly required the reviewed value `Always`.
+Do not edit or replace that failed evidence and do not rerun `dspace-prod-metrics-reconcile`.
+
+After this fix is merged, a separately authorized operator may run the following command exactly
+once, substituting only the three private absolute paths. This is a narrowly guarded production
+recovery, not a reconciliation retry. It accepts only the preserved ownership/finalization failure,
+revision 10 at chart 3.0.3, and the sole stored-value delta `IfNotPresent`; it then performs one
+digest-qualified upgrade to revision 11 with `Always` and writes a new evidence record.
+
+```bash
+just dspace-prod-metrics-pull-policy-recover \
+  failed_evidence=/absolute/private/path/failed-reconciliation.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
+  evidence=/absolute/private/path/new-pull-policy-recovery.json \
+  smoke_runner=/absolute/path/to/dspace/scripts/run-remote-chat-smoke.mjs \
+  kubeconfig=/absolute/private/path/config-sugarkube-prod \
+  confirm=dspace:prod:recover-revision-10-pull-policy-to-revision-11
+```
+
+The output path must not exist. The helper never retries, rolls back, uninstalls, rotates Secrets,
+or performs a second Helm mutation after failure; its sanitized failed record states the exact stage
+and whether the cluster may have changed. Preserve both records for review.
+
 There is deliberately no fabricated finalized record for the inconsistent pre-change revision 8,
 so it is not a valid rollback target. On any failure, stop, keep the freeze, preserve the reservation
 or redacted failure evidence and bounded post-failure status, and do not immediately mutate again.

--- a/justfile
+++ b/justfile
@@ -1862,6 +1862,34 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
     )
     "${reconciliation_command[@]}"
 
+# One-time, separately authorized repair for the revision-10 DSPACE pull-policy incident.
+dspace-prod-metrics-pull-policy-recover failed_evidence maintenance_target evidence smoke_runner kubeconfig confirm='' verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    strip_named() {
+      local name="$1" value="$2"
+      if [[ "${value}" == "${name}="* ]]; then value="${value#"${name}="}"; fi
+      if [[ -z "${value}" || "${value}" == *=* ]]; then
+        printf 'ERROR: %s must be nonempty and use only its own optional prefix.\n' "${name}" >&2
+        return 2
+      fi
+      printf '%s' "${value}"
+    }
+    failed_path="$(strip_named failed_evidence {{ quote(failed_evidence) }})"
+    target_path="$(strip_named maintenance_target {{ quote(maintenance_target) }})"
+    evidence_path="$(strip_named evidence {{ quote(evidence) }})"
+    smoke_path="$(strip_named smoke_runner {{ quote(smoke_runner) }})"
+    kubeconfig_path="$(strip_named kubeconfig {{ quote(kubeconfig) }})"
+    verifier_path={{ quote(verifier) }}; verifier_path="${verifier_path#verifier=}"
+    confirmation={{ quote(confirm) }}; confirmation="${confirmation#confirm=}"
+    config_path={{ quote(config) }}; config_path="${config_path#config=}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --pull-policy-recovery --environment prod \
+      --failed-evidence "${failed_path}" --maintenance-target "${target_path}" \
+      --evidence "${evidence_path}" --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" --verifier "${verifier_path}" \
+      --confirm "${confirmation}" --config "${config_path}"
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -29,6 +29,11 @@ from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
 OPERATION = "dspaceManifestRollback"
+RECOVERY_OPERATION = "dspaceProductionMetricsPullPolicyRecovery"
+RECOVERY_CONFIRMATION = "dspace:prod:recover-revision-10-pull-policy-to-revision-11"
+PRODUCTION_BASELINE = (
+    REPO_ROOT / "deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json"
+)
 REQUIRED_CAPABILITIES = (
     "applicationVersion",
     "runtimeSourceRevision",
@@ -679,7 +684,9 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
 
 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
-    if getattr(args, "configuration_reconciliation", False):
+    if getattr(args, "configuration_reconciliation", False) or getattr(
+        args, "pull_policy_recovery", False
+    ):
         if not args.kubeconfig or ":" in args.kubeconfig:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
@@ -701,16 +708,65 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     args.manifest = args.manifest.expanduser()
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
+    if getattr(args, "failed_evidence", None):
+        args.failed_evidence = args.failed_evidence.expanduser()
     try:
         baseline = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
     if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
-    configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    recovery = getattr(args, "pull_policy_recovery", False)
+    configuration_reconciliation = getattr(args, "configuration_reconciliation", False) or recovery
     target = baseline
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
         target = chart_maintenance_target(baseline, args.maintenance_target)
+    failed_reconciliation: dict[str, Any] | None = None
+    if recovery:
+        try:
+            failed_reconciliation = release._object(args.failed_evidence)
+        except (OSError, release.ManifestError) as exc:
+            raise RollbackError("preserved failed reconciliation evidence is invalid") from exc
+        expected_failure = {
+            "operation": "dspaceProductionMetricsReconciliation",
+            "state": "failed",
+            "failedStage": "ownership-and-finalization-proof",
+            "clusterMayHaveChanged": True,
+            "environment": "prod",
+            "release": "dspace",
+            "namespace": "dspace",
+        }
+        if any(failed_reconciliation.get(k) != v for k, v in expected_failure.items()):
+            raise RollbackError("failed evidence is not the authorized post-mutation failure")
+        invocation = failed_reconciliation.get("invocationId")
+        if not isinstance(invocation, str) or not re.fullmatch(r"[0-9a-f]{32}", invocation):
+            raise RollbackError("failed evidence is not bound to a valid original invocation")
+        before = failed_reconciliation.get("before")
+        if not isinstance(before, dict) or (
+            before.get("helmRevision"),
+            before.get("chartName"),
+            before.get("chartVersion"),
+        ) != (9, "dspace", "3.0.2"):
+            raise RollbackError("failed evidence does not record the approved revision-9 baseline")
+        target_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
+        expected_target = {
+            key: target[key]
+            for key in (
+                "chartVersion",
+                "chartDigest",
+                "imageTag",
+                "imageDigest",
+                "sourceRevision",
+                "chartSourceRevision",
+                "applicationVersion",
+                "expectedDefaultChatProvider",
+            )
+        }
+        if (
+            failed_reconciliation.get("targetManifestFingerprint") != target_fingerprint
+            or failed_reconciliation.get("target") != expected_target
+        ):
+            raise RollbackError("failed evidence is not bound to the reviewed target")
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -780,6 +836,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
         ]
     )
     before_helm, _before_history, before_identity = helm_snapshot(
@@ -789,7 +847,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != baseline["helmRevision"]:
+        expected_before_revision = 10 if recovery else baseline["helmRevision"]
+        if before_identity[2] != expected_before_revision:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -804,8 +863,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
+        expected_before_chart = target["chartVersion"] if recovery else baseline["chartVersion"]
+        if before_identity[:2] != ("dspace", expected_before_chart):
             raise RollbackError("live chart coordinate differs from finalized provenance")
+        if recovery and before_helm.get("info", {}).get("description") != (
+            "sugarkube-dspace-metrics-reconciliation:" + str(failed_reconciliation["invocationId"])
+        ):
+            raise RollbackError(
+                "live revision is not bound to the failed reconciliation invocation"
+            )
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
         live_values = json_command(
@@ -855,7 +921,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "template",
                 "dspace",
                 release.chart_coordinate(
-                    {
+                    approved
+                    if recovery
+                    else {
                         **approved,
                         "chartVersion": baseline["chartVersion"],
                         "chartDigest": baseline["chartDigest"],
@@ -865,6 +933,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "dspace",
                 "--values",
                 str(current_values_path),
+                "--set-string",
+                "image.pullPolicy=IfNotPresent" if recovery else "image.pullPolicy=Always",
             ]
         )
         if installed_manifest.strip() != approved_current_render.strip():
@@ -878,16 +948,28 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         except release.ManifestError as exc:
             raise RollbackError("desired production metrics contract is invalid") from exc
 
-        live_metrics = live_values.get("metrics")
-        live_monitor = live_values.get("serviceMonitor")
-        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
-            None,
-            {"enabled": False},
-        ):
-            raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
-        if baseline != desired_baseline:
-            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+        if recovery:
+            expected_live_values = copy.deepcopy(desired_values)
+            expected_live_values["image"]["pullPolicy"] = "IfNotPresent"
+            if live_values != expected_live_values:
+                raise RollbackError(
+                    "live Helm values contain drift beyond the sole pull-policy delta"
+                )
+        else:
+            live_metrics = live_values.get("metrics")
+            live_monitor = live_values.get("serviceMonitor")
+            if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
+                None,
+                {"enabled": False},
+            ):
+                raise RollbackError("live metrics values are not the approved disabled baseline")
+            baseline, desired_baseline = configuration_comparison_baselines(
+                live_values, desired_values
+            )
+            if baseline != desired_baseline:
+                raise RollbackError(
+                    "unrelated Helm values drift blocks configuration reconciliation"
+                )
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -963,7 +1045,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
-    confirmation(args.environment, args.confirm, target)
+    if recovery:
+        if args.confirm != RECOVERY_CONFIRMATION:
+            raise RollbackError(f"confirmation must exactly equal {RECOVERY_CONFIRMATION}")
+    else:
+        confirmation(args.environment, args.confirm, target)
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
@@ -976,7 +1062,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "operation": (
-            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+            RECOVERY_OPERATION
+            if recovery
+            else (
+                "dspaceProductionMetricsReconciliation"
+                if configuration_reconciliation
+                else OPERATION
+            )
         ),
         "state": "reserved",
         "invocationId": invocation,
@@ -1010,11 +1102,21 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "ociPreflight": oci,
     }
+    if recovery:
+        evidence["originalFailure"] = {
+            "invocationId": failed_reconciliation["invocationId"],
+            "evidenceFingerprint": hashlib.sha256(args.failed_evidence.read_bytes()).hexdigest(),
+            "failedStage": failed_reconciliation["failedStage"],
+        }
     reserve(args.evidence, evidence)
     mutated = False
     production_target_verified = not configuration_reconciliation
     failed_stage = "pre-mutation-revalidation"
-    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    operation = (
+        "metrics-pull-policy-recovery"
+        if recovery
+        else ("metrics-reconciliation" if configuration_reconciliation else "manifest-rollback")
+    )
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
         if configuration_reconciliation:
@@ -1082,6 +1184,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
             "--wait",
             "--timeout",
             args.timeout,
@@ -1127,6 +1231,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
+        if recovery and after_revision != 11:
+            raise RollbackError("recovery must advance Helm exactly from revision 10 to 11")
         if configuration_reconciliation and after_revision != before_identity[2] + 1:
             raise RollbackError("Helm revision did not advance exactly once")
         if not configuration_reconciliation and after_revision <= before_identity[2]:
@@ -1381,8 +1487,23 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--pull-policy-recovery", action="store_true")
+    parser.add_argument("--failed-evidence", type=Path)
     args = parser.parse_args(argv)
-    if args.configuration_reconciliation:
+    if args.pull_policy_recovery:
+        if (
+            args.configuration_reconciliation
+            or args.manifest is not None
+            or not args.failed_evidence
+        ):
+            parser.error("pull-policy recovery requires --failed-evidence and recovery coordinates")
+        if args.baseline_manifest is not None:
+            parser.error("pull-policy recovery owns its immutable revision-9 baseline")
+        if args.maintenance_target is None or args.environment != "prod":
+            parser.error("pull-policy recovery requires the production maintenance target")
+        args.baseline_manifest = PRODUCTION_BASELINE
+        args.manifest = PRODUCTION_BASELINE
+    elif args.configuration_reconciliation:
         if (
             args.manifest is not None
             or args.baseline_manifest is None
@@ -1399,7 +1520,9 @@ def main(argv: list[str] | None = None) -> int:
         or args.maintenance_target is not None
     ):
         parser.error("rollback requires --manifest and does not accept maintenance coordinates")
-    if args.kubeconfig is None and not args.configuration_reconciliation:
+    if args.kubeconfig is None and not (
+        args.configuration_reconciliation or args.pull_policy_recovery
+    ):
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:
         rollback(args)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3010,6 +3010,47 @@ def _run_dspace_prod_metrics_reconcile(
     return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
 
 
+def _run_dspace_pull_policy_recovery(
+    tmp_path: Path, args: list[str]
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bin_dir = tmp_path / "recovery-bin"
+    bin_dir.mkdir(parents=True)
+    log = tmp_path / "recovery-argv.log"
+    _write_executable(
+        bin_dir / "python3", f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {str(log)!r}\n"
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    result = _run_just(["dspace-prod-metrics-pull-policy-recover", *args], env)
+    return result, log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_pull_policy_recovery_has_separate_fail_closed_argv(tmp_path: Path) -> None:
+    values = {
+        "failed_evidence": "/private/failed.json",
+        "maintenance_target": "docs/apps/dspace.prod-metrics-chart-target.json",
+        "evidence": "/private/new-recovery.json",
+        "smoke_runner": "/opt/dspace/run-remote-chat-smoke.mjs",
+        "kubeconfig": "/private/config-sugarkube-prod",
+    }
+    result, argv = _run_dspace_pull_policy_recovery(
+        tmp_path,
+        [*(f"{key}={value}" for key, value in values.items()),
+         "confirm=dspace:prod:recover-revision-10-pull-policy-to-revision-11"],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--pull-policy-recovery" in argv
+    assert "--configuration-reconciliation" not in argv
+    assert "--baseline-manifest" not in argv
+    for key, value in values.items():
+        option = f"--{key.replace('_', '-')}"
+        assert argv[argv.index(option) + 1] == value
+    assert argv[argv.index("--confirm") + 1] == (
+        "dspace:prod:recover-revision-10-pull-policy-to-revision-11"
+    )
+
+
 @pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_forms(
     tmp_path: Path,

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1499,10 +1499,18 @@ def test_configuration_reconciliation_completes_all_production_gates(
     result = rollback.rollback(args, runner)
 
     upgrade = next(command for command in commands if "upgrade" in command)
+    renders = [command for command in commands if command[0] == "helm" and "template" in command]
+    assert renders
+    assert all(
+        "image.pullPolicy=Always" in command
+        for command in renders
+        if "live-values.json" not in " ".join(command)
+    )
     assert sum("upgrade" in command for command in commands) == 1
     assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
+    assert "image.pullPolicy=Always" in upgrade
     forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
     assert not any(item in upgrade for item in forbidden)
     assert selected["imageDigest"] not in next(


### PR DESCRIPTION
### Motivation

- The production reconciliation failed because the normal render/upgrade omitted an explicit `image.pullPolicy` override and chart 3.0.3 defaulted to `IfNotPresent`, so finalization rightly rejected stored values that expect `Always`.
- The repo must not weaken the stored-values contract or rewrite the original failed evidence, but it needs a narrowly scoped, operator‑authorized recovery path for that exact post‑mutation failure.

### Description

- Explicitly pass the approved `image.pullPolicy=Always` to all relevant Helm/`helm template` and `helm upgrade` invocation sites so rendered target, desired-value comparison, upgrade, and post-upgrade verification remain aligned (`scripts/dspace_manifest_rollback.py`).
- Add a one‑time, fail‑closed recovery operation that accepts preserved failed reconciliation evidence and performs a single digest‑qualified upgrade (revision 10 → 11) with `image.pullPolicy=Always`; the operation is guarded by `--pull-policy-recovery`, `--failed-evidence`, a strict confirmation string, and production-only preflight checks (`scripts/dspace_manifest_rollback.py`).
- Recovery preflight enforces the original failure characteristics (operation, failed state/stage, bound invocation id, recorded before state revision 9/chart 3.0.2, live revision 10/chart 3.0.3, exactly two Ready pods with the immutable approved tag/digest, and that the only stored-value delta is `image.pullPolicy`=`IfNotPresent`).
- Recovery writes a new private recovery evidence record that links to the immutable original failure using non‑secret identifiers and fingerprint; it never edits the original failed evidence and never retries/rolls back/rotates secrets on failure; diagnostics are sanitized; and the recovery command is exposed as a dedicated `just` recipe (`just dspace-prod-metrics-pull-policy-recover`) and documented in `docs/apps/dspace.md`.
- Small test and recipe updates to assert the explicit `--set image.pullPolicy=Always` presence in template and upgrade argv and to validate the new just recipe argv behavior (`tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`).
- Files changed: `scripts/dspace_manifest_rollback.py`, `justfile`, `docs/apps/dspace.md`, `tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`.

### Testing

- Ran focused pytest suites: `pytest -q tests/test_manifest_rollback.py tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_verifier.py tests/test_dspace_runtime_values.py`, and the test suites passed (all tests in run green after small test ordering fix).
- Compiled scripts: `python3 -m compileall -q scripts` succeeded and `python3 scripts/dspace_release_manifest.py validate --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json --final` succeeded.
- Verified `python3 scripts/app_config.py json --app dspace --env prod >/dev/null`, `git diff --check`, `git diff --cached | ./scripts/scan-secrets.py`, and `git diff --exit-code HEAD -- deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json docs/apps/dspace.prod.tag docs/apps/dspace.prod-metrics-chart-target.json` all reported clean state.
- Repo tooling not available in this environment: `pre-commit run --all-files`, `pyspelling`, and `linkchecker` were not executed due to missing commands; no live cluster access or mutation was performed.

Summary of root cause and safety invariants: the failure was caused by computed Helm defaults (chart 3.0.3) producing `image.pullPolicy=IfNotPresent` when the verifier and stored‑value contract require `Always`; the patch forces the approved override in every render/upgrade path, preserves the original failed evidence as immutable, and implements a one‑time, operator‑authorized, fail‑closed recovery that only advances revision 10→11 for the exact reviewed chart/image tuple and only if all strict pre/post checks pass.

Exact separately authorized post-merge command (do not run as a normal reconciliation; substitute private absolute paths):

```bash
just dspace-prod-metrics-pull-policy-recover \
  failed_evidence=/absolute/private/path/failed-reconciliation.json \
  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
  evidence=/absolute/private/path/new-pull-policy-recovery.json \
  smoke_runner=/absolute/path/to/dspace/scripts/run-remote-chat-smoke.mjs \
  kubeconfig=/absolute/private/path/config-sugarkube-prod \
  confirm=dspace:prod:recover-revision-10-pull-policy-to-revision-11
```

This PR implements the strict fix and the narrowly guarded recovery path; it adds regression tests to prevent recurrence and documents the one-time operator command and runbook guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e17f26150832f847ce1d020502d21)