### PR TITLE
Prepare DSPACE 3.1.1 promotion: add reviewed target, read-only planner, tests, docs

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -2,6 +2,47 @@
 
 This is the canonical runbook for deploying DSPACE from GHCR artifacts to Sugarkube. The generic `just app-*` recipes are the preferred future path. The `dspace-oci-*` recipes remain compatibility shims and are scheduled for later removal only after the generic flow has been exercised across routine releases.
 
+## DSPACE 3.1.1 promotion preparation (no operation authorized)
+
+`dspace.promotion-target.json` records the reviewed immutable application 3.1.1/chart 3.1.2
+coordinates. Application and chart source revisions remain independent schema-v2 fields. The
+deployment coordinate is immutable branch tag `main-22f506e` plus its digest; semantic tag
+`v3.1.1` is provenance only. Only the staging chart pin has advanced. Production pins, the
+finalized baseline, failed reconciliation, and finalized staging evidence remain unchanged.
+
+`scripts/dspace_promotion_plan.py` is read-only and fail closed. It consumes bounded classifier and
+source reports, checks the preserved failure, verifies OCI provenance, requires exact finalized
+staging proof, and renders staging and production offline from a digest-matching archive. Reports
+contain counts and booleans only: Secret values, raw metrics/source, scrape errors, unhealthy
+targets, partial families, or cluster mutation fail. The planner rejects semantic image tags,
+`--reuse-values`, non-`Always` pull policy, rendered Secrets, staging data in production, and values
+drift. Its sanitized output says `mutationPerformed: false`; it cannot upgrade Helm, mutate
+Kubernetes, create approval, or finalize evidence. Existing 3.1.0/chart 3.1.1 staging evidence is
+historical and cannot authorize 3.1.1/chart 3.1.2. The old classifier is classification, not
+deployment evidence.
+
+A future operator must, in order:
+
+1. record genuine approval metadata for the exact target;
+2. create a fresh staging candidate and deploy it through existing guarded machinery;
+3. prove exactly two Ready replicas at the exact digest;
+4. prove runtime/frontend identity, replica agreement, and public/direct agreement;
+5. prove the intended production provider remains `openai` and pass bounded remote `/chat` smoke;
+6. prove two healthy authenticated Prometheus targets without scrape errors and all six families:
+   `dspace_build_info`, `dspace_dchat_requests_total`, `dspace_dependency_requests_total`,
+   `dspace_http_request_duration_seconds_bucket`, `dspace_http_requests_total`, and
+   `dspace_instrumentation_up`, using a real server-observed chat/dependency journey when needed;
+7. atomically finalize non-overwritable staging evidence; and
+8. only then open a separate repository task for a one-shot production revision-10 successor.
+
+This preparation performs no live operation, publication, approval, candidate creation, evidence
+finalization, recovery, or promotion. Do not automatically reopen #2325 or #2329, and do not
+modify or conflate #2408.
+
+The existing `dspace-prod-metrics-pull-policy-recover` operation remains ineligible: immutable
+application 3.0.1 lacks the required families. Do not rerun, weaken, bypass, or repurpose its
+fail-closed checks; roll Helm back; uninstall; or read, rotate, or delete the metrics Secret.
+
 ## Production authenticated metrics chart maintenance
 
 This guarded operation is a **chart-only maintenance upgrade** from immutable DSPACE chart 3.0.2

--- a/docs/apps/dspace.promotion-target.json
+++ b/docs/apps/dspace.promotion-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.1.1",
+  "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "imageTag": "main-22f506e",
+  "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+  "chartVersion": "3.1.2",
+  "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+  "semanticTag": "v3.1.1"
+}

--- a/docs/apps/dspace.staging.version
+++ b/docs/apps/dspace.staging.version
@@ -1,2 +1,2 @@
-# DSPACE staging chart pin. Chart 3.1.1 packages DSPACE application 3.1.0 and supplies the required immutable OCI provenance.
-3.1.1
+# DSPACE staging chart pin. Chart 3.1.2 packages the reviewed DSPACE 3.1.1 promotion target.
+3.1.2

