### PR TITLE
dspace: set image.pullPolicy=Always in guarded reconciliations and add narrow pull-policy recovery

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -40,6 +40,34 @@ Any failure after reservation preserves failed evidence. Review that evidence an
 before any further mutation; never automatically rerun, uninstall, roll back, delete, or rotate the
 Secret.
 
+### Pull-policy recovery for the failed revision-10 transition
+
+The normal reconciliation above remains bound to the finalized revision-9/chart-3.0.2 baseline and
+must not be rerun after Helm has advanced. After this change is independently reviewed and merged,
+the operator may use the separate recovery operation for the single known revision-10/chart-3.0.3
+state whose invocation-bound reconciliation failed only because the computed pull policy was
+`IfNotPresent`:
+
+```bash
+just dspace-prod-metrics-pull-policy-recover \
+  original_evidence=/home/pi/operator-evidence/dspace-prod-metrics-reconcile-20260813T072927Z/reconciliation.json \
+  baseline_manifest=deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json \
+  maintenance_target=docs/apps/dspace.prod-metrics-chart-target.json \
+  evidence="$FRESH_NONEXISTING_RECOVERY_EVIDENCE" \
+  smoke_runner="$DSPACE_SMOKE_RUNNER" \
+  kubeconfig="$HOME/.kube/config-sugarkube-prod" \
+  confirm="dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+```
+
+Preflight binds the live Helm description to the failed evidence, verifies its immutable SHA-256,
+requires exactly revision 10/chart 3.0.3 with the approved image digest and the sole
+`IfNotPresent` defect, and reuses the strict production metrics, ServiceMonitor, runtime, OCI, and
+finalization contracts. The only mutation is one digest-qualified Helm upgrade with the complete
+committed values chain and explicit `image.pullPolicy=Always`, advancing exactly from revision 10
+to 11. An already repaired or otherwise drifted release fails closed. After evidence reservation,
+any failure retains sanitized failed evidence and never triggers a retry, rollback, uninstall, or
+Secret mutation.
+
 ## Production Helm reconciliation for application 3.0.1
 
 This section **prepares but does not execute** the incident reconciliation tracked by

--- a/justfile
+++ b/justfile
@@ -1862,6 +1862,37 @@ dspace-prod-metrics-reconcile baseline_manifest maintenance_target evidence smok
     )
     "${reconciliation_command[@]}"
 
+# One-shot fix-forward for the invocation-bound revision-10 DSPACE pull-policy failure.
+dspace-prod-metrics-pull-policy-recover original_evidence baseline_manifest maintenance_target evidence smoke_runner kubeconfig verifier="{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" confirm='' config='':
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    original={{ quote(original_evidence) }}
+    baseline={{ quote(baseline_manifest) }}
+    target={{ quote(maintenance_target) }}
+    recovery={{ quote(evidence) }}
+    smoke={{ quote(smoke_runner) }}
+    kube={{ quote(kubeconfig) }}
+    verifier_path={{ quote(verifier) }}
+    confirmation={{ quote(confirm) }}
+    config_path={{ quote(config) }}
+    for binding in original_evidence:"${original}" baseline_manifest:"${baseline}" maintenance_target:"${target}" evidence:"${recovery}" smoke_runner:"${smoke}" kubeconfig:"${kube}"; do
+      name="${binding%%:*}"; value="${binding#*:}"
+      value="${value#${name}=}"
+      [ -n "${value}" ] || { echo "ERROR: ${name} must not be empty." >&2; exit 2; }
+      printf -v "${name}" '%s' "${value}"
+    done
+    verifier_path="${verifier_path#verifier=}"
+    confirmation="${confirmation#confirm=}"
+    config_path="${config_path#config=}"
+    exec python3 "{{ justfile_directory() }}/scripts/dspace_manifest_rollback.py" \
+      --pull-policy-recovery --environment prod \
+      --original-evidence "${original_evidence}" \
+      --baseline-manifest "${baseline_manifest}" \
+      --maintenance-target "${maintenance_target}" \
+      --evidence "${evidence}" --smoke-runner "${smoke_runner}" \
+      --kubeconfig "${kubeconfig}" --verifier "${verifier_path}" \
+      --confirm "${confirmation}" --config "${config_path}"
+
 # Read-only DSPACE runtime, frontend, replica, and remote /chat proof.
 dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected_helm_revision='':
     #!/usr/bin/env bash

