### PR TITLE
DSPACE: enforce image.pullPolicy=Always and add one-shot pull-policy recovery

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -32,6 +32,29 @@ just dspace-prod-metrics-reconcile \
   confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
 ```
 
+### Pull-policy recovery for the failed revision-10 reconciliation
+
+The normal reconciliation remains bound to the finalized revision-9/chart-3.0.2 baseline and must
+not be retried after Helm has advanced. After this change is independently reviewed and merged, the
+single known revision-10/chart-3.0.3 failure may instead be repaired with the explicit operation:
+
+```bash
+just dspace-prod-metrics-pull-policy-recover \
+  original_evidence=/home/pi/operator-evidence/dspace-prod-metrics-reconcile-20260813T072927Z/reconciliation.json \
+  baseline_manifest=/path/to/finalized-chart-3.0.2.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
+  evidence=/home/pi/operator-evidence/dspace-prod-metrics-pull-policy-recover-$(date -u +%Y%m%dT%H%M%SZ)/recovery.json \
+  smoke_runner=/path/to/executable/dspace-smoke-runner \
+  kubeconfig=/absolute/path/to/production.kubeconfig \
+  confirm=dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d
+```
+
+The destination must not exist. The command accepts only the original bounded failure, proves that
+revision 10 differs solely by `image.pullPolicy=IfNotPresent`, and performs one digest-qualified
+revision 10 to 11 upgrade with `image.pullPolicy=Always`. Any mismatch or post-reservation failure
+fails closed without retry, rollback, uninstall, Secret access, or another mutation. Recovery
+evidence records the original file's SHA-256 and invocation ID; it never modifies that file.
+
 The command uses only the exact digest-qualified 3.0.3 OCI chart, the complete committed production
 values chain, and an invocation-bound opaque Helm description; it never uses `--reuse-values`.
 Afterward it proves replacement Ready pods retain the exact image digest, runs strict runtime,

--- a/justfile
+++ b/justfile
@@ -1862,6 +1862,31 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
     )
     "${reconciliation_command[@]}"
 
+# One-shot, fail-closed repair of the known revision-10 DSPACE pull-policy defect.
+dspace-prod-metrics-pull-policy-recover original_evidence baseline_manifest maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    strip() { local name="$1" value="$2"; value="${value#"${name}"=}"; [[ -n "${value}" ]] || { echo "ERROR: ${name} must not be empty." >&2; return 2; }; printf '%s' "${value}"; }
+    original_path="$(strip original_evidence {{ quote(original_evidence) }})"
+    baseline_path="$(strip baseline_manifest {{ quote(baseline_manifest) }})"
+    target_path="$(strip maintenance_target {{ quote(maintenance_target) }})"
+    evidence_path="$(strip evidence {{ quote(evidence) }})"
+    smoke_path="$(strip smoke_runner {{ quote(smoke_runner) }})"
+    kubeconfig_path="$(strip kubeconfig {{ quote(kubeconfig) }})"
+    verifier_path={{ quote(verifier) }}; verifier_path="${verifier_path#verifier=}"
+    confirmation={{ quote(confirm) }}; confirmation="${confirmation#confirm=}"
+    config_path={{ quote(config) }}; config_path="${config_path#config=}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --pull-policy-recovery --environment prod \
+      --original-evidence "${original_path}" \
+      --baseline-manifest "${baseline_path}" \
+      --maintenance-target "${target_path}" \
+      --evidence "${evidence_path}" \
+      --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" \
+      --verifier "${verifier_path}" \
+      --confirm "${confirmation}" --config "${config_path}"
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -29,6 +29,7 @@ from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
 OPERATION = "dspaceManifestRollback"
+RECOVERY_OPERATION = "dspaceProductionMetricsPullPolicyRecovery"
 REQUIRED_CAPABILITIES = (
     "applicationVersion",
     "runtimeSourceRevision",
@@ -461,6 +462,33 @@ def pods(
     return sorted(result, key=lambda item: str(item["name"]))
 
 
+def deployment_pull_policy(runner: Runner, kubeconfig: str) -> str:
+    deployment = json_command(
+        runner,
+        [
+            "kubectl",
+            "--kubeconfig",
+            kubeconfig,
+            "get",
+            "deployment/dspace",
+            "--namespace",
+            "dspace",
+            "-o",
+            "json",
+        ],
+        "DSPACE deployment",
+    )
+    containers = (
+        deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    )
+    matches = [
+        item for item in containers if isinstance(item, dict) and item.get("name") == "dspace"
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("imagePullPolicy"), str):
+        raise RollbackError("DSPACE deployment pull policy is invalid")
+    return matches[0]["imagePullPolicy"]
+
+
 def revision(status: dict[str, Any]) -> int:
     value = status.get("version")
     if not isinstance(value, int) or isinstance(value, bool) or value < 1:
@@ -617,6 +645,103 @@ def configuration_comparison_baselines(
     return baseline, desired_baseline
 
 
+def validate_failed_reconciliation_evidence(value: object) -> dict[str, Any]:
+    """Accept only the one revision-9 to revision-10 failure this recovery repairs."""
+    if not isinstance(value, dict):
+        raise RollbackError("original failed reconciliation evidence must be a JSON object")
+    expected = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+    }
+    if any(value.get(field) != wanted for field, wanted in expected.items()):
+        raise RollbackError("original evidence is not the approved failed reconciliation")
+    invocation = value.get("invocationId")
+    revision = value.get("sugarkubeRevision")
+    before = value.get("before")
+    target = value.get("target")
+    if not re.fullmatch(r"[0-9a-f]{32}", invocation or ""):
+        raise RollbackError("original evidence invocation ID is invalid")
+    if not re.fullmatch(r"[0-9a-f]{40}", revision or ""):
+        raise RollbackError("original evidence Sugarkube revision is invalid")
+    if not isinstance(before, dict) or (
+        before.get("helmRevision"),
+        before.get("chartName"),
+        before.get("chartVersion"),
+    ) != (9, "dspace", "3.0.2"):
+        raise RollbackError("original evidence before coordinates are not revision 9/chart 3.0.2")
+    required_target = {
+        "chartVersion": "3.0.3",
+        "chartDigest": "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c",
+        "applicationVersion": "3.0.1",
+        "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+        "imageTag": "main-1a31a56",
+        "imageDigest": "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401",
+        "expectedDefaultChatProvider": "openai",
+    }
+    if not isinstance(target, dict) or any(target.get(k) != v for k, v in required_target.items()):
+        raise RollbackError("original evidence target is not the approved chart 3.0.3 tuple")
+    return value
+
+
+def validate_known_pull_policy_defect(
+    user_values: object,
+    computed_values: object,
+    desired_values: dict[str, Any],
+    approved: dict[str, Any] | None = None,
+) -> None:
+    """Prove that pullPolicy is the sole live Helm-values difference."""
+    expected_user = copy.deepcopy(desired_values)
+    expected_user["image"].pop("pullPolicy")
+    if user_values != expected_user:
+        raise RollbackError("live user-supplied Helm values differ from guarded revision-10 inputs")
+    if not isinstance(computed_values, dict):
+        raise RollbackError("computed Helm values must be a JSON object")
+    image = computed_values.get("image")
+    monitor = computed_values.get("serviceMonitor")
+    if not isinstance(image, dict) or image != {
+        "repository": release.IMAGE_REF,
+        "tag": desired_values["image"]["tag"],
+        "pullPolicy": "IfNotPresent",
+    }:
+        raise RollbackError("computed Helm values differ beyond the known pull-policy defect")
+    if not isinstance(monitor, dict) or monitor.get("relabelings") != []:
+        raise RollbackError("computed ServiceMonitor values are invalid")
+    repaired = copy.deepcopy(computed_values)
+    repaired["image"]["pullPolicy"] = "Always"
+    try:
+        release.verify_helm_stored_values(
+            approved
+            or {
+                "schemaVersion": 2,
+                "app": "dspace",
+                "applicationVersion": "3.0.1",
+                "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+                "imageTag": desired_values["image"]["tag"],
+                "imageDigest": (
+                    "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401"
+                ),
+                "semanticTag": "v3.0.1",
+                "chartSourceRevision": "62da11005354e9f9a89c2e58584cdce4c8ec35aa",
+                "chartVersion": "3.0.3",
+                "chartDigest": (
+                    "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+                ),
+                "recordType": "candidate",
+                "environment": "prod",
+                "expectedDefaultChatProvider": "openai",
+                "approvedAt": "2026-08-13T00:00:00Z",
+                "approvedBy": "pull-policy-recovery",
+            },
+            repaired,
+            "prod",
+        )
+    except release.ManifestError as exc:
+        raise RollbackError("computed Helm values violate the production contract") from exc
+
+
 def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, Any]:
     """Apply a strict reviewed chart tuple without rewriting finalized evidence."""
     if (
@@ -679,7 +804,9 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
 
 
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
-    if getattr(args, "configuration_reconciliation", False):
+    if getattr(args, "configuration_reconciliation", False) or getattr(
+        args, "pull_policy_recovery", False
+    ):
         if not args.kubeconfig or ":" in args.kubeconfig:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
@@ -708,11 +835,34 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    pull_policy_recovery = getattr(args, "pull_policy_recovery", False)
+    original_evidence: dict[str, Any] | None = None
+    original_fingerprint: str | None = None
+    if pull_policy_recovery:
+        try:
+            original_bytes = args.original_evidence.expanduser().read_bytes()
+            original_evidence = validate_failed_reconciliation_evidence(
+                json.loads(original_bytes.decode("utf-8"))
+            )
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RollbackError(
+                "original failed reconciliation evidence is missing or malformed"
+            ) from exc
+        original_fingerprint = hashlib.sha256(original_bytes).hexdigest()
+        captured = original_evidence["sugarkubeRevision"]
+        try:
+            runner(["git", "merge-base", "--is-ancestor", captured, "HEAD"])
+        except RollbackError as exc:
+            raise RollbackError(
+                "original evidence revision is not an ancestor of recovery code"
+            ) from exc
     target = baseline
-    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+    if (configuration_reconciliation or pull_policy_recovery) and getattr(
+        args, "maintenance_target", None
+    ):
         target = chart_maintenance_target(baseline, args.maintenance_target)
     image_value = target["imageTag"]
-    if not configuration_reconciliation:
+    if not configuration_reconciliation and not pull_policy_recovery:
         image_value += f"@{target['imageDigest']}"
     # The manifest module's OCI and cluster proof functions deliberately accept
     # candidate records. Project the exact candidate portion of the validated
@@ -726,7 +876,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
-    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+    if (configuration_reconciliation or pull_policy_recovery) and getattr(
+        args, "maintenance_target", None
+    ):
         configured_version = chart_pin(root / config["SUGARKUBE_VERSION_FILE"])
         if configured_version != target["chartVersion"]:
             raise RollbackError("configured production chart pin differs from maintenance target")
@@ -748,7 +900,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         args.verifier, args.environment, "dspace", "dspace", runner
     )
     verifier_manifest = args.manifest
-    if configuration_reconciliation and target is not baseline:
+    if (configuration_reconciliation or pull_policy_recovery) and target is not baseline:
         verifier_manifest = staged_directory / "approved-target.json"
         verifier_manifest.write_text(release._canonical(approved), encoding="utf-8")
         os.chmod(verifier_manifest, 0o600)
@@ -780,17 +932,20 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
         ]
     )
     before_helm, _before_history, before_identity = helm_snapshot(
         runner, args.kubeconfig, "dspace", "dspace"
     )
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
-    if configuration_reconciliation:
+    if configuration_reconciliation or pull_policy_recovery:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != baseline["helmRevision"]:
-            raise RollbackError("live Helm revision differs from finalized provenance")
+        expected_revision = 10 if pull_policy_recovery else baseline["helmRevision"]
+        if before_identity[2] != expected_revision:
+            raise RollbackError("live Helm revision differs from the required recovery state")
         runner(
             [
                 "env",
@@ -804,8 +959,17 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
+        expected_chart = (
+            target["chartVersion"] if pull_policy_recovery else baseline["chartVersion"]
+        )
+        if before_identity[:2] != ("dspace", expected_chart):
             raise RollbackError("live chart coordinate differs from finalized provenance")
+        if pull_policy_recovery:
+            description = before_helm.get("info", {}).get("description")
+            if description != (
+                "sugarkube-dspace-metrics-reconciliation:" + original_evidence["invocationId"]
+            ):
+                raise RollbackError("live Helm description is not bound to original evidence")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
         live_values = json_command(
@@ -832,6 +996,29 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             "tag": target["imageTag"],
             "pullPolicy": "Always",
         }
+        if pull_policy_recovery:
+            computed_values = json_command(
+                runner,
+                [
+                    "helm",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "values",
+                    "dspace",
+                    "--namespace",
+                    "dspace",
+                    "--all",
+                    "-o",
+                    "json",
+                ],
+                "Helm computed values",
+            )
+            validate_known_pull_policy_defect(
+                live_values, computed_values, desired_values, approved
+            )
+            if deployment_pull_policy(runner, args.kubeconfig) != "IfNotPresent":
+                raise RollbackError("deployment is not in the exact known IfNotPresent state")
         current_values_path = staged_directory / "live-values.json"
         current_values_path.write_text(release._canonical(live_values), encoding="utf-8")
         os.chmod(current_values_path, 0o600)
@@ -857,8 +1044,16 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 release.chart_coordinate(
                     {
                         **approved,
-                        "chartVersion": baseline["chartVersion"],
-                        "chartDigest": baseline["chartDigest"],
+                        "chartVersion": (
+                            target["chartVersion"]
+                            if pull_policy_recovery
+                            else baseline["chartVersion"]
+                        ),
+                        "chartDigest": (
+                            target["chartDigest"]
+                            if pull_policy_recovery
+                            else baseline["chartDigest"]
+                        ),
                     }
                 ),
                 "--namespace",
@@ -880,13 +1075,19 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 
         live_metrics = live_values.get("metrics")
         live_monitor = live_values.get("serviceMonitor")
-        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
-            None,
-            {"enabled": False},
+        if not pull_policy_recovery and (
+            live_metrics not in (None, {"enabled": False})
+            or live_monitor
+            not in (
+                None,
+                {"enabled": False},
+            )
         ):
             raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
-        if baseline != desired_baseline:
+        baseline_values, desired_baseline = configuration_comparison_baselines(
+            live_values, desired_values
+        )
+        if not pull_policy_recovery and baseline_values != desired_baseline:
             raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
@@ -917,7 +1118,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             # identities in pod evidence and recover rather than crashing.
             current_ids.clear()
             break
-    if configuration_reconciliation and (
+    if (configuration_reconciliation or pull_policy_recovery) and (
         current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
         or current_ids != {target["imageDigest"]}
     ):
@@ -945,7 +1146,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         and current_ids == {target["imageDigest"]}
     ):
         raise RollbackError("current rendered release is already the exact approved target")
-    if configuration_reconciliation:
+    if configuration_reconciliation or pull_policy_recovery:
         render_errors = app_chart.validate_rendered_manifest(
             rendered_target,
             app_chart.ReleaseInputs(
@@ -976,7 +1177,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "operation": (
-            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+            RECOVERY_OPERATION
+            if pull_policy_recovery
+            else (
+                "dspaceProductionMetricsReconciliation"
+                if configuration_reconciliation
+                else OPERATION
+            )
         ),
         "state": "reserved",
         "invocationId": invocation,
@@ -1010,20 +1217,29 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "ociPreflight": oci,
     }
+    if pull_policy_recovery:
+        evidence["originalFailedEvidence"] = {
+            "sha256": original_fingerprint,
+            "invocationId": original_evidence["invocationId"],
+        }
     reserve(args.evidence, evidence)
     mutated = False
     production_target_verified = not configuration_reconciliation
     failed_stage = "pre-mutation-revalidation"
-    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    operation = (
+        "metrics-pull-policy-recovery"
+        if pull_policy_recovery
+        else ("metrics-reconciliation" if configuration_reconciliation else "manifest-rollback")
+    )
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
-        if configuration_reconciliation:
+        if configuration_reconciliation or pull_policy_recovery:
             production_target_verified = False
             assert_production_target(args.kubeconfig, runner)
             production_target_verified = True
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
-        if configuration_reconciliation:
+        if configuration_reconciliation or pull_policy_recovery:
             _current_status, _current_history, current_identity = helm_snapshot(
                 runner, args.kubeconfig, "dspace", "dspace"
             )
@@ -1050,6 +1266,11 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             )
             if current_values != live_values:
                 raise RollbackError("Helm values changed before mutation")
+            if (
+                pull_policy_recovery
+                and deployment_pull_policy(runner, args.kubeconfig) != "IfNotPresent"
+            ):
+                raise RollbackError("deployment pull policy changed before mutation")
             runner(
                 [
                     "env",
@@ -1082,6 +1303,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            "--set-string",
+            "image.pullPolicy=Always",
             "--wait",
             "--timeout",
             args.timeout,
@@ -1127,27 +1350,35 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if configuration_reconciliation and after_revision != before_identity[2] + 1:
+        if (
+            configuration_reconciliation or pull_policy_recovery
+        ) and after_revision != before_identity[2] + 1:
             raise RollbackError("Helm revision did not advance exactly once")
         if not configuration_reconciliation and after_revision <= before_identity[2]:
             raise RollbackError("Helm revision did not advance")
         if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
-        changed = configuration_reconciliation or (
-            before_identity[1] != target["chartVersion"]
-            or current_ids != {target["imageDigest"]}
-            or current_images
-            != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
+        changed = (
+            configuration_reconciliation
+            or pull_policy_recovery
+            or (
+                before_identity[1] != target["chartVersion"]
+                or current_ids != {target["imageDigest"]}
+                or current_images
+                != {f"{release.IMAGE_REF}:{target['imageTag']}@{target['imageDigest']}"}
+            )
         )
         verify_post_pods(
             after_pods,
             before_pods,
             target,
             changed,
-            retain_tag=configuration_reconciliation,
+            retain_tag=configuration_reconciliation or pull_policy_recovery,
         )
-        if configuration_reconciliation and len(after_pods) != 2:
+        if (configuration_reconciliation or pull_policy_recovery) and len(after_pods) != 2:
             raise RollbackError("reconciliation did not produce exactly two Ready DSPACE pods")
+        if pull_policy_recovery and deployment_pull_policy(runner, args.kubeconfig) != "Always":
+            raise RollbackError("recovery did not set deployment pull policy to Always")
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
         failed_stage = "ownership-and-finalization-proof"
         workloads = json_command(
@@ -1257,7 +1488,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
         )
-        if configuration_reconciliation:
+        if configuration_reconciliation or pull_policy_recovery:
             failed_stage = "production-metrics-verification"
             runner(
                 [
@@ -1314,7 +1545,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                             "unauthenticatedStatus": 401,
                         },
                     }
-                    if configuration_reconciliation
+                    if configuration_reconciliation or pull_policy_recovery
                     else {}
                 ),
             },
@@ -1381,25 +1612,36 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--pull-policy-recovery", action="store_true")
+    parser.add_argument("--original-evidence", type=Path)
     args = parser.parse_args(argv)
-    if args.configuration_reconciliation:
+    if args.configuration_reconciliation and args.pull_policy_recovery:
+        parser.error("reconciliation and pull-policy recovery are separate operations")
+    if args.configuration_reconciliation or args.pull_policy_recovery:
         if (
             args.manifest is not None
             or args.baseline_manifest is None
             or args.maintenance_target is None
+            or (args.pull_policy_recovery and args.original_evidence is None)
+            or (args.configuration_reconciliation and args.original_evidence is not None)
         ):
             parser.error(
-                "configuration reconciliation requires --baseline-manifest and "
-                "--maintenance-target, not --manifest"
+                "configuration operation requires its original evidence (recovery only), "
+                "--baseline-manifest, and --maintenance-target, not --manifest"
             )
         args.manifest = args.baseline_manifest
     elif (
         args.manifest is None
         or args.baseline_manifest is not None
         or args.maintenance_target is not None
+        or args.original_evidence is not None
     ):
         parser.error("rollback requires --manifest and does not accept maintenance coordinates")
-    if args.kubeconfig is None and not args.configuration_reconciliation:
+    if (
+        args.kubeconfig is None
+        and not args.configuration_reconciliation
+        and not args.pull_policy_recovery
+    ):
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:
         rollback(args)

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -938,9 +938,15 @@ def verify_helm_stored_values(
             "additionalLabels": {"release": "kube-prometheus-stack"},
             "cluster": "sugarkube-prod",
         }
+        actual_monitor = stored_values.get("serviceMonitor")
+        # `helm get values --all` includes this immutable chart default, while
+        # user-supplied values omit it. Both representations are exact.
+        if isinstance(actual_monitor, dict) and actual_monitor.get("relabelings") == []:
+            actual_monitor = dict(actual_monitor)
+            actual_monitor.pop("relabelings")
         if (
             stored_values.get("metrics") != expected_metrics
-            or stored_values.get("serviceMonitor") != expected_monitor
+            or actual_monitor != expected_monitor
             or contains_staging_reference(stored_values)
             or contains_inline_credential(
                 {

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1503,6 +1503,13 @@ def test_configuration_reconciliation_completes_all_production_gates(
     assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
+    assert "image.pullPolicy=Always" in upgrade
+    target_template = next(
+        command
+        for command in commands
+        if "template" in command and f"@{selected['chartDigest']}" in " ".join(command)
+    )
+    assert "image.pullPolicy=Always" in target_template
     forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
     assert not any(item in upgrade for item in forbidden)
     assert selected["imageDigest"] not in next(
@@ -1788,3 +1795,42 @@ def test_orchestration_preserves_complete_success_and_failure_evidence(
     assert written["targetManifestFingerprint"] == result["targetManifestFingerprint"]
     assert written["helm"]["beforeRevision"] == 7
     assert written["helm"]["afterRevision"] == 8
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("state", "reserved"),
+        ("operation", "wrong"),
+        ("failedStage", "wrong"),
+        ("failureCode", "wrong"),
+        ("clusterMayHaveChanged", False),
+    ],
+)
+def test_pull_policy_recovery_rejects_wrong_original_failure(field: str, value: object) -> None:
+    evidence = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+        "invocationId": "a" * 32,
+        "sugarkubeRevision": "b" * 40,
+        "before": {"helmRevision": 9, "chartName": "dspace", "chartVersion": "3.0.2"},
+        "target": {
+            "chartVersion": "3.0.3",
+            "chartDigest": (
+                "sha256:6ee663c426673bc0e516ed8f8b0ab11a918d2f2bb81fc9047b3eb37b78329f5c"
+            ),
+            "applicationVersion": "3.0.1",
+            "sourceRevision": "1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+            "imageTag": "main-1a31a56",
+            "imageDigest": (
+                "sha256:23dbc573377549136c1f10b05706b3c176ffbabaf04a3194381a24752104a401"
+            ),
+            "expectedDefaultChatProvider": "openai",
+        },
+    }
+    evidence[field] = value
+    with pytest.raises(rollback.RollbackError, match="approved failed reconciliation"):
+        rollback.validate_failed_reconciliation_evidence(evidence)

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -722,6 +722,7 @@ def test_committed_production_values_pass_stored_values_contract() -> None:
 def test_helm_stored_values_accept_chart_defaults_and_safe_references() -> None:
     value = split_candidate("prod")
     stored = production_stored_values()
+    stored["serviceMonitor"]["relabelings"] = []
     stored["env"] = [
         {
             "name": "METRICS_TOKEN",


### PR DESCRIPTION
### Motivation

- Fix the reconciliation mismatch where Helm upgraded to chart 3.0.3 but the guarded render/upgrade did not pass `image.pullPolicy=Always`, causing verify/ownership proof to fail.
- Provide a narrowly scoped, fail-closed recovery that can repair only the exact known revision-9 → revision-10 pull-policy defect without weakening any validators or changing chart/image coordinates.

### Description

- Ensure all guarded digest-qualified `helm template` and `helm upgrade` invocations explicitly set `--set-string image.pullPolicy=Always` for the normal reconciliation path and the recovery mutation. (scripts/dspace_manifest_rollback.py)
- Add a dedicated, fail-closed recovery mode and CLI flag (`--pull-policy-recovery` plus `--original-evidence`) which strictly validates the original failed evidence, live Helm revision/description, user/computed Helm values, ServiceMonitor defaults (`relabelings: []`), Deployment pull policy, pod readiness/count/digest, and OCI provenance before performing exactly one guarded upgrade advancing revision 10 → 11. (scripts/dspace_manifest_rollback.py)
- Add a helper that accepts the exact original-failure contract and rejects any mismatch to ensure recovery preflight only accepts the single approved failure. (scripts/dspace_manifest_rollback.py)
- Accept the chart-default `serviceMonitor.relabelings: []` representation when verifying stored Helm values so the stored-values check is compatible with `helm get values --all`. (scripts/dspace_release_manifest.py)
- Add an operator `just` recipe `dspace-prod-metrics-pull-policy-recover` and document the guarded recovery invocation and constraints in the DSPACE runbook. (justfile, docs/apps/dspace.md)
- Add focused tests for the new validation logic and ensure normal reconciliation template/upgrade include the `image.pullPolicy=Always` set. (tests/test_manifest_rollback.py, tests/test_release_manifest.py)

Files changed: scripts/dspace_manifest_rollback.py, scripts/dspace_release_manifest.py, justfile, docs/apps/dspace.md, tests/test_manifest_rollback.py, tests/test_release_manifest.py.

### Testing

- Ran targeted compilation and validators: `python3 -m compileall scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py` and `python3 scripts/observability_app_metrics.py validate`, both succeeded.
- Ran the focused pytest selection: `pytest -q tests/test_manifest_rollback.py tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py` and the relevant tests passed (focused runs reported all exercised tests passing; full selected test files passed in CI-like runs with 797 passed and 1 warning observed in this environment).
- Confirmed the new unit tests exercising the recovery validators passed: `test_pull_policy_recovery_*` tests and stored-values compatibility tests passed.
- Ran `linkchecker --no-warnings README.md docs/` successfully; `pyspelling -c .spellcheck.yaml` could not complete because the environment lacks the `aspell` binary; repository-wide `pre-commit run --all-files` required environment setup and surfaced unrelated existing repository lint checks (not caused by this change).

If reviewers want, the exact guarded operator command for recovery is shown in the amended DSPACE docs and the new `just` recipe `dspace-prod-metrics-pull-policy-recover` (requires `original_evidence`, `baseline_manifest`, `maintenance_target`, `evidence`, `smoke_runner`, `kubeconfig`, and `confirm`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e2b370a90832f99acf88a91798651)