--- a/scripts/dspace_promotion_plan.py
+++ b/scripts/dspace_promotion_plan.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Fail-closed, read-only planning for the DSPACE 3.1.1 promotion."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts import app_chart
+from scripts import dspace_release_manifest as release
+
+TARGET = Path("docs/apps/dspace.promotion-target.json")
+FAMILIES = (
+    "dspace_build_info",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "dspace_http_requests_total",
+    "dspace_instrumentation_up",
+)
+CLASSIFIER_FIELDS = {
+    "schemaVersion",
+    "classification",
+    "healthyTargets",
+    "targetScrapeErrors",
+    "publicMetricsStatus",
+    "secretContractExists",
+    "secretValueRead",
+    "defaultNodeMetricSampleCounts",
+    "applicationFamilySampleCounts",
+    "clusterMutationPerformed",
+    "rawMetricsIncluded",
+}
+SOURCE_FIELDS = {
+    "schemaVersion",
+    "sourceRevision",
+    "metricFamilies",
+    "privacySafe",
+    "clusterMutationPerformed",
+    "rawSourceIncluded",
+}
+
+
+class PlanError(ValueError):
+    """A planning input is unsafe, incomplete, or not the reviewed target."""
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PlanError(f"cannot read bounded report: {path}") from exc
+    if not isinstance(value, dict):
+        raise PlanError("bounded report must be an object")
+    return value
+
+
+def target(path: Path = TARGET) -> dict[str, Any]:
+    value = load(path)
+    release._exact_fields(value, release.UPSTREAM_FIELDS_V2)
+    release._validate_upstream(value)
+    expected = load(TARGET) if path != TARGET else value
+    if value != expected:
+        raise PlanError("promotion coordinates differ from the reviewed target")
+    return value
+
+
+def validate_classifier(value: dict[str, Any]) -> None:
+    if set(value) != CLASSIFIER_FIELDS:
+        raise PlanError("classifier report fields are incomplete or unsafe")
+    expected_counts = {name: 0 for name in FAMILIES}
+    if (
+        value["schemaVersion"] != 1
+        or value["classification"] != "IMMUTABLE_APP_LACKS_REQUIRED_DSPACE_METRICS"
+        or value["healthyTargets"] != 2
+        or value["targetScrapeErrors"] != 0
+        or value["publicMetricsStatus"] != 401
+        or value["secretContractExists"] is not True
+        or value["secretValueRead"] is not False
+        or value["clusterMutationPerformed"] is not False
+        or value["rawMetricsIncluded"] is not False
+        or value["applicationFamilySampleCounts"] != expected_counts
+        or not isinstance(value["defaultNodeMetricSampleCounts"], dict)
+        or not value["defaultNodeMetricSampleCounts"]
+        or any(count != 2 for count in value["defaultNodeMetricSampleCounts"].values())
+    ):
+        raise PlanError("classifier report does not prove the bounded incident classification")
+
+
+def validate_source(value: dict[str, Any], promotion: dict[str, Any]) -> None:
+    if set(value) != SOURCE_FIELDS:
+        raise PlanError("source report fields are incomplete or unsafe")
+    if (
+        value["schemaVersion"] != 1
+        or value["sourceRevision"] != promotion["sourceRevision"]
+        or value["metricFamilies"] != list(FAMILIES)
+        or value["privacySafe"] is not True
+        or value["clusterMutationPerformed"] is not False
+        or value["rawSourceIncluded"] is not False
+    ):
+        raise PlanError("source report does not prove the reviewed privacy-safe metric definitions")
+
+
+def validate_failed(value: dict[str, Any]) -> None:
+    required = {
+        "schemaVersion": 1,
+        "environment": "prod",
+        "release": "dspace",
+        "namespace": "dspace",
+        "operation": "dspaceProductionMetricsReconciliation",
+        "state": "failed",
+        "failedStage": "ownership-and-finalization-proof",
+        "failureCode": "ownership-and-finalization-proof-failed",
+        "clusterMayHaveChanged": True,
+    }
+    if any(value.get(key) != expected for key, expected in required.items()):
+        raise PlanError("preserved reconciliation is not the immutable failed operation")
+    before = value.get("before")
+    if not isinstance(before, dict) or before.get("helmRevision") != 9:
+        raise PlanError("preserved reconciliation has an invalid before-state")
+
+
+def validate_staging(evidence: dict[str, Any], promotion: dict[str, Any]) -> None:
+    metrics_results = [
+        item
+        for item in evidence.get("verificationResults", [])
+        if isinstance(item, dict) and item.get("check") == "metrics"
+    ]
+    lifecycle = dict(evidence)
+    lifecycle["verificationResults"] = [
+        item
+        for item in evidence.get("verificationResults", [])
+        if not isinstance(item, dict) or item.get("check") != "metrics"
+    ]
+    try:
+        release.validate(lifecycle, True)
+    except release.ManifestError as exc:
+        raise PlanError(f"staging evidence is invalid: {exc}") from exc
+    fields = release.UPSTREAM_FIELDS_V2
+    if any(evidence[field] != promotion[field] for field in fields):
+        raise PlanError("historical staging evidence cannot authorize these coordinates")
+    if evidence["environment"] != "staging" or evidence["expectedDefaultChatProvider"] != "openai":
+        raise PlanError("staging evidence must prove the intended production provider openai")
+    checks = {item["check"]: item["passed"] for item in lifecycle["verificationResults"]}
+    if (
+        len(metrics_results) != 1
+        or metrics_results[0].get("passed") is not True
+        or any(checks.get(name) is not True for name in release.RUNTIME_VERIFICATION_CHECKS)
+    ):
+        raise PlanError("staging evidence lacks runtime, smoke, or metrics success")
+
+
+def render(
+    chart: Path,
+    promotion: dict[str, Any],
+    environment: str,
+    runner: Callable[[list[str]], str] | None = None,
+) -> str:
+    digest = "sha256:" + hashlib.sha256(chart.read_bytes()).hexdigest()
+    if digest != promotion["chartDigest"]:
+        raise PlanError("chart archive digest differs from reviewed immutable digest")
+    values = Path(f"docs/examples/dspace.values.{environment}.yaml")
+    command = [
+        "helm",
+        "template",
+        "dspace",
+        str(chart),
+        "--namespace",
+        "dspace",
+        "-f",
+        str(values),
+        "--set",
+        "replicaCount=2",
+        "--set",
+        f"image.repository={release.IMAGE_REF}",
+        "--set",
+        f"image.tag={promotion['imageTag']}",
+        "--set",
+        "image.pullPolicy=Always",
+    ]
+    if "--reuse-values" in command:
+        raise PlanError("--reuse-values is forbidden")
+    output = (
+        runner(command)
+        if runner
+        else subprocess.run(command, check=True, text=True, capture_output=True).stdout
+    )
+    docs = [doc for doc in app_chart.safe_yaml_documents(output) if isinstance(doc, dict)]
+    if any(doc.get("kind") == "Secret" for doc in docs):
+        raise PlanError("rendered Secret resources are forbidden")
+    if environment == "prod" and release.contains_staging_reference(docs):
+        raise PlanError("production render contains staging-only configuration")
+    inputs = app_chart.ReleaseInputs(
+        app="dspace",
+        env=environment,
+        release="dspace",
+        namespace="dspace",
+        chart=str(chart),
+        version=promotion["chartVersion"],
+        values=(str(values),),
+        tag=promotion["imageTag"],
+        host="democratized.space" if environment == "prod" else "staging.democratized.space",
+    )
+    errors = app_chart.validate_rendered_manifest(output, inputs)
+    if errors:
+        raise PlanError("render validation failed: " + "; ".join(errors))
+    return output
+
+
+def plan(args: argparse.Namespace) -> dict[str, Any]:
+    promotion = target(args.target)
+    validate_classifier(load(args.classifier))
+    validate_source(load(args.source), promotion)
+    validate_failed(load(args.failed_reconciliation))
+    validate_staging(load(args.staging_evidence), promotion)
+    release.preflight(
+        release.candidate(promotion, "staging", "openai", args.approved_at, args.approved_by),
+        release.IMAGE_REF,
+        release.CHART_REF,
+        args.oras_command,
+    )
+    render(args.chart_archive, promotion, "staging")
+    render(args.chart_archive, promotion, "prod")
+    return {
+        "schemaVersion": 1,
+        "mode": "plan",
+        "mutationPerformed": False,
+        "target": promotion,
+        "renders": ["staging", "prod"],
+        "authorization": "future-operator-action-required",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", type=Path, default=TARGET)
+    parser.add_argument("--classifier", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--failed-reconciliation", type=Path, required=True)
+    parser.add_argument("--staging-evidence", type=Path, required=True)
+    parser.add_argument("--chart-archive", type=Path, required=True)
+    parser.add_argument("--approved-at", required=True)
+    parser.add_argument("--approved-by", required=True)
+    parser.add_argument("--oras-command", default="oras")
+    args = parser.parse_args(argv)
+    print(json.dumps(plan(args), sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_promotion_plan.py
+++ b/tests/test_dspace_promotion_plan.py
@@ -1,0 +1,193 @@
+"""Preparation-only DSPACE promotion planner policy tests."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_promotion_plan as planner
+
+
+def reviewed():
+    return json.loads(Path("docs/apps/dspace.promotion-target.json").read_text())
+
+
+def classifier():
+    return {
+        "schemaVersion": 1,
+        "classification": "IMMUTABLE_APP_LACKS_REQUIRED_DSPACE_METRICS",
+        "healthyTargets": 2,
+        "targetScrapeErrors": 0,
+        "publicMetricsStatus": 401,
+        "secretContractExists": True,
+        "secretValueRead": False,
+        "defaultNodeMetricSampleCounts": {"process_cpu_seconds_total": 2},
+        "applicationFamilySampleCounts": {name: 0 for name in planner.FAMILIES},
+        "clusterMutationPerformed": False,
+        "rawMetricsIncluded": False,
+    }
+
+
+def successor_evidence():
+    value = json.loads(
+        Path("deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json").read_text()
+    )
+    target = reviewed()
+    for field in planner.release.UPSTREAM_FIELDS_V2:
+        value[field] = target[field]
+    value["expectedDefaultChatProvider"] = "openai"
+    value["runtimeSourceRevision"] = target["sourceRevision"]
+    for pod in value["pods"]:
+        pod["imageID"] = "docker-pullable://dspace@" + target["imageDigest"]
+    proof = value["runtimeVerification"]
+    proof.update(
+        applicationVersion=target["applicationVersion"],
+        runtimeSourceRevision=target["sourceRevision"],
+        frontendSourceRevision=target["sourceRevision"],
+        defaultProvider="openai",
+    )
+    value["verificationResults"].append(
+        {"check": "metrics", "passed": True, "details": "six bounded families passed"}
+    )
+    return value
+
+
+def test_reviewed_target_is_exact_and_staging_pin_only_advanced():
+    assert reviewed() == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.1.1",
+        "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "imageTag": "main-22f506e",
+        "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+        "chartVersion": "3.1.2",
+        "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+        "semanticTag": "v3.1.1",
+    }
+    assert planner.target() == reviewed()
+    assert Path("docs/apps/dspace.staging.version").read_text().splitlines()[-1] == "3.1.2"
+
+
+@pytest.mark.parametrize(
+    "field", ["sourceRevision", "imageTag", "imageDigest", "chartVersion", "chartDigest"]
+)
+def test_altered_target_is_rejected(tmp_path, field):
+    value = reviewed()
+    value[field] = "altered"
+    path = tmp_path / "target.json"
+    path.write_text(json.dumps(value))
+    with pytest.raises((planner.PlanError, planner.release.ManifestError)):
+        planner.target(path)
+
+
+def test_historical_310_evidence_is_explicitly_ineligible():
+    old = json.loads(
+        Path("deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json").read_text()
+    )
+    with pytest.raises(planner.PlanError, match="historical"):
+        planner.validate_staging(old, reviewed())
+
+
+def test_exact_synthetic_successor_evidence_is_accepted_and_every_coordinate_is_bound():
+    planner.validate_staging(successor_evidence(), reviewed())
+    for field in (*planner.release.UPSTREAM_FIELDS_V2, "expectedDefaultChatProvider"):
+        altered = successor_evidence()
+        altered[field] = "token-place" if field == "expectedDefaultChatProvider" else "wrong"
+        with pytest.raises((planner.PlanError, planner.release.ManifestError)):
+            planner.validate_staging(altered, reviewed())
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda x: x["applicationFamilySampleCounts"].pop(planner.FAMILIES[0]),
+        lambda x: x.update(healthyTargets=1),
+        lambda x: x.update(targetScrapeErrors=1),
+        lambda x: x.update(secretValue="forbidden"),
+        lambda x: x.update(secretValueRead=True),
+        lambda x: x.update(clusterMutationPerformed=True),
+        lambda x: x.update(rawMetricsIncluded=True),
+    ],
+)
+def test_classifier_is_strict_bounded_and_read_only(change):
+    value = classifier()
+    change(value)
+    with pytest.raises(planner.PlanError):
+        planner.validate_classifier(value)
+
+
+def test_source_report_requires_all_privacy_safe_definitions():
+    report = {
+        "schemaVersion": 1,
+        "sourceRevision": reviewed()["sourceRevision"],
+        "metricFamilies": list(planner.FAMILIES),
+        "privacySafe": True,
+        "clusterMutationPerformed": False,
+        "rawSourceIncluded": False,
+    }
+    planner.validate_source(report, reviewed())
+    report["metricFamilies"].pop()
+    with pytest.raises(planner.PlanError):
+        planner.validate_source(report, reviewed())
+
+
+def test_offline_render_is_exact_read_only_and_rejects_secret_or_staging_leak(tmp_path):
+    chart = tmp_path / "dspace.tgz"
+    chart.write_bytes(b"fixture")
+    target = reviewed()
+    target["chartDigest"] = "sha256:" + hashlib.sha256(chart.read_bytes()).hexdigest()
+    rendered = """apiVersion: apps/v1
+kind: Deployment
+metadata: {name: dspace, labels: {app.kubernetes.io/instance: dspace}}
+spec:
+  replicas: 2
+  selector: {matchLabels: {app: dspace}}
+  template:
+    metadata: {labels: {app: dspace}}
+    spec:
+      containers:
+      - name: dspace
+        image: ghcr.io/democratizedspace/dspace:main-22f506e
+        imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata: {name: dspace, labels: {app.kubernetes.io/instance: dspace}}
+spec: {selector: {app: dspace}, ports: [{port: 80}]}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata: {name: dspace, labels: {app.kubernetes.io/instance: dspace}}
+spec: {rules: [{host: staging.democratized.space}]}
+"""
+    commands = []
+    planner.render(chart, target, "staging", lambda command: commands.append(command) or rendered)
+    joined = " ".join(commands[0])
+    assert "replicaCount=2" in joined and "image.pullPolicy=Always" in joined
+    assert "--reuse-values" not in joined
+    assert not any(word in joined for word in ("upgrade", "kubectl", "rollout", "finalize"))
+    with pytest.raises(planner.PlanError, match="Secret"):
+        planner.render(chart, target, "staging", lambda _: rendered + "---\nkind: Secret\n")
+    prod = rendered.replace("staging.democratized.space", "democratized.space")
+    with pytest.raises(planner.PlanError, match="staging-only"):
+        planner.render(
+            chart,
+            target,
+            "prod",
+            lambda _: prod + "---\nkind: ConfigMap\ndata: {x: sugarkube-int}\n",
+        )
+
+
+def test_planner_source_contains_no_mutation_or_evidence_finalization_path():
+    source = Path("scripts/dspace_promotion_plan.py").read_text()
+    for forbidden in (
+        "helm upgrade",
+        "kubectl apply",
+        "kubectl delete",
+        "kubectl patch",
+        "rollout restart",
+        "release.finalize",
+    ):
+        assert forbidden not in source

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -149,7 +149,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
-    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
+    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.2"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
     assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -193,7 +193,7 @@ if [ "${{1:-}}" = upgrade ]; then
   done
 fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
-  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
+  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.2}}"
   if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.3; fi
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   revision=7
@@ -227,7 +227,7 @@ if [[ "$*" == show\ chart* ]]; then
   if [[ "$*" == *"charts/dspace"* ]]; then
     version="${{*: -1}}"
     if [[ "$version" == oci://*@sha256:* ]]; then
-      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
+      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.2}}"
       if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.3; fi
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
@@ -2963,7 +2963,7 @@ def _write_dspace_candidate(
         "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
         "imageTag": "main-abcdef0",
         "imageDigest": image_digest or "sha256:" + "1" * 64,
-        "chartVersion": "3.1.1" if environment == "staging" else "3.0.3",
+        "chartVersion": "3.1.2" if environment == "staging" else "3.0.3",
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "candidate",
@@ -3624,7 +3624,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
 
     _write_dspace_candidate(prod_manifest, "prod")
     prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
-    prod_record["chartVersion"] = "3.1.1"
+    prod_record["chartVersion"] = "3.1.2"
     prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     config = tmp_path / "dspace.env"
     config.write_text(
@@ -3634,7 +3634,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
                 "SUGARKUBE_RELEASE=dspace",
                 "SUGARKUBE_NAMESPACE=dspace",
                 "SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace",
-                "SUGARKUBE_VERSION=3.1.1",
+                "SUGARKUBE_VERSION=3.1.2",
                 "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
                 "SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml",
                 "SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
@@ -3644,7 +3644,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
         + "\n",
         encoding="utf-8",
     )
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.1"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.2"
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     runtime_log = Path(env["RUNTIME_VERIFIER_LOG"])
     runtime_log.write_text("", encoding="utf-8")
@@ -3746,11 +3746,11 @@ def test_dspace_prod_staging_gate_failures_stop_before_production_work(
 
     _write_dspace_candidate(prod_manifest, "prod")
     prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
-    prod_record["chartVersion"] = "3.1.1"
+    prod_record["chartVersion"] = "3.1.2"
     prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.1"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.2"
     if staging_record_kind == "revision":
         env["SUGARKUBE_STUB_STAGING_HELM_REVISION"] = "8"
     for name in ("helm.log", "kubectl.log", "commands.log", "runtime-verifier.log"):


### PR DESCRIPTION
### Motivation

- Prepare repository-only, fail-closed support for a staging-first promotion of immutable DSPACE application `3.1.1` / chart `3.1.2` without performing any live cluster mutation, publishing, or evidence finalization.  
- Provide an operator-facing, read-only preflight/planning interface that reuses existing release-manifest and app-chart helpers to strictly validate provenance, bounded classifier/source reports, the preserved failed reconciliation, and offline renders before any future operator action.

### Description

- Add a reviewed, machine-readable promotion target at `docs/apps/dspace.promotion-target.json` containing the exact `3.1.1` application / `3.1.2` chart coordinates, keeping application and chart source revisions separate and using only the immutable branch-SHA image tag and digest.  
- Advance only the staging chart pin `docs/apps/dspace.staging.version` to `3.1.2` and update the DSPACE runbook `docs/apps/dspace.md` with a clear, non-operative staging-first sequence and gates; leave all production pins, finalized evidence, and the preserved failed reconciliation unchanged.  
- Add a fail-closed, read-only planner `scripts/dspace_promotion_plan.py` that: validates the exact immutable coordinates via existing `dspace_release_manifest` helpers, accepts only bounded classifier and privacy-safe source reports (no Secret values or raw metrics), verifies the preserved failed reconciliation, requires finalized staging proof for the exact coordinates (and that the intended production provider is `openai`), enforces `image.pullPolicy=Always`, rejects semantic tags/`--reuse-values`/rendered Secrets/staging leaks or values drift, renders offline from a digest-matching chart archive using existing `app_chart` render validation, and emits a sanitized plan with `mutationPerformed: false`.  
- Add focused tests `tests/test_dspace_promotion_plan.py` covering exact target schema, rejection of altered fields, rejection of historical 3.1.0 staging evidence as authorization, acceptance only of a fully correct synthetic finalized-staging fixture, classifier/source schema strictness, offline render constraints, and explicit absence of any mutation/finalization paths; update small test fixtures to reflect the advanced staging pin.

This change is preparation-only: it does not create approvals, deploy to staging/prod, finalize any evidence, publish artifacts, or alter live clusters, and it explicitly preserves the existing `dspace-prod-metrics-pull-policy-recover` checks as ineligible for this promotion.

### Testing

- Ran the new focused unit tests: `python3 -m pytest -q tests/test_dspace_promotion_plan.py` — all promotion-plan tests passed (`18 passed`).  
- Exercised the relevant integration/focused suites with the updated staging pin: `python3 -m pytest -q tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py tests/test_dspace_promotion_plan.py` — focused suites including the new planner tests passed (full focused run reported success).  
- Performed provenance and rendering checks where possible: `python3 scripts/observability_app_metrics.py validate` and `python3 scripts/app_config.py json --app dspace --env staging` / `--env prod` all succeeded, and `oras` manifest fetch confirmed the immutable image provides Linux/amd64 and Linux/arm64 platform descriptors; `helm show chart` against GHCR returned `401 unauthorized` so the chart OCI manifest could not be pulled from GHCR in this environment, but chart metadata (`Chart.yaml`) and the application source at the reviewed commit were fetched from GitHub raw and were inspected to confirm presence of the six `dspace_*` metric families.  
- Repository checks: `just --unstable --fmt --check`, `git diff --check`, and `git diff --cached | ./scripts/scan-secrets.py` were run; formatting for the added files was applied. A full `pre-commit run --all-files` could not complete cleanly due to pre-existing repo-wide YAML/template and lint issues unrelated to this change, and `pyspelling` could not complete here because the `aspell` binary is not available in the execution environment; these environment/tooling limits are reported and no gates were weakened to bypass any verifier.

Residual notes and limits: offline GHCR chart fetch was blocked by registry auth (401) in this environment, so the planner still defers to `release.preflight` (which will perform the OCI checks when run with proper registry/credentials in operator hands); no cluster or Helm mutation was run; no approval metadata was created; no evidence finalized; and the change strictly preserves the immutable failed-reconciliation evidence and the existing recovery operation as ineligible for this promotion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eb7165070832fbce3bed28cf18e3c)