--- a/scripts/dspace_manifest_rollback.py
+++ b/scripts/dspace_manifest_rollback.py
@@ -23,8 +23,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import app_config  # noqa: E402
 from scripts import app_chart  # noqa: E402
+from scripts import app_config  # noqa: E402
 from scripts import dspace_release_manifest as release  # noqa: E402
 
 SCHEMA_VERSION = 1
@@ -678,8 +678,104 @@ def chart_maintenance_target(baseline: dict[str, Any], path: Path) -> dict[str, 
     return target
 
 
+def validate_pull_policy_recovery_evidence(
+    path: Path,
+    baseline: dict[str, Any],
+    target: dict[str, Any],
+    live_helm: dict[str, Any],
+    runner: Runner,
+) -> dict[str, Any]:
+    """Bind recovery to the one known failed revision-9 to revision-10 transition."""
+    try:
+        evidence = release._object(path.expanduser())
+    except (OSError, release.ManifestError) as exc:
+        raise RollbackError(f"original failed reconciliation evidence is invalid: {exc}") from exc
+    required = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+    }
+    if any(evidence.get(key) != value for key, value in required.items()):
+        raise RollbackError("original evidence is not the confirmed failed reconciliation")
+    before = evidence.get("before")
+    recorded_target = evidence.get("target")
+    if not isinstance(before, dict) or not isinstance(recorded_target, dict):
+        raise RollbackError("original evidence does not contain bounded transition coordinates")
+    if (before.get("helmRevision"), before.get("chartVersion")) != (9, "3.0.2"):
+        raise RollbackError("original evidence before coordinate is not revision 9/chart 3.0.2")
+    expected_target = {
+        key: target[key]
+        for key in (
+            "chartVersion",
+            "chartDigest",
+            "imageTag",
+            "imageDigest",
+            "sourceRevision",
+            "chartSourceRevision",
+            "applicationVersion",
+            "expectedDefaultChatProvider",
+        )
+    }
+    if recorded_target != expected_target:
+        raise RollbackError("original evidence target is not the immutable chart 3.0.3 tuple")
+    invocation = evidence.get("invocationId")
+    if not isinstance(invocation, str) or not re.fullmatch(r"[0-9a-f]{32}", invocation):
+        raise RollbackError("original evidence invocation ID is invalid")
+    if live_helm.get("info", {}).get("description") != (
+        f"sugarkube-dspace-metrics-reconciliation:{invocation}"
+    ):
+        raise RollbackError("live Helm description is not bound to the failed invocation")
+    revision = evidence.get("sugarkubeRevision")
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise RollbackError("original evidence Sugarkube revision is invalid")
+    try:
+        runner(["git", "merge-base", "--is-ancestor", revision, "HEAD"])
+    except Exception as exc:
+        raise RollbackError(
+            "original evidence revision is not an ancestor of this recovery"
+        ) from exc
+    return evidence
+
+
+def verify_resource_pull_policy(
+    workloads: dict[str, Any], pod_list: dict[str, Any], expected: str
+) -> None:
+    """Require the Deployment template and every serving pod to use one policy."""
+    deployments = [
+        item
+        for item in workloads.get("items", [])
+        if isinstance(item, dict) and item.get("kind") == "Deployment"
+    ]
+    if len(deployments) != 1:
+        raise RollbackError("recovery requires exactly one DSPACE Deployment")
+
+    def policy(item: dict[str, Any], *, template: bool) -> str | None:
+        spec = item.get("spec", {})
+        if template:
+            spec = spec.get("template", {}).get("spec", {})
+        containers = [
+            container
+            for container in spec.get("containers", [])
+            if isinstance(container, dict) and container.get("name") == "dspace"
+        ]
+        return containers[0].get("imagePullPolicy") if len(containers) == 1 else None
+
+    if policy(deployments[0], template=True) != expected:
+        raise RollbackError("DSPACE Deployment pull policy does not match recovery state")
+    pods_items = pod_list.get("items", [])
+    if len(pods_items) != 2 or any(
+        not isinstance(item, dict) or policy(item, template=False) != expected
+        for item in pods_items
+    ):
+        raise RollbackError("DSPACE pod pull policies do not match recovery state")
+
+
 def rollback(args: argparse.Namespace, runner: Runner = run) -> dict[str, Any]:
-    if getattr(args, "configuration_reconciliation", False):
+    if getattr(args, "configuration_reconciliation", False) or getattr(
+        args, "pull_policy_recovery", False
+    ):
         if not args.kubeconfig or ":" in args.kubeconfig:
             raise RollbackError(
                 "metrics configuration reconciliation requires one explicit absolute kubeconfig"
@@ -707,12 +803,15 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError(f"target must be finalized DSPACE release evidence: {exc}") from exc
     if baseline["environment"] != args.environment:
         raise RollbackError("target manifest environment does not match selected environment")
+    pull_policy_recovery = getattr(args, "pull_policy_recovery", False)
     configuration_reconciliation = getattr(args, "configuration_reconciliation", False)
+    production_reconciliation = configuration_reconciliation or pull_policy_recovery
+    original_failure: dict[str, Any] | None = None
     target = baseline
-    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+    if production_reconciliation and getattr(args, "maintenance_target", None):
         target = chart_maintenance_target(baseline, args.maintenance_target)
     image_value = target["imageTag"]
-    if not configuration_reconciliation:
+    if not production_reconciliation:
         image_value += f"@{target['imageDigest']}"
     # The manifest module's OCI and cluster proof functions deliberately accept
     # candidate records. Project the exact candidate portion of the validated
@@ -726,7 +825,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("DSPACE config chart repository is not canonical")
     if config["SUGARKUBE_RELEASE"] != "dspace" or config["SUGARKUBE_NAMESPACE"] != "dspace":
         raise RollbackError("DSPACE release and namespace must both be dspace")
-    if configuration_reconciliation and getattr(args, "maintenance_target", None):
+    if production_reconciliation and getattr(args, "maintenance_target", None):
         configured_version = chart_pin(root / config["SUGARKUBE_VERSION_FILE"])
         if configured_version != target["chartVersion"]:
             raise RollbackError("configured production chart pin differs from maintenance target")
@@ -748,7 +847,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         args.verifier, args.environment, "dspace", "dspace", runner
     )
     verifier_manifest = args.manifest
-    if configuration_reconciliation and target is not baseline:
+    if production_reconciliation and target is not baseline:
         verifier_manifest = staged_directory / "approved-target.json"
         verifier_manifest.write_text(release._canonical(approved), encoding="utf-8")
         os.chmod(verifier_manifest, 0o600)
@@ -765,6 +864,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         raise RollbackError("repository runtime verifier rejected its required arguments")
     coordinate = release.chart_coordinate(approved)
     helm_values = [part for path in values for part in ("--values", str(path))]
+    pull_policy_args = (
+        ["--set-string", "image.pullPolicy=Always"] if production_reconciliation else []
+    )
     rendered_target = runner(
         [
             "helm",
@@ -780,16 +882,18 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            *pull_policy_args,
         ]
     )
     before_helm, _before_history, before_identity = helm_snapshot(
         runner, args.kubeconfig, "dspace", "dspace"
     )
     before_pods = pods(runner, args.kubeconfig, "dspace", "dspace", require_any=False)
-    if configuration_reconciliation:
+    if production_reconciliation:
         if args.environment != "prod":
             raise RollbackError("metrics configuration reconciliation is production-only")
-        if before_identity[2] != baseline["helmRevision"]:
+        expected_before_revision = 10 if pull_policy_recovery else baseline["helmRevision"]
+        if before_identity[2] != expected_before_revision:
             raise RollbackError("live Helm revision differs from finalized provenance")
         runner(
             [
@@ -804,7 +908,10 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 "prod",
             ]
         )
-        if before_identity[:2] != ("dspace", baseline["chartVersion"]):
+        expected_before_chart = (
+            target["chartVersion"] if pull_policy_recovery else baseline["chartVersion"]
+        )
+        if before_identity[:2] != ("dspace", expected_before_chart):
             raise RollbackError("live chart coordinate differs from finalized provenance")
         if len(before_pods) != 2 or any(not pod.get("ready") for pod in before_pods):
             raise RollbackError("live release must have exactly two Ready DSPACE pods")
