### PR TITLE
dspace: enforce image.pullPolicy=Always in reconciliation and add guarded recovery for revision-10 pull-policy incident

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -32,6 +32,32 @@ just dspace-prod-metrics-reconcile \
   confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
 ```
 
+### One-time production pull-policy recovery
+
+The failed revision-10 reconciliation evidence is immutable and remains failed. After this change is
+merged, a separately authorized operator may repair only the reviewed incident state: revision 10,
+chart 3.0.3, and complete approved values with the sole delta
+`image.pullPolicy=IfNotPresent`. This is **not** a rerun of
+`dspace-prod-metrics-reconcile`. The command fails closed on any other revision, chart, invocation,
+pod, image, Secret contract, provenance, or values state; it performs at most one digest-qualified
+upgrade to revision 11 and writes a new private evidence record.
+
+Do not run this during development. Following explicit production authorization, use exactly:
+
+```bash
+just dspace-prod-metrics-pull-policy-recover \
+  failed_evidence=/private/evidence/dspace-prod-metrics-failed.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
+  recovery_evidence=/private/evidence/dspace-prod-metrics-pull-policy-recovery.json \
+  smoke_runner="$HOME/dspace/scripts/run-remote-chat-smoke.mjs" \
+  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
+  confirm=dspace:prod:recover-revision-10-pull-policy
+```
+
+The failed and recovery evidence paths must be private; the recovery destination must not exist.
+Never retry, roll back, uninstall, rotate Secrets, or issue a second Helm mutation automatically if
+the recovery fails. Preserve its failed-stage evidence and investigate the sanitized diagnostics.
+
 The command uses only the exact digest-qualified 3.0.3 OCI chart, the complete committed production
 values chain, and an invocation-bound opaque Helm description; it never uses `--reuse-values`.
 Afterward it proves replacement Ready pods retain the exact image digest, runs strict runtime,

--- a/justfile
+++ b/justfile
@@ -1862,6 +1862,34 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
     )
     "${reconciliation_command[@]}"
 
+# One-time, separately authorized repair of the revision-10 DSPACE pull policy incident.
+dspace-prod-metrics-pull-policy-recover failed_evidence maintenance_target recovery_evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    failed_path={{ quote(failed_evidence) }}
+    target_path={{ quote(maintenance_target) }}
+    output_path={{ quote(recovery_evidence) }}
+    smoke_path={{ quote(smoke_runner) }}
+    kubeconfig_path={{ quote(kubeconfig) }}
+    verifier_path={{ quote(verifier) }}
+    confirmation={{ quote(confirm) }}
+    config_path={{ quote(config) }}
+    for variable in failed_path target_path output_path smoke_path kubeconfig_path; do
+      value="${!variable}"
+      while [[ "${value}" == *=* ]]; do value="${value#*=}"; done
+      [ -n "${value}" ] || { echo "ERROR: ${variable} must not be empty." >&2; exit 2; }
+      printf -v "${variable}" '%s' "${value}"
+    done
+    while [[ "${verifier_path}" == verifier=* ]]; do verifier_path="${verifier_path#verifier=}"; done
+    while [[ "${confirmation}" == confirm=* ]]; do confirmation="${confirmation#confirm=}"; done
+    while [[ "${config_path}" == config=* ]]; do config_path="${config_path#config=}"; done
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --production-metrics-recovery --environment prod \
+      --failed-evidence "${failed_path}" --maintenance-target "${target_path}" \
+      --evidence "${output_path}" --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" --verifier "${verifier_path}" \
+      --confirm "${confirmation}" --config "${config_path}"
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -1876,13 +1876,19 @@ dspace-prod-metrics-pull-policy-recover failed_evidence maintenance_target recov
     config_path={{ quote(config) }}
     for variable in failed_path target_path output_path smoke_path kubeconfig_path; do
       value="${!variable}"
-      while [[ "${value}" == *=* ]]; do value="${value#*=}"; done
+      case "${variable}:${value}" in
+        failed_path:failed_evidence=*) value="${value#failed_evidence=}" ;;
+        target_path:maintenance_target=*) value="${value#maintenance_target=}" ;;
+        output_path:recovery_evidence=*) value="${value#recovery_evidence=}" ;;
+        smoke_path:smoke_runner=*) value="${value#smoke_runner=}" ;;
+        kubeconfig_path:kubeconfig=*) value="${value#kubeconfig=}" ;;
+      esac
       [ -n "${value}" ] || { echo "ERROR: ${variable} must not be empty." >&2; exit 2; }
       printf -v "${variable}" '%s' "${value}"
     done
-    while [[ "${verifier_path}" == verifier=* ]]; do verifier_path="${verifier_path#verifier=}"; done
-    while [[ "${confirmation}" == confirm=* ]]; do confirmation="${confirmation#confirm=}"; done
-    while [[ "${config_path}" == config=* ]]; do config_path="${config_path#config=}"; done
+    [[ "${verifier_path}" != verifier=* ]] || verifier_path="${verifier_path#verifier=}"
+    [[ "${confirmation}" != confirm=* ]] || confirmation="${confirmation#confirm=}"
+    [[ "${config_path}" != config=* ]] || config_path="${config_path#config=}"
     python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
       --production-metrics-recovery --environment prod \
       --failed-evidence "${failed_path}" --maintenance-target "${target_path}" \

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -800,6 +800,11 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
     recovery = getattr(args, "production_metrics_recovery", False)
     args.evidence = args.evidence.expanduser()
+    # These attributes cross the pre-reservation boundary deliberately: the
+    # outer lifecycle is responsible for preserving failures until an evidence
+    # file has been reserved, while _rollback owns the reserved lifecycle.
+    args._recovery_failed_stage = "kubeconfig-and-cluster-identity"
+    args._recovery_original_failure = None
     try:
         if getattr(args, "configuration_reconciliation", False):
             if not args.kubeconfig or ":" in args.kubeconfig:
@@ -821,16 +826,19 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
         # Preserve every pre-reservation recovery rejection. An existing path is
         # deliberately left byte-for-byte untouched.
         if recovery and not args.evidence.exists():
+            failed_stage = args._recovery_failed_stage
             failure = {
                 "schemaVersion": SCHEMA_VERSION,
                 "operation": RECOVERY_OPERATION,
                 "state": "failed",
-                "failedStage": "recovery-preflight",
-                "failureCode": "recovery-preflight-failed",
+                "failedStage": failed_stage,
+                "failureCode": f"{failed_stage}-failed",
                 "failedAt": timestamp(),
                 "clusterMayHaveChanged": False,
                 "diagnostics": {"failureType": type(exc).__name__},
             }
+            if args._recovery_original_failure is not None:
+                failure["originalFailure"] = args._recovery_original_failure
             reserve(args.evidence, failure)
         raise
 
@@ -840,6 +848,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     args.manifest = args.manifest.expanduser()
     args.evidence = args.evidence.expanduser()
     args.verifier = args.verifier.expanduser()
+    if getattr(args, "production_metrics_recovery", False):
+        args._recovery_failed_stage = "failed-evidence-authorization"
     try:
         baseline = release.validate(release._object(args.manifest), True)
     except release.ManifestError as exc:
@@ -852,6 +862,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
         target = chart_maintenance_target(baseline, args.maintenance_target)
     failed = failed_reconciliation(args.failed_evidence, target) if recovery else None
+    if recovery:
+        args._recovery_original_failure = {
+            "invocationId": failed["invocationId"],
+            "targetManifestFingerprint": failed["targetManifestFingerprint"],
+        }
+        args._recovery_failed_stage = "live-state-and-provenance"
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -1089,6 +1105,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             # Prove the complete incident state, including both public journeys,
             # bounded remote chat, replica/ownership identity and revision 10,
             # before asking for authorization or reserving/mutating anything.
+            args._recovery_failed_stage = "runtime-and-metrics-preflight"
             validate_verifier_result(
                 json_command(
                     runner,
@@ -1145,6 +1162,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         )
     except release.ManifestError as exc:
         raise RollbackError("OCI preflight validation failed") from exc
+    if recovery:
+        args._recovery_failed_stage = "live-state-and-provenance"
     print(summary(before_helm, before_identity, before_pods, target, values_proof))
     current_images = {application_image(pod) for pod in before_pods if application_image(pod)}
     current_ids: set[str] = set()
@@ -1205,6 +1224,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
+    if recovery:
+        args._recovery_failed_stage = "confirmation"
     (
         recovery_confirmation(args.confirm)
         if recovery
@@ -1267,6 +1288,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "invocationId": failed["invocationId"],
             "targetManifestFingerprint": failed["targetManifestFingerprint"],
         }
+    if recovery:
+        args._recovery_failed_stage = "reservation"
     reserve(args.evidence, evidence)
     mutated = False
     production_target_verified = not configuration_reconciliation

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -1149,6 +1149,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 )
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
+    if recovery:
+        args._recovery_failed_stage = "immutable-oci-provenance"
     try:
         oci = release.preflight(
             approved,
@@ -1334,6 +1336,26 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             )
             if current_values != live_values:
                 raise RollbackError("Helm values changed before mutation")
+            if recovery:
+                current_computed_values = json_command(
+                    runner,
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "get",
+                        "values",
+                        "dspace",
+                        "--namespace",
+                        "dspace",
+                        "--all",
+                        "-o",
+                        "json",
+                    ],
+                    "Helm computed values",
+                )
+                if current_computed_values != computed_values:
+                    raise RollbackError("Helm computed values changed before mutation")
             runner(
                 [
                     "env",

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -66,6 +66,31 @@ PRODUCTION_BASELINE = (
 )
 RECOVERY_OPERATION = "dspaceProductionMetricsPullPolicyRecovery"
 RECOVERY_CONFIRMATION = "dspace:prod:recover-revision-10-pull-policy"
+FAILED_RECONCILIATION_FIELDS = (
+    "schemaVersion",
+    "operation",
+    "state",
+    "failedStage",
+    "failureCode",
+    "clusterMayHaveChanged",
+    "invocationId",
+    "targetManifestFingerprint",
+    "environment",
+    "release",
+    "namespace",
+    "before",
+    "target",
+)
+RECORDED_TARGET_FIELDS = (
+    "chartVersion",
+    "chartDigest",
+    "imageTag",
+    "imageDigest",
+    "sourceRevision",
+    "chartSourceRevision",
+    "applicationVersion",
+    "expectedDefaultChatProvider",
+)
 
 
 class RollbackError(ValueError):
@@ -524,14 +549,61 @@ def recovery_confirmation(supplied: str) -> None:
         raise RollbackError(f"recovery confirmation must exactly equal {RECOVERY_CONFIRMATION}")
 
 
+def runtime_verifier_command(
+    args: argparse.Namespace,
+    target: dict[str, Any],
+    manifest: Path,
+    *,
+    expected_revision: int | None = None,
+) -> list[str]:
+    """Build the repository verifier invocation used on both sides of mutation."""
+    command = [
+        str(args.verifier),
+        "verify",
+        "--environment",
+        args.environment,
+        "--release",
+        "dspace",
+        "--namespace",
+        "dspace",
+        "--application-version",
+        target["applicationVersion"],
+        "--source-revision",
+        target["sourceRevision"],
+        "--provider",
+        target["expectedDefaultChatProvider"],
+        "--manifest",
+        str(manifest),
+        "--smoke-runner",
+        str(args.smoke_runner),
+        "--kubeconfig",
+        str(args.kubeconfig),
+    ]
+    if args.config:
+        command.extend(("--config", str(args.config)))
+    if expected_revision is not None:
+        command.extend(("--expected-helm-revision", str(expected_revision)))
+    return command
+
+
 def failed_reconciliation(path: Path, target: dict[str, Any]) -> dict[str, Any]:
     """Validate the immutable failure that alone authorizes the revision-10 repair."""
     try:
         value = release._object(path.expanduser())
     except release.ManifestError as exc:
         raise RollbackError("preserved failed reconciliation evidence is unreadable") from exc
+    # Failure records may also contain the normal immutable lifecycle metadata,
+    # but every incident-authorizing field is mandatory.  In particular, do not
+    # use ``get``-based projections which silently ignore missing target fields.
+    missing = sorted(set(FAILED_RECONCILIATION_FIELDS) - value.keys())
+    if missing:
+        raise RollbackError("preserved failed reconciliation evidence schema is incomplete")
     if (
-        value.get("operation") != "dspaceProductionMetricsReconciliation"
+        value.get("schemaVersion") != SCHEMA_VERSION
+        or value.get("environment") != "prod"
+        or value.get("release") != "dspace"
+        or value.get("namespace") != "dspace"
+        or value.get("operation") != "dspaceProductionMetricsReconciliation"
         or value.get("state") != "failed"
         or value.get("failedStage") != "ownership-and-finalization-proof"
         or value.get("failureCode") != "ownership-and-finalization-proof-failed"
@@ -555,19 +627,8 @@ def failed_reconciliation(path: Path, target: dict[str, Any]) -> dict[str, Any]:
     ) != (9, "dspace", "3.0.2"):
         raise RollbackError("failed reconciliation before state is not revision 9/chart 3.0.2")
     recorded_target = value.get("target")
-    required = (
-        "applicationVersion",
-        "sourceRevision",
-        "imageTag",
-        "imageDigest",
-        "chartSourceRevision",
-        "chartVersion",
-        "chartDigest",
-        "expectedDefaultChatProvider",
-    )
-    if not isinstance(recorded_target, dict) or any(
-        recorded_target.get(field) != target.get(field) for field in required
-    ):
+    expected_target = {field: target[field] for field in RECORDED_TARGET_FIELDS}
+    if recorded_target != expected_target:
         raise RollbackError("failed reconciliation target differs from the reviewed target")
     return value
 
@@ -737,41 +798,41 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
 
 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
-    if getattr(args, "configuration_reconciliation", False):
-        if not args.kubeconfig or ":" in args.kubeconfig:
-            raise RollbackError(
-                "metrics configuration reconciliation requires one explicit absolute kubeconfig"
-            )
-        kubeconfig = Path(args.kubeconfig).expanduser()
-        if not kubeconfig.is_absolute():
-            raise RollbackError(
-                "metrics configuration reconciliation requires one explicit absolute kubeconfig"
-            )
-        args.kubeconfig = str(kubeconfig)
-    with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
-        os.chmod(temporary, 0o700)
-        try:
+    recovery = getattr(args, "production_metrics_recovery", False)
+    args.evidence = args.evidence.expanduser()
+    try:
+        if getattr(args, "configuration_reconciliation", False):
+            if not args.kubeconfig or ":" in args.kubeconfig:
+                raise RollbackError(
+                    "metrics configuration reconciliation requires one explicit absolute kubeconfig"
+                )
+            kubeconfig = Path(args.kubeconfig).expanduser()
+            if not kubeconfig.is_absolute():
+                raise RollbackError(
+                    "metrics configuration reconciliation requires one explicit absolute kubeconfig"
+                )
+            args.kubeconfig = str(kubeconfig)
+        with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
+            os.chmod(temporary, 0o700)
             if getattr(args, "configuration_reconciliation", False):
                 assert_production_target(args.kubeconfig, runner)
             return _rollback(args, runner, Path(temporary))
-        except Exception:
-            # Recovery has its own evidence lifecycle. Preserve even a pre-mutation
-            # rejection, but never overwrite an existing reservation/final record.
-            if getattr(args, "production_metrics_recovery", False) and not args.evidence.exists():
-                reserve(
-                    args.evidence,
-                    {
-                        "schemaVersion": SCHEMA_VERSION,
-                        "operation": RECOVERY_OPERATION,
-                        "state": "failed",
-                        "failedStage": "recovery-preflight",
-                        "failureCode": "recovery-preflight-failed",
-                        "failedAt": timestamp(),
-                        "clusterMayHaveChanged": False,
-                        "diagnostics": {},
-                    },
-                )
-            raise
+    except Exception as exc:
+        # Preserve every pre-reservation recovery rejection. An existing path is
+        # deliberately left byte-for-byte untouched.
+        if recovery and not args.evidence.exists():
+            failure = {
+                "schemaVersion": SCHEMA_VERSION,
+                "operation": RECOVERY_OPERATION,
+                "state": "failed",
+                "failedStage": "recovery-preflight",
+                "failureCode": "recovery-preflight-failed",
+                "failedAt": timestamp(),
+                "clusterMayHaveChanged": False,
+                "diagnostics": {"failureType": type(exc).__name__},
+            }
+            reserve(args.evidence, failure)
+        raise
 
 
 def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) -> dict[str, Any]:
@@ -817,6 +878,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     bundled_verifier = (
         args.verifier.resolve() == (REPO_ROOT / "scripts/dspace_runtime_verifier.py").resolve()
     )
+    if recovery and not bundled_verifier:
+        raise RollbackError("recovery requires the repository runtime verifier")
     if bundled_verifier:
         configured_smoke = getattr(args, "smoke_runner", None) or os.environ.get(
             "DSPACE_SMOKE_RUNNER", ""
@@ -995,20 +1058,63 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 ],
                 "Helm computed values",
             )
-            computed_image = computed_values.get("image")
-            if (
-                not isinstance(computed_image, dict)
-                or computed_image.get("pullPolicy") != "IfNotPresent"
-            ):
+            defaults_path = staged_directory / "chart-defaults.yaml"
+            defaults_path.write_text(
+                runner(["helm", "show", "values", coordinate]), encoding="utf-8"
+            )
+            os.chmod(defaults_path, 0o600)
+            expected_computed = app_chart.merged_values_document(
+                (str(defaults_path), *(str(path) for path in values))
+            )
+            if not isinstance(expected_computed, dict):
+                raise RollbackError("chart defaults produced invalid computed values")
+            expected_image_values = expected_computed.get("image")
+            if not isinstance(expected_image_values, dict):
+                raise RollbackError("chart defaults do not define image values")
+            expected_image_values.update(
+                repository=release.IMAGE_REF,
+                tag=target["imageTag"],
+                pullPolicy="IfNotPresent",
+            )
+            if computed_values != expected_computed:
                 raise RollbackError(
-                    "live computed pull policy is not the recoverable chart default"
+                    "live computed values differ from the exact recoverable chart defaults"
                 )
-            strict_computed = copy.deepcopy(computed_values)
+            strict_computed = copy.deepcopy(expected_computed)
             strict_computed["image"]["pullPolicy"] = "Always"
             try:
                 release.verify_helm_stored_values(approved, strict_computed, "prod")
             except release.ManifestError as exc:
                 raise RollbackError("live computed values violate the approved contract") from exc
+            # Prove the complete incident state, including both public journeys,
+            # bounded remote chat, replica/ownership identity and revision 10,
+            # before asking for authorization or reserving/mutating anything.
+            validate_verifier_result(
+                json_command(
+                    runner,
+                    runtime_verifier_command(
+                        args, target, verifier_manifest, expected_revision=10
+                    ),
+                    "recovery runtime preflight",
+                ),
+                target,
+                "prod",
+            )
+            # This repository verifier owns the Secret, ServiceMonitor, exactly
+            # two healthy targets, metric-family, and Grafana API contract.
+            runner(
+                [
+                    "env",
+                    f"KUBECONFIG={args.kubeconfig}",
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "observability_app_metrics.py"),
+                    "verify",
+                    "--app",
+                    "dspace",
+                    "--env",
+                    "prod",
+                ]
+            )
         else:
             live_metrics = live_values.get("metrics")
             live_monitor = live_values.get("serviceMonitor")
@@ -1361,6 +1467,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "Helm stored values",
             )
             try:
+                if recovery and stored_values != strict_computed:
+                    raise RollbackError(
+                        "post-upgrade computed values differ from the exact approved document"
+                    )
                 helm_stored_values_result = release.verify_helm_stored_values(
                     approved, stored_values, args.environment
                 )
@@ -1384,20 +1494,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             helm_history=after_history,
         )
         verifier_command = [
-            str(args.verifier),
-            "verify",
-            "--environment",
-            args.environment,
-            "--release",
-            "dspace",
-            "--namespace",
-            "dspace",
-            "--application-version",
-            target["applicationVersion"],
-            "--source-revision",
-            target["sourceRevision"],
-            "--provider",
-            target["expectedDefaultChatProvider"],
+            str(args.verifier), "verify", "--environment", args.environment,
+            "--release", "dspace", "--namespace", "dspace",
+            "--application-version", target["applicationVersion"],
+            "--source-revision", target["sourceRevision"],
+            "--provider", target["expectedDefaultChatProvider"],
         ]
         # The repository verifier owns these extended arguments.  Preserve the
         # original verify contract for compatible third-party verifiers rather
@@ -1410,6 +1511,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             verifier_command.extend(("--kubeconfig", str(args.kubeconfig)))
             if args.config:
                 verifier_command.extend(("--config", str(args.config)))
+            if recovery:
+                verifier_command.extend(("--expected-helm-revision", "11"))
         failed_stage = "runtime-verification"
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -61,6 +61,11 @@ MAINTENANCE_TARGET_FIELDS = (
     "chartVersion",
     "chartDigest",
 )
+PRODUCTION_BASELINE = (
+    REPO_ROOT / "deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json"
+)
+RECOVERY_OPERATION = "dspaceProductionMetricsPullPolicyRecovery"
+RECOVERY_CONFIRMATION = "dspace:prod:recover-revision-10-pull-policy"
 
 
 class RollbackError(ValueError):
@@ -514,6 +519,59 @@ def confirmation(environment: str, supplied: str, target: dict[str, Any]) -> Non
         raise RollbackError(f"production confirmation must exactly equal {expected}")
 
 
+def recovery_confirmation(supplied: str) -> None:
+    if supplied != RECOVERY_CONFIRMATION:
+        raise RollbackError(f"recovery confirmation must exactly equal {RECOVERY_CONFIRMATION}")
+
+
+def failed_reconciliation(path: Path, target: dict[str, Any]) -> dict[str, Any]:
+    """Validate the immutable failure that alone authorizes the revision-10 repair."""
+    try:
+        value = release._object(path.expanduser())
+    except release.ManifestError as exc:
+        raise RollbackError("preserved failed reconciliation evidence is unreadable") from exc
+    if (
+        value.get("operation") != "dspaceProductionMetricsReconciliation"
+        or value.get("state") != "failed"
+        or value.get("failedStage") != "ownership-and-finalization-proof"
+        or value.get("failureCode") != "ownership-and-finalization-proof-failed"
+        or value.get("clusterMayHaveChanged") is not True
+    ):
+        raise RollbackError("preserved evidence is not the authorized failed reconciliation")
+    invocation = value.get("invocationId")
+    fingerprint = value.get("targetManifestFingerprint")
+    if not isinstance(invocation, str) or not re.fullmatch(r"[0-9a-f]{32}", invocation):
+        raise RollbackError("failed reconciliation invocation binding is invalid")
+    if not isinstance(fingerprint, str) or not re.fullmatch(r"[0-9a-f]{64}", fingerprint):
+        raise RollbackError("failed reconciliation target binding is invalid")
+    expected_fingerprint = hashlib.sha256(release._canonical(target).encode()).hexdigest()
+    if fingerprint != expected_fingerprint:
+        raise RollbackError("failed reconciliation is not bound to the reviewed target")
+    before = value.get("before")
+    if not isinstance(before, dict) or (
+        before.get("helmRevision"),
+        before.get("chartName"),
+        before.get("chartVersion"),
+    ) != (9, "dspace", "3.0.2"):
+        raise RollbackError("failed reconciliation before state is not revision 9/chart 3.0.2")
+    recorded_target = value.get("target")
+    required = (
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartSourceRevision",
+        "chartVersion",
+        "chartDigest",
+        "expectedDefaultChatProvider",
+    )
+    if not isinstance(recorded_target, dict) or any(
+        recorded_target.get(field) != target.get(field) for field in required
+    ):
+        raise RollbackError("failed reconciliation target differs from the reviewed target")
+    return value
+
+
 def reserve(path: Path, metadata: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
@@ -693,7 +751,26 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
         args.kubeconfig = str(kubeconfig)
     with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
         os.chmod(temporary, 0o700)
-        return _rollback(args, runner, Path(temporary))
+        try:
+            return _rollback(args, runner, Path(temporary))
+        except Exception:
+            # Recovery has its own evidence lifecycle. Preserve even a pre-mutation
+            # rejection, but never overwrite an existing reservation/final record.
+            if getattr(args, "production_metrics_recovery", False) and not args.evidence.exists():
+                reserve(
+                    args.evidence,
+                    {
+                        "schemaVersion": SCHEMA_VERSION,
+                        "operation": RECOVERY_OPERATION,
+                        "state": "failed",
+                        "failedStage": "recovery-preflight",
+                        "failureCode": "recovery-preflight-failed",
+                        "failedAt": timestamp(),
+                        "clusterMayHaveChanged": False,
+                        "diagnostics": {},
+                    },
+                )
+            raise
 
 
 def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) -> dict[str, Any]:
@@ -708,9 +785,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    recovery = getattr(args, "production_metrics_recovery", False)
     target = baseline
     if configuration_reconciliation and getattr(args, "maintenance_target", None):
         target = chart_maintenance_target(baseline, args.maintenance_target)
+    failed = failed_reconciliation(args.failed_evidence, target) if recovery else None
     image_value = target["imageTag"]
     if not configuration_reconciliation:
         image_value += f"@{target['imageDigest']}"
@@ -780,6 +859,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
         ]
     )
     before_helm, _before_history, before_identity = helm_snapshot(
@@ -789,8 +870,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if configuration_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != baseline["helmRevision"]:
-            raise RollbackError("live Helm revision differs from finalized provenance")
+        expected_before_revision = 10 if recovery else baseline["helmRevision"]
+        expected_before_chart = target["chartVersion"] if recovery else baseline["chartVersion"]
+        if before_identity[2] != expected_before_revision:
+            raise RollbackError("live Helm revision differs from authorized provenance")
         runner(
             [
                 "env",
@@ -804,8 +887,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
+        if before_identity[:2] != ("dspace", expected_before_chart):
             raise RollbackError("live chart coordinate differs from finalized provenance")
+        if recovery and before_helm.get("info", {}).get("description") != (
+            f"sugarkube-dspace-metrics-reconciliation:{failed['invocationId']}"
+        ):
+            raise RollbackError("revision 10 is not bound to the failed invocation")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
         live_values = json_command(
@@ -857,8 +944,12 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 release.chart_coordinate(
                     {
                         **approved,
-                        "chartVersion": baseline["chartVersion"],
-                        "chartDigest": baseline["chartDigest"],
+                        "chartVersion": (
+                            target["chartVersion"] if recovery else baseline["chartVersion"]
+                        ),
+                        "chartDigest": (
+                            target["chartDigest"] if recovery else baseline["chartDigest"]
+                        ),
                     }
                 ),
                 "--namespace",
@@ -878,16 +969,59 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         except release.ManifestError as exc:
             raise RollbackError("desired production metrics contract is invalid") from exc
 
-        live_metrics = live_values.get("metrics")
-        live_monitor = live_values.get("serviceMonitor")
-        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
-            None,
-            {"enabled": False},
-        ):
-            raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
-        if baseline != desired_baseline:
-            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+        if recovery:
+            recovery_values = copy.deepcopy(desired_values)
+            recovery_values["image"].pop("pullPolicy")
+            if live_values != recovery_values:
+                raise RollbackError(
+                    "live values have drift beyond the sole recoverable pull policy"
+                )
+            computed_values = json_command(
+                runner,
+                [
+                    "helm",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "values",
+                    "dspace",
+                    "--namespace",
+                    "dspace",
+                    "--all",
+                    "-o",
+                    "json",
+                ],
+                "Helm computed values",
+            )
+            computed_image = computed_values.get("image")
+            if (
+                not isinstance(computed_image, dict)
+                or computed_image.get("pullPolicy") != "IfNotPresent"
+            ):
+                raise RollbackError(
+                    "live computed pull policy is not the recoverable chart default"
+                )
+            strict_computed = copy.deepcopy(computed_values)
+            strict_computed["image"]["pullPolicy"] = "Always"
+            try:
+                release.verify_helm_stored_values(approved, strict_computed, "prod")
+            except release.ManifestError as exc:
+                raise RollbackError("live computed values violate the approved contract") from exc
+        else:
+            live_metrics = live_values.get("metrics")
+            live_monitor = live_values.get("serviceMonitor")
+            if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
+                None,
+                {"enabled": False},
+            ):
+                raise RollbackError("live metrics values are not the approved disabled baseline")
+            baseline_values, desired_baseline = configuration_comparison_baselines(
+                live_values, desired_values
+            )
+            if baseline_values != desired_baseline:
+                raise RollbackError(
+                    "unrelated Helm values drift blocks configuration reconciliation"
+                )
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -963,7 +1097,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("strict application chart render validation failed")
     # Matching chart version and image identity alone is not exact proof: Helm
     # status cannot establish the installed OCI chart digest.
-    confirmation(args.environment, args.confirm, target)
+    (
+        recovery_confirmation(args.confirm)
+        if recovery
+        else confirmation(args.environment, args.confirm, target)
+    )
     sugarkube_revision = runner(["git", "rev-parse", "HEAD"]).strip()
     if not re.fullmatch(r"[0-9a-f]{40}", sugarkube_revision):
         raise RollbackError("could not capture the Sugarkube revision")
@@ -976,7 +1114,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "operation": (
-            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+            RECOVERY_OPERATION
+            if recovery
+            else (
+                "dspaceProductionMetricsReconciliation"
+                if configuration_reconciliation
+                else OPERATION
+            )
         ),
         "state": "reserved",
         "invocationId": invocation,
@@ -1010,11 +1154,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "ociPreflight": oci,
     }
+    if recovery:
+        evidence["originalFailure"] = {
+            "invocationId": failed["invocationId"],
+            "targetManifestFingerprint": failed["targetManifestFingerprint"],
+        }
     reserve(args.evidence, evidence)
     mutated = False
     production_target_verified = not configuration_reconciliation
     failed_stage = "pre-mutation-revalidation"
-    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    operation = (
+        "metrics-pull-policy-recovery"
+        if recovery
+        else ("metrics-reconciliation" if configuration_reconciliation else "manifest-rollback")
+    )
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
         if configuration_reconciliation:
@@ -1082,6 +1235,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
             "--wait",
             "--timeout",
             args.timeout,
@@ -1381,7 +1536,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--production-metrics-recovery", action="store_true")
+    parser.add_argument("--failed-evidence", type=Path)
     args = parser.parse_args(argv)
+    if args.production_metrics_recovery:
+        if (
+            args.configuration_reconciliation
+            or args.manifest is not None
+            or args.baseline_manifest is not None
+        ):
+            parser.error(
+                "production metrics recovery does not accept reconciliation or manifest flags"
+            )
+        if args.failed_evidence is None or args.maintenance_target is None:
+            parser.error(
+                "production metrics recovery requires --failed-evidence and --maintenance-target"
+            )
+        args.configuration_reconciliation = True
+        args.baseline_manifest = PRODUCTION_BASELINE
     if args.configuration_reconciliation:
         if (
             args.manifest is not None

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -747,11 +747,12 @@ def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
             )
-        assert_production_target(str(kubeconfig), runner)
         args.kubeconfig = str(kubeconfig)
     with tempfile.TemporaryDirectory(prefix="dspace-rollback-values-") as temporary:
         os.chmod(temporary, 0o700)
         try:
+            if getattr(args, "configuration_reconciliation", False):
+                assert_production_target(args.kubeconfig, runner)
             return _rollback(args, runner, Path(temporary))
         except Exception:
             # Recovery has its own evidence lifecycle. Preserve even a pre-mutation
@@ -888,7 +889,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             ]
         )
         if before_identity[:2] != ("dspace", expected_before_chart):
-            raise RollbackError("live chart coordinate differs from finalized provenance")
+            provenance = "authorized live chart" if recovery else "finalized provenance"
+            raise RollbackError(f"live chart coordinate differs from {provenance}")
         if recovery and before_helm.get("info", {}).get("description") != (
             f"sugarkube-dspace-metrics-reconciliation:{failed['invocationId']}"
         ):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3171,6 +3171,47 @@ def test_dspace_recovery_staging_config_uses_production_chart_pin(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_pull_policy_recovery_recipe_forwards_exact_guard_inputs(tmp_path: Path) -> None:
+    inputs = {
+        "failed_evidence": tmp_path / "failed=x.json",
+        "maintenance_target": tmp_path / "reviewed-target.json",
+        "recovery_evidence": tmp_path / "fresh-output.json",
+        "smoke_runner": tmp_path / "remote-smoke",
+        "kubeconfig": tmp_path / "prod-kubeconfig",
+        "verifier": REPO_ROOT / "scripts/dspace_runtime_verifier.py",
+    }
+    confirmation = "dspace:prod:recover-revision-10-pull-policy"
+    result = subprocess.run(
+        [
+            "just",
+            "--dry-run",
+            "dspace-prod-metrics-pull-policy-recover",
+            *(f"{name}={path}" for name, path in inputs.items()),
+            f"confirm={confirmation}",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    # `just --dry-run` writes recipe lines to stderr so their stdout remains
+    # distinguishable from a command's output.
+    rendered = result.stdout + result.stderr
+    assert "--production-metrics-recovery --environment prod" in rendered
+    assert str(inputs["failed_evidence"]) in rendered
+    assert str(inputs["maintenance_target"]) in rendered
+    assert str(inputs["recovery_evidence"]) in rendered
+    assert str(inputs["smoke_runner"]) in rendered
+    assert str(inputs["kubeconfig"]) in rendered
+    assert str(inputs["verifier"]) in rendered
+    assert confirmation in rendered
+    assert "helm upgrade" not in rendered
+    assert "kubectl" not in rendered
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_manifest_rollback_preserves_legacy_positional_verifier(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1966,7 +1966,11 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
 
 
 def recovery_execution_case(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, fail_after_upgrade: bool = False
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_after_upgrade: bool = False,
+    fault: str | None = None,
 ) -> tuple[Namespace, list[list[str]], Path, Path, dict[str, object]]:
     """Build the reviewed revision-10 incident around the real recovery lifecycle."""
     baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
@@ -2013,6 +2017,8 @@ def recovery_execution_case(
     smoke.chmod(0o700)
     values = tmp_path / "values.yaml"
     values.write_text("replicaCount: 2\n", encoding="utf-8")
+    production_values = tmp_path / "prod-values.yaml"
+    production_values.write_text("metrics:\n  enabled: true\n", encoding="utf-8")
     version = tmp_path / "version"
     version.write_text("3.0.3\n", encoding="utf-8")
     args = Namespace(
@@ -2046,7 +2052,18 @@ def recovery_execution_case(
     user_values["image"].pop("pullPolicy")
     computed_before = json.loads(json.dumps(desired))
     computed_before["image"]["pullPolicy"] = "IfNotPresent"
-    state = {"upgraded": False, "description": "", "pod_reads": 0, "all_reads": 0}
+    state = {
+        "upgraded": False,
+        "description": "",
+        "pod_reads": 0,
+        "all_reads": 0,
+        "status_reads": 0,
+        "user_reads": 0,
+        "strict_calls": [],
+        "finalize_calls": [],
+        "render_calls": [],
+        "preflight_calls": [],
+    }
     commands: list[list[str]] = []
 
     monkeypatch.setattr(rollback, "assert_production_target", lambda *_args: None)
@@ -2055,28 +2072,43 @@ def recovery_execution_case(
         rollback, "verifier_capabilities", lambda *_args: {"contract": "repository"}
     )
     monkeypatch.setattr(rollback, "verifier_accepts_runtime_arguments", lambda *_args: True)
-    monkeypatch.setattr(
-        rollback.release, "preflight", lambda *_args, **_kwargs: {"image": True, "chart": True}
-    )
+    def preflight(*call_args: object, **call_kwargs: object) -> dict[str, bool]:
+        state["preflight_calls"].append((call_args, call_kwargs))
+        if fault == "provenance":
+            raise manifest.ManifestError("SENTINEL missing immutable provenance")
+        return {"image": True, "chart": True}
+
+    monkeypatch.setattr(rollback.release, "preflight", preflight)
     monkeypatch.setattr(
         rollback.release,
         "verify_helm_stored_values",
-        lambda *_args: [{"check": "helmStoredValues", "passed": True}],
+        lambda *call_args: state["strict_calls"].append(call_args)
+        or [{"check": "helmStoredValues", "passed": True}],
     )
     monkeypatch.setattr(
         rollback.release,
         "finalize",
-        lambda *_args, **_kwargs: {"verificationResults": [{"check": "ownership", "passed": True}]},
+        lambda *call_args, **call_kwargs: state["finalize_calls"].append(
+            (call_args, call_kwargs)
+        )
+        or {"verificationResults": [{"check": "ownership", "passed": True}]},
     )
-    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+    monkeypatch.setattr(
+        rollback.app_chart,
+        "validate_rendered_manifest",
+        lambda *call_args: state["render_calls"].append(call_args) or [],
+    )
     monkeypatch.setattr(rollback.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(rollback, "chart_pin", lambda _path: "3.0.3")
     monkeypatch.setattr(
         rollback,
         "stage_values",
         lambda _config, _root, _staged: (
-            [values],
-            [{"path": "values.yaml", "sha256": hashlib.sha256(values.read_bytes()).hexdigest()}],
+            [values, production_values],
+            [
+                {"path": path.name, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+                for path in (values, production_values)
+            ],
         ),
     )
     monkeypatch.setattr(
@@ -2111,26 +2143,12 @@ def recovery_execution_case(
     monkeypatch.setattr(
         rollback,
         "pods",
-        lambda *_args, **_kwargs: json.loads(
-            json.dumps(after_pods if state["upgraded"] else before_pods)
-        ),
+        lambda *_args, **_kwargs: _recovery_pods(state, fault, before_pods, after_pods),
     )
     monkeypatch.setattr(
         rollback,
         "helm_status",
-        lambda *_args: {
-            "name": "dspace",
-            "namespace": "dspace",
-            "version": 11 if state["upgraded"] else 10,
-            "info": {
-                "status": "deployed",
-                "description": (
-                    state["description"]
-                    if state["upgraded"]
-                    else f"sugarkube-dspace-metrics-reconciliation:{original['invocationId']}"
-                ),
-            },
-        },
+        lambda *_args: _recovery_helm_status(state, fault, original),
     )
 
     def runner(command: list[str]) -> str:
@@ -2151,15 +2169,28 @@ def recovery_execution_case(
         if command[0] == "helm" and "get" in command and "values" in command:
             if "--all" in command:
                 state["all_reads"] += 1
-                return json.dumps(desired if state["upgraded"] else computed_before)
-            return json.dumps(user_values)
+                result = desired if state["upgraded"] else computed_before
+                if fault == "computed-drift" and state["all_reads"] == 1:
+                    result = {**computed_before, "unrelated": True}
+                if fault == "concurrent-computed" and state["all_reads"] == 2:
+                    result = {**computed_before, "unrelated": True}
+                return json.dumps(result)
+            state["user_reads"] += 1
+            result = user_values
+            if fault == "user-drift" and state["user_reads"] == 1:
+                result = {**user_values, "unrelated": True}
+            if fault == "concurrent-user" and state["user_reads"] == 2:
+                result = {**user_values, "unrelated": True}
+            return json.dumps(result)
         if command[0] == "helm" and "show" in command:
             return "image:\n  pullPolicy: IfNotPresent\n"
         if command[0] == "helm" and "manifest" in command:
-            return "current render"
+            return "different render" if fault == "render" else "current render"
         if command[0] == "helm" and "template" in command:
             return "current render" if "live-values.json" in joined else "approved render"
         if command[:2] == [str(args.verifier), "verify"]:
+            if fault == "runtime":
+                raise rollback.RollbackError("runtime ownership failed")
             expected = command[command.index("--expected-helm-revision") + 1]
             assert expected == ("11" if state["upgraded"] else "10")
             return json.dumps(
@@ -2171,12 +2202,81 @@ def recovery_execution_case(
                     defaultProvider=selected["expectedDefaultChatProvider"],
                 )
             )
+        if (
+            "observability_app_metrics.py" in joined
+            and "secret-check" in command
+            and fault == "secret"
+        ):
+            raise rollback.RollbackError("Secret contract failed")
+        if "observability_app_metrics.py" in joined and "verify" in command and fault == "metrics":
+            raise rollback.RollbackError("metrics verification failed")
         if command[0] == "kubectl" and "get" in command:
             return '{"items": []}'
         return ""
 
+    args._test_state = state
+    args._test_values = [values, production_values]
     args._test_runner = runner
     return args, commands, failed_path, baseline_path, selected
+
+
+def _recovery_helm_status(
+    state: dict[str, object], fault: str | None, original: dict[str, object]
+) -> dict[str, object]:
+    state["status_reads"] += 1
+    revision = 11 if state["upgraded"] else 10
+    if not state["upgraded"] and state["status_reads"] == 1:
+        if fault == "revision":
+            revision = 9
+        elif fault == "already-recovered":
+            revision = 11
+    if fault == "concurrent-revision" and state["status_reads"] == 3:
+        revision = 12
+    return {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": revision,
+            "chart": {
+                "metadata": {
+                    "name": "dspace",
+                    "version": "3.0.2" if fault == "chart" else "3.0.3",
+                }
+            },
+            "info": {
+                "status": "deployed",
+                "description": (
+                    state["description"]
+                    if state["upgraded"]
+                    else (
+                        "wrong-description"
+                        if fault == "description"
+                        else f"sugarkube-dspace-metrics-reconciliation:{original['invocationId']}"
+                    )
+                ),
+            },
+    }
+
+
+def _recovery_pods(
+    state: dict[str, object],
+    fault: str | None,
+    before_pods: list[dict[str, object]],
+    after_pods: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    state["pod_reads"] += 1
+    result = json.loads(json.dumps(after_pods if state["upgraded"] else before_pods))
+    if not state["upgraded"] and state["pod_reads"] == 1:
+        if fault == "pod-count":
+            result.pop()
+        elif fault == "pod-readiness":
+            result[0]["ready"] = False
+        elif fault == "image-digest":
+            result[0]["applicationImageID"] = f"{manifest.IMAGE_REF}@sha256:{'0' * 64}"
+        elif fault == "image-tag":
+            result[0]["applicationImage"] = f"{manifest.IMAGE_REF}:wrong-tag"
+    if fault == "concurrent-pod" and state["pod_reads"] == 2:
+        result[0]["uid"] = "drifted"
+    return result
 
 
 def test_production_metrics_recovery_completes_revision_10_to_11(
@@ -2189,7 +2289,9 @@ def test_production_metrics_recovery_completes_revision_10_to_11(
     assert len(upgrades) == 1
     upgrade = upgrades[0]
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
-    assert [upgrade[i + 1] for i, value in enumerate(upgrade) if value == "--values"]
+    assert [upgrade[i + 1] for i, value in enumerate(upgrade) if value == "--values"] == [
+        str(path) for path in args._test_values
+    ]
     assert f"image.repository={manifest.IMAGE_REF}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
     assert "image.pullPolicy=Always" in upgrade
@@ -2214,6 +2316,12 @@ def test_production_metrics_recovery_completes_revision_10_to_11(
         sum("observability_app_metrics.py" in " ".join(c) and "verify" in c for c in commands) == 2
     )
     assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+    assert len(args._test_state["preflight_calls"]) == 1
+    assert len(args._test_state["render_calls"]) == 1
+    assert len(args._test_state["strict_calls"]) == 3
+    assert len(args._test_state["finalize_calls"]) == 1
+    assert args._test_state["all_reads"] == 3
+    assert args._test_state["status_reads"] >= 4
 
 
 def test_production_metrics_recovery_post_upgrade_failure_is_single_shot_and_sanitized(
@@ -2287,3 +2395,58 @@ def test_production_metrics_recovery_output_collision_is_byte_immutable_and_non_
         and any(action in command for action in ("upgrade", "rollback", "uninstall"))
         for command in commands
     )
+
+
+@pytest.mark.parametrize(
+    ("fault", "failed_stage"),
+    (
+        ("revision", "live-state-and-provenance"),
+        ("already-recovered", "live-state-and-provenance"),
+        ("chart", "live-state-and-provenance"),
+        ("description", "live-state-and-provenance"),
+        ("image-tag", "live-state-and-provenance"),
+        ("image-digest", "live-state-and-provenance"),
+        ("pod-count", "live-state-and-provenance"),
+        ("pod-readiness", "live-state-and-provenance"),
+        ("secret", "live-state-and-provenance"),
+        ("render", "live-state-and-provenance"),
+        ("user-drift", "live-state-and-provenance"),
+        ("computed-drift", "live-state-and-provenance"),
+        ("runtime", "runtime-and-metrics-preflight"),
+        ("metrics", "runtime-and-metrics-preflight"),
+        ("provenance", "immutable-oci-provenance"),
+        ("concurrent-revision", "pre-mutation-revalidation"),
+        ("concurrent-pod", "pre-mutation-revalidation"),
+        ("concurrent-user", "pre-mutation-revalidation"),
+        ("concurrent-computed", "pre-mutation-revalidation"),
+    ),
+)
+def test_production_metrics_recovery_real_path_rejections_are_linked_and_non_mutating(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+    failed_stage: str,
+) -> None:
+    args, commands, failed, baseline, selected = recovery_execution_case(
+        tmp_path, monkeypatch, fault=fault
+    )
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    with pytest.raises(rollback.RollbackError):
+        rollback.rollback(args, args._test_runner)
+    assert not any(
+        command[0] == "helm"
+        and any(action in command for action in ("upgrade", "rollback", "uninstall"))
+        for command in commands
+    )
+    assert not any(command[0] == "kubectl" and "secret" in command for command in commands)
+    written = json.loads(args.evidence.read_text(encoding="utf-8"))
+    assert written["failedStage"] == failed_stage
+    assert written["clusterMayHaveChanged"] is False
+    assert written["originalFailure"] == {
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": hashlib.sha256(
+            manifest._canonical(selected).encode()
+        ).hexdigest(),
+    }
+    assert "SENTINEL" not in args.evidence.read_text(encoding="utf-8")
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -897,6 +897,39 @@ def test_render_failure_precedes_reservation_and_mutation(
     assert_no_mutation(commands)
 
 
+def test_recovery_initial_production_assertion_failure_is_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    args.kubeconfig = str(kubeconfig)
+    args.configuration_reconciliation = True
+    args.production_metrics_recovery = True
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        return "unexpected-context" if "current-context" in command else ""
+
+    with pytest.raises(rollback.RollbackError, match="requires sugar-prod"):
+        rollback.rollback(args, runner)
+
+    written = json.loads(evidence.read_text(encoding="utf-8"))
+    assert written.pop("failedAt")
+    assert written == {
+        "schemaVersion": rollback.SCHEMA_VERSION,
+        "operation": rollback.RECOVERY_OPERATION,
+        "state": "failed",
+        "failedStage": "recovery-preflight",
+        "failureCode": "recovery-preflight-failed",
+        "clusterMayHaveChanged": False,
+        "diagnostics": {},
+    }
+    assert_no_mutation(commands)
+
+
 def test_exact_no_op_is_rejected_before_reservation_and_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1645,6 +1678,26 @@ def test_just_recipe_has_no_revision_rollback_or_reuse_values() -> None:
     assert "dspace_manifest_rollback.py" in block
     assert "--reuse-values" not in block
     assert "helm rollback" not in block
+
+
+def test_recovery_recipe_strips_only_the_matching_argument_prefix_once() -> None:
+    recipe = (Path(__file__).parents[1] / "justfile").read_text(encoding="utf-8")
+    block = recipe.split("dspace-prod-metrics-pull-policy-recover", 1)[1].split(
+        "\n# Read-only DSPACE", 1
+    )[0]
+    for prefix in (
+        "failed_evidence",
+        "maintenance_target",
+        "recovery_evidence",
+        "smoke_runner",
+        "kubeconfig",
+        "verifier",
+        "confirm",
+        "config",
+    ):
+        assert f"#{prefix}=" in block
+    assert "while [[" not in block
+    assert "${value#*=}" not in block
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -943,11 +943,60 @@ def test_recovery_initial_production_assertion_failure_is_preserved(
         "schemaVersion": rollback.SCHEMA_VERSION,
         "operation": rollback.RECOVERY_OPERATION,
         "state": "failed",
-        "failedStage": "recovery-preflight",
-        "failureCode": "recovery-preflight-failed",
+        "failedStage": "kubeconfig-and-cluster-identity",
+        "failureCode": "kubeconfig-and-cluster-identity-failed",
         "clusterMayHaveChanged": False,
         "diagnostics": {"failureType": "RollbackError"},
     }
+    assert_no_mutation(commands)
+
+
+@pytest.mark.parametrize(
+    "failed_stage",
+    (
+        "failed-evidence-authorization",
+        "live-state-and-provenance",
+        "runtime-and-metrics-preflight",
+        "confirmation",
+        "reservation",
+    ),
+)
+def test_linked_recovery_pre_reservation_failures_preserve_precise_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failed_stage: str,
+) -> None:
+    args, commands, evidence, _verifier = pre_reservation_case(
+        tmp_path, monkeypatch, environment="prod"
+    )
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    args.kubeconfig = str(kubeconfig)
+    args.configuration_reconciliation = True
+    args.production_metrics_recovery = True
+    original = {
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": "b" * 64,
+    }
+    monkeypatch.setattr(rollback, "assert_production_target", lambda *_args: None)
+
+    def reject(_args: Namespace, _runner: object, _staged: Path) -> dict[str, object]:
+        _args._recovery_failed_stage = failed_stage
+        _args._recovery_original_failure = original
+        raise rollback.RollbackError("sensitive diagnostic must not be persisted")
+
+    monkeypatch.setattr(rollback, "_rollback", reject)
+
+    with pytest.raises(rollback.RollbackError, match="sensitive diagnostic"):
+        rollback.rollback(args, commands.append)
+
+    written = json.loads(evidence.read_text(encoding="utf-8"))
+    assert written["failedStage"] == failed_stage
+    assert written["failureCode"] == f"{failed_stage}-failed"
+    assert written["clusterMayHaveChanged"] is False
+    assert written["originalFailure"] == original
+    assert written["diagnostics"] == {"failureType": "RollbackError"}
+    assert "sensitive" not in evidence.read_text(encoding="utf-8")
     assert_no_mutation(commands)
 
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -2079,12 +2079,16 @@ def recovery_execution_case(
         return {"image": True, "chart": True}
 
     monkeypatch.setattr(rollback.release, "preflight", preflight)
-    monkeypatch.setattr(
-        rollback.release,
-        "verify_helm_stored_values",
-        lambda *call_args: state["strict_calls"].append(call_args)
-        or [{"check": "helmStoredValues", "passed": True}],
-    )
+
+    def verify_stored(*call_args: object) -> list[dict[str, object]]:
+        state["strict_calls"].append(call_args)
+        if (fault == "stored-contract" and len(state["strict_calls"]) == 2) or (
+            fault == "post-stored-contract" and state["upgraded"]
+        ):
+            raise manifest.ManifestError("SENTINEL invalid stored values")
+        return [{"check": "helmStoredValues", "passed": True}]
+
+    monkeypatch.setattr(rollback.release, "verify_helm_stored_values", verify_stored)
     monkeypatch.setattr(
         rollback.release,
         "finalize",
@@ -2124,6 +2128,11 @@ def recovery_execution_case(
     )
 
     def merged(paths: object) -> dict[str, object]:
+        if any("chart-defaults" in str(p) for p in paths):
+            if fault == "invalid-chart-defaults":
+                return []  # type: ignore[return-value]
+            if fault == "missing-default-image":
+                return {"replicaCount": 2}
         return json.loads(
             json.dumps(
                 computed_before if any("chart-defaults" in str(p) for p in paths) else desired
@@ -2170,6 +2179,8 @@ def recovery_execution_case(
             if "--all" in command:
                 state["all_reads"] += 1
                 result = desired if state["upgraded"] else computed_before
+                if fault == "post-computed" and state["upgraded"]:
+                    result = {**desired, "unrelated": True}
                 if fault == "computed-drift" and state["all_reads"] == 1:
                     result = {**computed_before, "unrelated": True}
                 if fault == "concurrent-computed" and state["all_reads"] == 2:
@@ -2353,6 +2364,7 @@ def test_production_metrics_recovery_post_upgrade_failure_is_single_shot_and_san
     (
         ("failedStage", "runtime-verification"),
         ("invocationId", "not-an-invocation"),
+        ("targetManifestFingerprint", "not-a-fingerprint"),
         ("targetManifestFingerprint", "0" * 64),
     ),
 )
@@ -2412,6 +2424,9 @@ def test_production_metrics_recovery_output_collision_is_byte_immutable_and_non_
         ("render", "live-state-and-provenance"),
         ("user-drift", "live-state-and-provenance"),
         ("computed-drift", "live-state-and-provenance"),
+        ("invalid-chart-defaults", "live-state-and-provenance"),
+        ("missing-default-image", "live-state-and-provenance"),
+        ("stored-contract", "live-state-and-provenance"),
         ("runtime", "runtime-and-metrics-preflight"),
         ("metrics", "runtime-and-metrics-preflight"),
         ("provenance", "immutable-oci-provenance"),
@@ -2450,3 +2465,99 @@ def test_production_metrics_recovery_real_path_rejections_are_linked_and_non_mut
     }
     assert "SENTINEL" not in args.evidence.read_text(encoding="utf-8")
     assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+
+
+@pytest.mark.parametrize(
+    ("fault", "failed_stage"),
+    (
+        ("post-computed", "ownership-and-finalization-proof"),
+        ("post-stored-contract", "ownership-and-finalization-proof"),
+    ),
+)
+def test_production_metrics_recovery_postflight_value_failures_are_single_shot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+    failed_stage: str,
+) -> None:
+    args, commands, failed, baseline, _selected = recovery_execution_case(
+        tmp_path, monkeypatch, fault=fault
+    )
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+        rollback.rollback(args, args._test_runner)
+    written = json.loads(args.evidence.read_text(encoding="utf-8"))
+    assert written["failedStage"] == failed_stage
+    assert written["clusterMayHaveChanged"] is True
+    assert written["originalFailure"]["invocationId"] == "a" * 32
+    assert "SENTINEL" not in args.evidence.read_text(encoding="utf-8")
+    assert sum(command[0] == "helm" and "upgrade" in command for command in commands) == 1
+    assert not any("rollback" in command or "uninstall" in command for command in commands)
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+
+
+def test_recovery_helpers_cover_optional_and_rejected_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selected = target()
+    with pytest.raises(rollback.RollbackError, match="recovery confirmation"):
+        rollback.recovery_confirmation("wrong")
+
+    args = Namespace(
+        verifier=Path("verifier"),
+        environment="prod",
+        smoke_runner=Path("smoke"),
+        kubeconfig=Path("kubeconfig"),
+        config="runtime.json",
+    )
+    command = rollback.runtime_verifier_command(args, selected, Path("manifest.json"))
+    assert command[-2:] == ["--config", "runtime.json"]
+
+    unreadable = tmp_path / "unreadable.json"
+    unreadable.write_text("not-json", encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="unreadable"):
+        rollback.failed_reconciliation(unreadable, selected)
+    incomplete = tmp_path / "incomplete.json"
+    incomplete.write_text("{}", encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="schema is incomplete"):
+        rollback.failed_reconciliation(incomplete, selected)
+
+    recovery_dir = tmp_path / "recovery"
+    recovery_dir.mkdir()
+    args, commands, _failed, _baseline, _selected = recovery_execution_case(
+        recovery_dir, monkeypatch
+    )
+    args.verifier = tmp_path / "third-party-verifier"
+    with pytest.raises(rollback.RollbackError, match="repository runtime verifier"):
+        rollback.rollback(args, args._test_runner)
+    assert not any("upgrade" in command for command in commands)
+
+
+def test_main_validates_and_normalizes_production_recovery_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    common = [
+        "--environment",
+        "prod",
+        "--evidence",
+        str(tmp_path / "out.json"),
+        "--verifier",
+        str(tmp_path / "verifier"),
+        "--production-metrics-recovery",
+    ]
+    with pytest.raises(SystemExit):
+        rollback.main([*common, "--manifest", str(tmp_path / "manifest.json")])
+    with pytest.raises(SystemExit):
+        rollback.main(common)
+
+    observed: list[Namespace] = []
+    monkeypatch.setattr(rollback, "rollback", lambda args: observed.append(args) or {})
+    assert rollback.main(
+        [
+            *common,
+            "--failed-evidence", str(tmp_path / "failed.json"),
+            "--maintenance-target", str(tmp_path / "target.json"),
+        ]
+    ) == 0
+    assert observed[0].configuration_reconciliation is True
+    assert observed[0].baseline_manifest == rollback.PRODUCTION_BASELINE

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -22,6 +22,10 @@ def test_failed_reconciliation_accepts_only_exact_authorized_incident(tmp_path: 
     baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
     selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
     evidence = {
+        "schemaVersion": rollback.SCHEMA_VERSION,
+        "environment": "prod",
+        "release": "dspace",
+        "namespace": "dspace",
         "operation": "dspaceProductionMetricsReconciliation",
         "state": "failed",
         "failedStage": "ownership-and-finalization-proof",
@@ -51,7 +55,14 @@ def test_failed_reconciliation_accepts_only_exact_authorized_incident(tmp_path: 
     assert rollback.failed_reconciliation(path, selected)["invocationId"] == "a" * 32
 
     for field, wrong in (
+        ("schemaVersion", 2),
+        ("environment", "staging"),
+        ("release", "other"),
+        ("namespace", "other"),
+        ("operation", "other"),
+        ("state", "succeeded"),
         ("failedStage", "runtime-verification"),
+        ("failureCode", "runtime-verification-failed"),
         ("invocationId", "wrong"),
         ("clusterMayHaveChanged", False),
     ):
@@ -64,6 +75,16 @@ def test_failed_reconciliation_accepts_only_exact_authorized_incident(tmp_path: 
     path.write_text(json.dumps(changed), encoding="utf-8")
     with pytest.raises(rollback.RollbackError, match="revision 9"):
         rollback.failed_reconciliation(path, selected)
+
+    for target_change in ("missing", "extra"):
+        changed = json.loads(json.dumps(evidence))
+        if target_change == "missing":
+            changed["target"].pop("imageDigest")
+        else:
+            changed["target"]["ignored"] = "must-not-be-accepted"
+        path.write_text(json.dumps(changed), encoding="utf-8")
+        with pytest.raises(rollback.RollbackError, match="reviewed target"):
+            rollback.failed_reconciliation(path, selected)
 
 
 def target(environment: str = "staging", schema_version: int = 1) -> dict[str, object]:
@@ -925,7 +946,7 @@ def test_recovery_initial_production_assertion_failure_is_preserved(
         "failedStage": "recovery-preflight",
         "failureCode": "recovery-preflight-failed",
         "clusterMayHaveChanged": False,
-        "diagnostics": {},
+        "diagnostics": {"failureType": "RollbackError"},
     }
     assert_no_mutation(commands)
 

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from argparse import Namespace
 from pathlib import Path
@@ -15,6 +16,54 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 PROD_BASELINE = Path("deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json")
 PROD_MAINTENANCE_TARGET = Path("docs/apps/dspace.prod-metrics-chart-target.json")
+
+
+def test_failed_reconciliation_accepts_only_exact_authorized_incident(tmp_path: Path) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    evidence = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": hashlib.sha256(
+            manifest._canonical(selected).encode()
+        ).hexdigest(),
+        "before": {"helmRevision": 9, "chartName": "dspace", "chartVersion": "3.0.2"},
+        "target": {
+            field: selected[field]
+            for field in (
+                "applicationVersion",
+                "sourceRevision",
+                "imageTag",
+                "imageDigest",
+                "chartSourceRevision",
+                "chartVersion",
+                "chartDigest",
+                "expectedDefaultChatProvider",
+            )
+        },
+    }
+    path = tmp_path / "failed.json"
+    path.write_text(json.dumps(evidence), encoding="utf-8")
+    assert rollback.failed_reconciliation(path, selected)["invocationId"] == "a" * 32
+
+    for field, wrong in (
+        ("failedStage", "runtime-verification"),
+        ("invocationId", "wrong"),
+        ("clusterMayHaveChanged", False),
+    ):
+        path.write_text(json.dumps({**evidence, field: wrong}), encoding="utf-8")
+        with pytest.raises(rollback.RollbackError):
+            rollback.failed_reconciliation(path, selected)
+
+    changed = json.loads(json.dumps(evidence))
+    changed["before"]["helmRevision"] = 10
+    path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="revision 9"):
+        rollback.failed_reconciliation(path, selected)
 
 
 def target(environment: str = "staging", schema_version: int = 1) -> dict[str, object]:
@@ -1503,6 +1552,9 @@ def test_configuration_reconciliation_completes_all_production_gates(
     assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
+    assert "image.pullPolicy=Always" in upgrade
+    rendered = next(command for command in commands if "template" in command)
+    assert "image.pullPolicy=Always" in rendered
     forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
     assert not any(item in upgrade for item in forbidden)
     assert selected["imageDigest"] not in next(

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1963,3 +1963,327 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
     assert written["targetManifestFingerprint"] == result["targetManifestFingerprint"]
     assert written["helm"]["beforeRevision"] == 7
     assert written["helm"]["afterRevision"] == 8
+
+
+def recovery_execution_case(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, fail_after_upgrade: bool = False
+) -> tuple[Namespace, list[list[str]], Path, Path, dict[str, object]]:
+    """Build the reviewed revision-10 incident around the real recovery lifecycle."""
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    selected = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(manifest._canonical(baseline), encoding="utf-8")
+    target_path = tmp_path / "target.json"
+    target_path.write_bytes(PROD_MAINTENANCE_TARGET.read_bytes())
+    failed_path = tmp_path / "failed.json"
+    fingerprint = hashlib.sha256(manifest._canonical(selected).encode()).hexdigest()
+    original = {
+        "schemaVersion": rollback.SCHEMA_VERSION,
+        "environment": "prod",
+        "release": "dspace",
+        "namespace": "dspace",
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": fingerprint,
+        "before": {"helmRevision": 9, "chartName": "dspace", "chartVersion": "3.0.2"},
+        "target": {
+            key: selected[key]
+            for key in (
+                "applicationVersion",
+                "sourceRevision",
+                "imageTag",
+                "imageDigest",
+                "chartSourceRevision",
+                "chartVersion",
+                "chartDigest",
+                "expectedDefaultChatProvider",
+            )
+        },
+    }
+    failed_path.write_text(json.dumps(original), encoding="utf-8")
+    evidence = tmp_path / "recovery.json"
+    kubeconfig = tmp_path / "kubeconfig"
+    kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+    smoke = tmp_path / "smoke"
+    smoke.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    smoke.chmod(0o700)
+    values = tmp_path / "values.yaml"
+    values.write_text("replicaCount: 2\n", encoding="utf-8")
+    version = tmp_path / "version"
+    version.write_text("3.0.3\n", encoding="utf-8")
+    args = Namespace(
+        environment="prod",
+        manifest=baseline_path,
+        baseline_manifest=baseline_path,
+        maintenance_target=target_path,
+        failed_evidence=failed_path,
+        evidence=evidence,
+        verifier=rollback.REPO_ROOT / "scripts/dspace_runtime_verifier.py",
+        smoke_runner=smoke,
+        confirm=rollback.RECOVERY_CONFIRMATION,
+        config="",
+        kubeconfig=str(kubeconfig),
+        oras="oras",
+        timeout="7m",
+        configuration_reconciliation=True,
+        production_metrics_recovery=True,
+    )
+    desired = {
+        "replicaCount": 2,
+        "image": {
+            "repository": manifest.IMAGE_REF,
+            "tag": selected["imageTag"],
+            "pullPolicy": "Always",
+        },
+        "metrics": {"enabled": True},
+        "serviceMonitor": {"enabled": True},
+    }
+    user_values = json.loads(json.dumps(desired))
+    user_values["image"].pop("pullPolicy")
+    computed_before = json.loads(json.dumps(desired))
+    computed_before["image"]["pullPolicy"] = "IfNotPresent"
+    state = {"upgraded": False, "description": "", "pod_reads": 0, "all_reads": 0}
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(rollback, "assert_production_target", lambda *_args: None)
+    monkeypatch.setattr(rollback, "cluster_environment", lambda *_args: "prod")
+    monkeypatch.setattr(
+        rollback, "verifier_capabilities", lambda *_args: {"contract": "repository"}
+    )
+    monkeypatch.setattr(rollback, "verifier_accepts_runtime_arguments", lambda *_args: True)
+    monkeypatch.setattr(
+        rollback.release, "preflight", lambda *_args, **_kwargs: {"image": True, "chart": True}
+    )
+    monkeypatch.setattr(
+        rollback.release,
+        "verify_helm_stored_values",
+        lambda *_args: [{"check": "helmStoredValues", "passed": True}],
+    )
+    monkeypatch.setattr(
+        rollback.release,
+        "finalize",
+        lambda *_args, **_kwargs: {"verificationResults": [{"check": "ownership", "passed": True}]},
+    )
+    monkeypatch.setattr(rollback.app_chart, "validate_rendered_manifest", lambda *_args: [])
+    monkeypatch.setattr(rollback.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(rollback, "chart_pin", lambda _path: "3.0.3")
+    monkeypatch.setattr(
+        rollback,
+        "stage_values",
+        lambda _config, _root, _staged: (
+            [values],
+            [{"path": "values.yaml", "sha256": hashlib.sha256(values.read_bytes()).hexdigest()}],
+        ),
+    )
+    monkeypatch.setattr(
+        rollback.app_config,
+        "load_config",
+        lambda *_args: {
+            "SUGARKUBE_CHART": f"oci://{manifest.CHART_REF}",
+            "SUGARKUBE_RELEASE": "dspace",
+            "SUGARKUBE_NAMESPACE": "dspace",
+            "SUGARKUBE_VALUES": str(values),
+            "SUGARKUBE_VERSION_FILE": str(version),
+        },
+    )
+
+    def merged(paths: object) -> dict[str, object]:
+        return json.loads(
+            json.dumps(
+                computed_before if any("chart-defaults" in str(p) for p in paths) else desired
+            )
+        )
+
+    monkeypatch.setattr(rollback.app_chart, "merged_values_document", merged)
+
+    def ready(uid: str) -> dict[str, object]:
+        return {
+            **pod(uid),
+            "applicationImage": f"{manifest.IMAGE_REF}:{selected['imageTag']}",
+            "applicationImageID": f"{manifest.IMAGE_REF}@{selected['imageDigest']}",
+        }
+
+    before_pods, after_pods = [ready("old-1"), ready("old-2")], [ready("new-1"), ready("new-2")]
+    monkeypatch.setattr(
+        rollback,
+        "pods",
+        lambda *_args, **_kwargs: json.loads(
+            json.dumps(after_pods if state["upgraded"] else before_pods)
+        ),
+    )
+    monkeypatch.setattr(
+        rollback,
+        "helm_status",
+        lambda *_args: {
+            "name": "dspace",
+            "namespace": "dspace",
+            "version": 11 if state["upgraded"] else 10,
+            "info": {
+                "status": "deployed",
+                "description": (
+                    state["description"]
+                    if state["upgraded"]
+                    else f"sugarkube-dspace-metrics-reconciliation:{original['invocationId']}"
+                ),
+            },
+        },
+    )
+
+    def runner(command: list[str]) -> str:
+        commands.append(command)
+        joined = " ".join(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "f" * 40
+        if command[0] == "helm" and "history" in command:
+            return json.dumps(
+                [{"revision": 11 if state["upgraded"] else 10, "chart": "dspace-3.0.3"}]
+            )
+        if command[0] == "helm" and "upgrade" in command:
+            state["description"] = command[command.index("--description") + 1]
+            state["upgraded"] = True
+            if fail_after_upgrade:
+                raise rollback.RollbackError("credential=secret SENTINEL raw command output")
+            return ""
+        if command[0] == "helm" and "get" in command and "values" in command:
+            if "--all" in command:
+                state["all_reads"] += 1
+                return json.dumps(desired if state["upgraded"] else computed_before)
+            return json.dumps(user_values)
+        if command[0] == "helm" and "show" in command:
+            return "image:\n  pullPolicy: IfNotPresent\n"
+        if command[0] == "helm" and "manifest" in command:
+            return "current render"
+        if command[0] == "helm" and "template" in command:
+            return "current render" if "live-values.json" in joined else "approved render"
+        if command[:2] == [str(args.verifier), "verify"]:
+            expected = command[command.index("--expected-helm-revision") + 1]
+            assert expected == ("11" if state["upgraded"] else "10")
+            return json.dumps(
+                verifier_result(
+                    environment="prod",
+                    applicationVersion=selected["applicationVersion"],
+                    runtimeSourceRevision=selected["sourceRevision"],
+                    frontendSourceRevision=selected["sourceRevision"],
+                    defaultProvider=selected["expectedDefaultChatProvider"],
+                )
+            )
+        if command[0] == "kubectl" and "get" in command:
+            return '{"items": []}'
+        return ""
+
+    args._test_runner = runner
+    return args, commands, failed_path, baseline_path, selected
+
+
+def test_production_metrics_recovery_completes_revision_10_to_11(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, failed, baseline, selected = recovery_execution_case(tmp_path, monkeypatch)
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    result = rollback.rollback(args, args._test_runner)
+    upgrades = [command for command in commands if command[0] == "helm" and "upgrade" in command]
+    assert len(upgrades) == 1
+    upgrade = upgrades[0]
+    assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
+    assert [upgrade[i + 1] for i, value in enumerate(upgrade) if value == "--values"]
+    assert f"image.repository={manifest.IMAGE_REF}" in upgrade
+    assert f"image.tag={selected['imageTag']}" in upgrade
+    assert "image.pullPolicy=Always" in upgrade
+    assert "--wait" in upgrade and upgrade[upgrade.index("--timeout") + 1] == "7m"
+    assert "--reuse-values" not in upgrade
+    assert not any("rollback" in command or "uninstall" in command for command in commands)
+    assert result["helm"]["beforeRevision"] == 10
+    assert result["helm"]["afterRevision"] == 11
+    assert result["originalFailure"] == {
+        "invocationId": "a" * 32,
+        "targetManifestFingerprint": hashlib.sha256(
+            manifest._canonical(selected).encode()
+        ).hexdigest(),
+    }
+    verifier_revisions = [
+        command[command.index("--expected-helm-revision") + 1]
+        for command in commands
+        if command[:2] == [str(args.verifier), "verify"]
+    ]
+    assert verifier_revisions == ["10", "11"]
+    assert (
+        sum("observability_app_metrics.py" in " ".join(c) and "verify" in c for c in commands) == 2
+    )
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+
+
+def test_production_metrics_recovery_post_upgrade_failure_is_single_shot_and_sanitized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, failed, baseline, _selected = recovery_execution_case(
+        tmp_path, monkeypatch, fail_after_upgrade=True
+    )
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    with pytest.raises(rollback.RollbackError, match="preserved evidence"):
+        rollback.rollback(args, args._test_runner)
+    written = json.loads(args.evidence.read_text(encoding="utf-8"))
+    assert written["failedStage"] == "helm-upgrade"
+    assert written["clusterMayHaveChanged"] is True
+    assert written["originalFailure"]["invocationId"] == "a" * 32
+    serialized = args.evidence.read_text(encoding="utf-8")
+    assert not any(
+        secret in serialized
+        for secret in ("SENTINEL", "credential", "secret", "raw command output")
+    )
+    assert sum(command[0] == "helm" and "upgrade" in command for command in commands) == 1
+    assert not any("rollback" in command or "uninstall" in command for command in commands)
+    assert not any(command[0] == "kubectl" and "secret" in command for command in commands)
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+
+
+@pytest.mark.parametrize(
+    ("field", "wrong"),
+    (
+        ("failedStage", "runtime-verification"),
+        ("invocationId", "not-an-invocation"),
+        ("targetManifestFingerprint", "0" * 64),
+    ),
+)
+def test_production_metrics_recovery_rejects_bad_original_evidence_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, field: str, wrong: object
+) -> None:
+    args, commands, failed, baseline, _selected = recovery_execution_case(tmp_path, monkeypatch)
+    changed = json.loads(failed.read_text(encoding="utf-8"))
+    changed[field] = wrong
+    failed.write_text(json.dumps(changed), encoding="utf-8")
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    with pytest.raises(rollback.RollbackError):
+        rollback.rollback(args, args._test_runner)
+    assert not any(
+        command[0] == "helm"
+        and any(action in command for action in ("upgrade", "rollback", "uninstall"))
+        for command in commands
+    )
+    assert not any(command[0] == "kubectl" and "secret" in command for command in commands)
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+    assert (
+        json.loads(args.evidence.read_text(encoding="utf-8"))["failedStage"]
+        == "failed-evidence-authorization"
+    )
+
+
+def test_production_metrics_recovery_output_collision_is_byte_immutable_and_non_mutating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args, commands, failed, baseline, _selected = recovery_execution_case(tmp_path, monkeypatch)
+    collision = b"existing recovery evidence = immutable\n"
+    args.evidence.write_bytes(collision)
+    source_bytes = (failed.read_bytes(), baseline.read_bytes())
+    with pytest.raises(rollback.RollbackError, match="overwrite"):
+        rollback.rollback(args, args._test_runner)
+    assert args.evidence.read_bytes() == collision
+    assert (failed.read_bytes(), baseline.read_bytes()) == source_bytes
+    assert not any(
+        command[0] == "helm"
+        and any(action in command for action in ("upgrade", "rollback", "uninstall"))
+        for command in commands
+    )


### PR DESCRIPTION
### Motivation

Fix the DSPACE production metrics reconciliation bug that allowed chart 3.0.3’s default `image.pullPolicy=IfNotPresent` to reach revision 10, causing strict stored-values finalization to reject the deployment. Add a separately authorized, fail-closed recovery for that exact post-mutation incident without weakening validation or modifying the preserved failed evidence.

### Summary

- Explicitly pass `image.pullPolicy=Always` to every relevant reconciliation render and Helm upgrade, keeping desired values, rendered manifests, mutations, and stored-values validation aligned.
- Add `--production-metrics-recovery` and the `dspace-prod-metrics-pull-policy-recover` recipe for the one reviewed revision 10 → 11 repair.
- Bind recovery authorization to the preserved failed reconciliation, its invocation and target fingerprint, revision 9/chart 3.0.2 before-state, and the approved chart 3.0.3/application/image coordinates.
- Require the repository runtime verifier, executable remote-chat smoke runner, one absolute production kubeconfig, exact recovery confirmation, immutable OCI provenance, strict rendered-manifest validation, and complete reviewed values.
- Accept only revision 10 with exactly two Ready approved pods and the sole computed-values delta `image.pullPolicy=IfNotPresent`.
- Revalidate Helm revision, pods, user values, and computed `--all` values immediately before the single digest-qualified upgrade.
- Require revision 11, replacement Ready pods, strict `Always` stored values, ownership/finalizer checks, runtime/frontend/provider identity, public and remote-chat journeys, production metrics/Grafana verification, and revision stability before finalizing recovery evidence.
- Preserve exact staged failure evidence with sanitized diagnostics and `clusterMayHaveChanged`; never retry, roll back, uninstall, rotate Secrets, or perform a second Helm mutation automatically.
- Never edit the original finalized deployment evidence or preserved failed reconciliation evidence.

### Files changed

- `scripts/dspace_manifest_rollback.py`
- `tests/test_manifest_rollback.py`
- `tests/test_generic_app_just_recipes.py`
- `justfile`
- `docs/apps/dspace.md`

### Verification

The focused test suite completed with `1013 passed`:

~~~bash
pytest -q \
  tests/test_manifest_rollback.py \
  tests/test_release_manifest.py \
  tests/test_generic_app_just_recipes.py \
  tests/test_dspace_runtime_verifier.py \
  tests/test_dspace_runtime_values.py
~~~

The following checks also passed:

~~~bash
python3 -m compileall -q scripts
python3 scripts/dspace_release_manifest.py validate \
  --manifest deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
  --final
python3 scripts/app_config.py json --app dspace --env prod >/dev/null
python3 -m ruff check \
  tests/test_manifest_rollback.py \
  scripts/dspace_manifest_rollback.py
git diff --check
git diff --cached | ./scripts/scan-secrets.py
git diff --exit-code HEAD -- \
  deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
  docs/apps/dspace.prod.tag \
  docs/apps/dspace.prod-metrics-chart-target.json
~~~

No live cluster or production mutation was performed during development.

### Separately authorized post-merge recovery

This is a one-time production recovery, not a rerun of `dspace-prod-metrics-reconcile`. Do not run it during development. After explicit production authorization, an operator supplies private evidence paths and the production kubeconfig:

~~~bash
just dspace-prod-metrics-pull-policy-recover \
  failed_evidence=/private/evidence/dspace-prod-metrics-failed.json \
  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
  recovery_evidence=/private/evidence/dspace-prod-metrics-pull-policy-recovery.json \
  smoke_runner="$HOME/dspace/scripts/run-remote-chat-smoke.mjs" \
  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
  confirm=dspace:prod:recover-revision-10-pull-policy
~~~

The recovery destination must not already exist. If recovery fails, preserve its evidence and investigate the sanitized failure; do not automatically retry or roll back.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e17f7a52c832f827c8888653a73c6)