@@ -857,8 +964,16 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                 release.chart_coordinate(
                     {
                         **approved,
-                        "chartVersion": baseline["chartVersion"],
-                        "chartDigest": baseline["chartDigest"],
+                        "chartVersion": (
+                            target["chartVersion"]
+                            if pull_policy_recovery
+                            else baseline["chartVersion"]
+                        ),
+                        "chartDigest": (
+                            target["chartDigest"]
+                            if pull_policy_recovery
+                            else baseline["chartDigest"]
+                        ),
                     }
                 ),
                 "--namespace",
@@ -880,14 +995,105 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
 
         live_metrics = live_values.get("metrics")
         live_monitor = live_values.get("serviceMonitor")
-        if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
-            None,
-            {"enabled": False},
-        ):
-            raise RollbackError("live metrics values are not the approved disabled baseline")
-        baseline, desired_baseline = configuration_comparison_baselines(live_values, desired_values)
-        if baseline != desired_baseline:
-            raise RollbackError("unrelated Helm values drift blocks configuration reconciliation")
+        if pull_policy_recovery:
+            original_failure = validate_pull_policy_recovery_evidence(
+                args.original_evidence, baseline, target, before_helm, runner
+            )
+            expected_user_values = copy.deepcopy(desired_values)
+            expected_user_values["image"].pop("pullPolicy")
+            if live_values != expected_user_values:
+                raise RollbackError("live user-supplied Helm values differ from failed revision 10")
+            computed_values = json_command(
+                runner,
+                [
+                    "helm",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "values",
+                    "dspace",
+                    "--namespace",
+                    "dspace",
+                    "--all",
+                    "-o",
+                    "json",
+                ],
+                "Helm computed values",
+            )
+            image = computed_values.get("image")
+            if not isinstance(image, dict) or image.get("pullPolicy") != "IfNotPresent":
+                raise RollbackError("recovery requires the exact unrepaired IfNotPresent state")
+            if computed_values.get("serviceMonitor", {}).get("relabelings") != []:
+                raise RollbackError("computed ServiceMonitor chart defaults have drifted")
+            repaired_values = copy.deepcopy(computed_values)
+            repaired_values["image"]["pullPolicy"] = "Always"
+            try:
+                release.verify_helm_stored_values(approved, repaired_values, "prod")
+            except release.ManifestError as exc:
+                raise RollbackError(
+                    "computed values have drift beyond the pull-policy defect"
+                ) from exc
+            recovery_workloads = json_command(
+                runner,
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "deployments",
+                    "--namespace",
+                    "dspace",
+                    "-l",
+                    "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                    "-o",
+                    "json",
+                ],
+                "DSPACE recovery Deployment",
+            )
+            recovery_pods = json_command(
+                runner,
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    args.kubeconfig,
+                    "get",
+                    "pods",
+                    "--namespace",
+                    "dspace",
+                    "-l",
+                    "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                    "-o",
+                    "json",
+                ],
+                "DSPACE recovery pods",
+            )
+            verify_resource_pull_policy(recovery_workloads, recovery_pods, "IfNotPresent")
+            runner(
+                [
+                    "env",
+                    f"KUBECONFIG={args.kubeconfig}",
+                    sys.executable,
+                    str(REPO_ROOT / "scripts" / "observability_app_metrics.py"),
+                    "verify",
+                    "--app",
+                    "dspace",
+                    "--env",
+                    "prod",
+                ]
+            )
+        else:
+            if live_metrics not in (None, {"enabled": False}) or live_monitor not in (
+                None,
+                {"enabled": False},
+            ):
+                raise RollbackError("live metrics values are not the approved disabled baseline")
+            baseline_values, desired_baseline = configuration_comparison_baselines(
+                live_values, desired_values
+            )
+            if baseline_values != desired_baseline:
+                raise RollbackError(
+                    "unrelated Helm values drift blocks configuration reconciliation"
+                )
     # Keep the registry proof fresh: no tag resolution occurs between this
     # exact-digest check and confirmation/reservation/mutation.
     try:
@@ -917,7 +1123,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             # identities in pod evidence and recover rather than crashing.
             current_ids.clear()
             break
-    if configuration_reconciliation and (
+    if production_reconciliation and (
         current_images != {f"{release.IMAGE_REF}:{target['imageTag']}"}
         or current_ids != {target["imageDigest"]}
     ):
@@ -945,7 +1151,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         and current_ids == {target["imageDigest"]}
     ):
         raise RollbackError("current rendered release is already the exact approved target")
-    if configuration_reconciliation:
+    if production_reconciliation:
         render_errors = app_chart.validate_rendered_manifest(
             rendered_target,
             app_chart.ReleaseInputs(
@@ -976,7 +1182,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
     evidence: dict[str, Any] = {
         "schemaVersion": SCHEMA_VERSION,
         "operation": (
-            "dspaceProductionMetricsReconciliation" if configuration_reconciliation else OPERATION
+            "dspaceProductionMetricsPullPolicyRecovery"
+            if pull_policy_recovery
+            else (
+                "dspaceProductionMetricsReconciliation"
+                if configuration_reconciliation
+                else OPERATION
+            )
         ),
         "state": "reserved",
         "invocationId": invocation,
@@ -1010,21 +1222,31 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         },
         "ociPreflight": oci,
     }
+    if original_failure is not None:
+        original_bytes = args.original_evidence.expanduser().read_bytes()
+        evidence["originalFailure"] = {
+            "sha256": hashlib.sha256(original_bytes).hexdigest(),
+            "invocationId": original_failure["invocationId"],
+        }
     reserve(args.evidence, evidence)
     mutated = False
-    production_target_verified = not configuration_reconciliation
+    production_target_verified = not production_reconciliation
     failed_stage = "pre-mutation-revalidation"
-    operation = "metrics-reconciliation" if configuration_reconciliation else "manifest-rollback"
+    operation = (
+        "metrics-pull-policy-recovery"
+        if pull_policy_recovery
+        else ("metrics-reconciliation" if configuration_reconciliation else "manifest-rollback")
+    )
     description = f"sugarkube-dspace-{operation}:{invocation}"
     try:
-        if configuration_reconciliation:
+        if production_reconciliation:
             production_target_verified = False
             assert_production_target(args.kubeconfig, runner)
             production_target_verified = True
         if runner(["git", "rev-parse", "HEAD"]).strip() != sugarkube_revision:
             raise RollbackError("Sugarkube revision changed before mutation")
-        if configuration_reconciliation:
-            _current_status, _current_history, current_identity = helm_snapshot(
+        if production_reconciliation:
+            current_status, _current_history, current_identity = helm_snapshot(
                 runner, args.kubeconfig, "dspace", "dspace"
             )
             if current_identity != before_identity:
@@ -1050,6 +1272,68 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             )
             if current_values != live_values:
                 raise RollbackError("Helm values changed before mutation")
+            if pull_policy_recovery:
+                validate_pull_policy_recovery_evidence(
+                    args.original_evidence, baseline, target, current_status, runner
+                )
+                current_computed_values = json_command(
+                    runner,
+                    [
+                        "helm",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "get",
+                        "values",
+                        "dspace",
+                        "--namespace",
+                        "dspace",
+                        "--all",
+                        "-o",
+                        "json",
+                    ],
+                    "Helm computed values",
+                )
+                if current_computed_values != computed_values:
+                    raise RollbackError("Helm computed values changed before mutation")
+                current_recovery_workloads = json_command(
+                    runner,
+                    [
+                        "kubectl",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "get",
+                        "deployments",
+                        "--namespace",
+                        "dspace",
+                        "-l",
+                        "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                        "-o",
+                        "json",
+                    ],
+                    "DSPACE recovery Deployment",
+                )
+                current_recovery_pods = json_command(
+                    runner,
+                    [
+                        "kubectl",
+                        "--kubeconfig",
+                        args.kubeconfig,
+                        "get",
+                        "pods",
+                        "--namespace",
+                        "dspace",
+                        "-l",
+                        "app.kubernetes.io/name=dspace,app.kubernetes.io/instance=dspace",
+                        "-o",
+                        "json",
+                    ],
+                    "DSPACE recovery pods",
+                )
+                if (current_recovery_workloads, current_recovery_pods) != (
+                    recovery_workloads,
+                    recovery_pods,
+                ):
+                    raise RollbackError("DSPACE resources changed before mutation")
             runner(
                 [
                     "env",
@@ -1082,6 +1366,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             f"image.repository={release.IMAGE_REF}",
             "--set-string",
             f"image.tag={image_value}",
+            *pull_policy_args,
             "--wait",
             "--timeout",
             args.timeout,
@@ -1127,13 +1412,13 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             raise RollbackError("Helm did not report the expected deployed release")
         if after_helm.get("info", {}).get("description") != description:
             raise RollbackError("Helm release description is not bound to this invocation")
-        if configuration_reconciliation and after_revision != before_identity[2] + 1:
+        if production_reconciliation and after_revision != before_identity[2] + 1:
             raise RollbackError("Helm revision did not advance exactly once")
-        if not configuration_reconciliation and after_revision <= before_identity[2]:
+        if not production_reconciliation and after_revision <= before_identity[2]:
             raise RollbackError("Helm revision did not advance")
         if after_identity[0] != "dspace" or after_identity[1] != target["chartVersion"]:
             raise RollbackError("installed chart name/version does not match target")
-        changed = configuration_reconciliation or (
+        changed = production_reconciliation or (
             before_identity[1] != target["chartVersion"]
             or current_ids != {target["imageDigest"]}
             or current_images
@@ -1144,9 +1429,9 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             before_pods,
             target,
             changed,
-            retain_tag=configuration_reconciliation,
+            retain_tag=production_reconciliation,
         )
-        if configuration_reconciliation and len(after_pods) != 2:
+        if production_reconciliation and len(after_pods) != 2:
             raise RollbackError("reconciliation did not produce exactly two Ready DSPACE pods")
         # Reuse finalization's strict Deployment/ReplicaSet ownership validator.
         failed_stage = "ownership-and-finalization-proof"
@@ -1184,6 +1469,8 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
             ],
             "DSPACE pods",
         )
+        if pull_policy_recovery:
+            verify_resource_pull_policy(workloads, raw_pods, "Always")
         helm_stored_values_result = None
         if approved["schemaVersion"] == 2:
             stored_values = json_command(
@@ -1257,7 +1544,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
         verifier = validate_verifier_result(
             json_command(runner, verifier_command, "runtime verifier"), target, args.environment
         )
-        if configuration_reconciliation:
+        if production_reconciliation:
             failed_stage = "production-metrics-verification"
             runner(
                 [
@@ -1314,7 +1601,7 @@ def _rollback(args: argparse.Namespace, runner: Runner, staged_directory: Path) 
                             "unauthenticatedStatus": 401,
                         },
                     }
-                    if configuration_reconciliation
+                    if production_reconciliation
                     else {}
                 ),
             },
@@ -1381,8 +1668,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--oras", default=os.environ.get("SUGARKUBE_ORAS_COMMAND", "oras"))
     parser.add_argument("--timeout", default="10m")
     parser.add_argument("--configuration-reconciliation", action="store_true")
+    parser.add_argument("--pull-policy-recovery", action="store_true")
+    parser.add_argument("--original-evidence", type=Path)
     args = parser.parse_args(argv)
-    if args.configuration_reconciliation:
+    if args.configuration_reconciliation and args.pull_policy_recovery:
+        parser.error("select exactly one reconciliation operation")
+    if args.configuration_reconciliation or args.pull_policy_recovery:
         if (
             args.manifest is not None
             or args.baseline_manifest is None
@@ -1392,6 +1683,10 @@ def main(argv: list[str] | None = None) -> int:
                 "configuration reconciliation requires --baseline-manifest and "
                 "--maintenance-target, not --manifest"
             )
+        if args.pull_policy_recovery and args.original_evidence is None:
+            parser.error("pull-policy recovery requires --original-evidence")
+        if args.configuration_reconciliation and args.original_evidence is not None:
+            parser.error("normal reconciliation does not accept --original-evidence")
         args.manifest = args.baseline_manifest
     elif (
         args.manifest is None
@@ -1399,7 +1694,9 @@ def main(argv: list[str] | None = None) -> int:
         or args.maintenance_target is not None
     ):
         parser.error("rollback requires --manifest and does not accept maintenance coordinates")
-    if args.kubeconfig is None and not args.configuration_reconciliation:
+    if args.kubeconfig is None and not (
+        args.configuration_reconciliation or args.pull_policy_recovery
+    ):
         args.kubeconfig = str(Path.home() / ".kube" / "config-sugarkube")
     try:
         rollback(args)

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3011,6 +3011,35 @@ def _run_dspace_prod_metrics_reconcile(
 
 
 @pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_pull_policy_recovery_exposes_separate_guarded_interface(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "recovery-bin"
+    bin_dir.mkdir()
+    log = tmp_path / "argv.log"
+    _write_executable(
+        bin_dir / "python3",
+        f"#!/bin/sh\nprintf '%s\\n' \"$@\" > {str(log)!r}\n",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    values = [
+        "original_evidence=/evidence/original-failed.json",
+        "baseline_manifest=/evidence/finalized-3.0.2.json",
+        "maintenance_target=/reviewed/chart-3.0.3.json",
+        "evidence=/evidence/fresh-recovery.json",
+        "smoke_runner=/tools/remote-chat-smoke",
+        "kubeconfig=/kube/production",
+        "verifier=/tools/runtime-verifier",
+        "confirm=dspace:prod:1a31a569aff2dbeb238e8c2688b9e85140d2077d",
+    ]
+    result = _run_just(["dspace-prod-metrics-pull-policy-recover", *values], env)
+    argv = log.read_text(encoding="utf-8").splitlines()
+    assert result.returncode == 0, result.stderr
+    assert "--pull-policy-recovery" in argv
+    assert "--configuration-reconciliation" not in argv
+    assert argv[argv.index("--original-evidence") + 1] == "/evidence/original-failed.json"
+
+
+@pytest.mark.usefixtures("ensure_just_available")
 def test_dspace_prod_metrics_reconcile_normalizes_documented_and_positional_forms(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_manifest_rollback.py
+++ b/tests/test_manifest_rollback.py
@@ -1499,10 +1499,19 @@ def test_configuration_reconciliation_completes_all_production_gates(
     result = rollback.rollback(args, runner)
 
     upgrade = next(command for command in commands if "upgrade" in command)
+    target_render = next(
+        command
+        for command in commands
+        if command[0] == "helm"
+        and "template" in command
+        and "live-values.json" not in " ".join(command)
+    )
     assert sum("upgrade" in command for command in commands) == 1
     assert upgrade[upgrade.index("--kubeconfig") + 1] == str(kubeconfig)
     assert f"oci://{manifest.CHART_REF}@{selected['chartDigest']}" in upgrade
     assert f"image.tag={selected['imageTag']}" in upgrade
+    assert "image.pullPolicy=Always" in upgrade
+    assert "image.pullPolicy=Always" in target_render
     forbidden = ("--reuse-values", "--version", selected["semanticTag"], "rollback")
     assert not any(item in upgrade for item in forbidden)
     assert selected["imageDigest"] not in next(
@@ -1552,6 +1561,85 @@ def test_configuration_reconciliation_completes_all_production_gates(
         command for command in commands if command[:2] == [str(verifier), "verify"]
     )
     assert verifier_command[verifier_command.index("--manifest") + 1] != str(args.manifest)
+
+
+def test_pull_policy_recovery_evidence_binds_exact_failed_transition(tmp_path: Path) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    target = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    invocation = "a" * 32
+    evidence = {
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+        "invocationId": invocation,
+        "sugarkubeRevision": "b" * 40,
+        "before": {"helmRevision": 9, "chartVersion": "3.0.2"},
+        "target": {
+            key: target[key]
+            for key in (
+                "chartVersion",
+                "chartDigest",
+                "imageTag",
+                "imageDigest",
+                "sourceRevision",
+                "chartSourceRevision",
+                "applicationVersion",
+                "expectedDefaultChatProvider",
+            )
+        },
+    }
+    path = tmp_path / "failed.json"
+    path.write_text(json.dumps(evidence), encoding="utf-8")
+    live = {"info": {"description": f"sugarkube-dspace-metrics-reconciliation:{invocation}"}}
+    commands: list[list[str]] = []
+
+    assert (
+        rollback.validate_pull_policy_recovery_evidence(
+            path, baseline, target, live, lambda command: commands.append(command) or ""
+        )
+        == evidence
+    )
+    assert commands == [["git", "merge-base", "--is-ancestor", "b" * 40, "HEAD"]]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("operation", "dspaceProductionMetricsPullPolicyRecovery"),
+        ("state", "reserved"),
+        ("state", "succeeded"),
+        ("failedStage", "runtime-verification"),
+        ("failureCode", "runtime-verification-failed"),
+        ("clusterMayHaveChanged", False),
+    ),
+)
+def test_pull_policy_recovery_rejects_nonmatching_failure(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    baseline = manifest.validate(manifest._object(PROD_BASELINE), True)
+    target = rollback.chart_maintenance_target(baseline, PROD_MAINTENANCE_TARGET)
+    path = tmp_path / "failed.json"
+    path.write_text(json.dumps({field: value}), encoding="utf-8")
+    with pytest.raises(rollback.RollbackError, match="confirmed failed reconciliation"):
+        rollback.validate_pull_policy_recovery_evidence(path, baseline, target, {}, lambda _c: "")
+
+
+def test_pull_policy_recovery_requires_exact_deployment_and_pod_policy() -> None:
+    container = {"name": "dspace", "imagePullPolicy": "IfNotPresent"}
+    workloads = {
+        "items": [
+            {
+                "kind": "Deployment",
+                "spec": {"template": {"spec": {"containers": [container]}}},
+            }
+        ]
+    }
+    raw_pods = {"items": [{"spec": {"containers": [container]}} for _ in range(2)]}
+    rollback.verify_resource_pull_policy(workloads, raw_pods, "IfNotPresent")
+    with pytest.raises(rollback.RollbackError, match="Deployment pull policy"):
+        rollback.verify_resource_pull_policy(workloads, raw_pods, "Always")
 
 
 def test_staging_is_non_interactive_and_reservation_collision_is_immutable(


### PR DESCRIPTION
### Motivation

- Fix a production reconciliation-finalization failure caused by chart 3.0.3 computing `image.pullPolicy=IfNotPresent` while `verify_helm_stored_values` expects `Always`.
- Provide a narrowly scoped, fail-closed recovery path that can repair the exact already-mutated revision-10 → 11 transition without weakening any validators.

### Description

- Ensure guarded renders and Helm upgrades explicitly pass `--set-string image.pullPolicy=Always` for the production/metrics reconciliation paths so rendered and mutated manifests match the stored-value expectations (changes in `scripts/dspace_manifest_rollback.py`).
- Add a one-shot, invocation-bound recovery mode (`--pull-policy-recovery` + `--original-evidence`) that strictly validates the known failed transition, binds to the original failed evidence, verifies exact live Helm/user/computed values, the lone `IfNotPresent` defect, ServiceMonitor chart-defaults, pod/deployment pull-policy, and OCI provenance before performing exactly one digest-qualified Helm upgrade with `image.pullPolicy=Always` (changes in `scripts/dspace_manifest_rollback.py`).
- Introduce helper validators `validate_pull_policy_recovery_evidence` and `verify_resource_pull_policy`, include original-evidence fingerprinting in reserved evidence, and keep the existing normal-path fail-closed semantics.
- Add an operator recipe `dspace-prod-metrics-pull-policy-recover` to `justfile` and document the guarded recovery interface in `docs/apps/dspace.md`.
- Add focused tests exercising the new recovery binding and the requirement that both the template and upgrade include `image.pullPolicy=Always` and the recovery CLI interface (`tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`).

### Testing

- `python3 -m compileall scripts/dspace_manifest_rollback.py scripts/dspace_release_manifest.py` — OK.
- `python3 scripts/observability_app_metrics.py validate` — OK.
- `python3 -m pytest -q tests/test_manifest_rollback.py tests/test_release_manifest.py tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py` — OK; test run completed (801 passed, 1 warning reported by tests during the run).
- `linkchecker --no-warnings README.md docs/` — OK (internal links only, no errors).
- `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` — OK.
- Notes: `pyspelling` failed in this environment because `aspell` is not installed, and `pre-commit run --all-files` surfaced unrelated, pre-existing repository-wide checks and YAML/flake8 items outside the scope of this change; those were not introduced by this patch.

Files changed (principal targets): `scripts/dspace_manifest_rollback.py`, `justfile`, `docs/apps/dspace.md`, `tests/test_manifest_rollback.py`, `tests/test_generic_app_just_recipes.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e2b43ba74832f8bd4d81797e6279f)