### PR TITLE
Prepare read-only staging-first promotion plan for DSPACE 3.1.1 / chart 3.1.2

### DIFF
--- a/docs/apps/dspace-3.1.1-promotion-preparation.md
+++ b/docs/apps/dspace-3.1.1-promotion-preparation.md
@@ -1,0 +1,50 @@
+# DSPACE 3.1.1 promotion preparation
+
+This repository change is **preparation only**. It does not contact a cluster, publish an artifact,
+create approval metadata, create or finalize deployment evidence, recover production, or promote
+production. Production remains release/namespace `dspace`/`dspace`, revision 10, chart 3.0.3 and
+application 3.0.1. The reviewed successor is recorded in
+`dspace.promotion-target.json`; its immutable deployment coordinate is `main-22f506e`, never the
+semantic release tag.
+
+## Read-only planning gate
+
+`scripts/dspace_promotion_plan.py` accepts only bounded, sanitized JSON reports. The artifact report
+must independently establish the exact image digest, Linux/ARM64 image availability, OCI source
+annotation, chart digest, chart `version`/`appVersion`/source revision, and the `v3.1.1` and
+`chart-v3.1.2` tags. The source report must establish privacy-safe definitions for all six required
+`dspace_*` families. The incident classifier may contain counts and status only: never a Secret
+value or raw metrics payload. The preserved failed reconciliation is validated independently
+against the finalized production baseline and maintenance target.
+
+The command runs only `helm template` against the chart **digest**, renders staging and eventual
+production with `main-22f506e`, two replicas and `image.pullPolicy=Always`, and prints a sanitized
+plan. It rejects rendered Secrets, staging data in production, semantic image coordinates and
+coordinate drift. It has no `--reuse-values`, Helm upgrade, kubectl, rollout, Secret mutation, or
+evidence-finalization path. The old classifier explains why 3.0.1 cannot satisfy the metrics gate;
+it is not deployment evidence.
+
+## Required future sequence
+
+1. Record genuine, reviewed operator approval metadata outside this preparation change.
+2. Create a fresh staging candidate for the exact application 3.1.1/chart 3.1.2 coordinates.
+   Existing finalized application 3.1.0/chart 3.1.1 evidence is historical and cannot authorize it.
+3. Deploy staging through the existing guarded release machinery, not this planner.
+4. Prove exactly two Ready replicas running the exact image digest; prove runtime and frontend
+   source identity, replica agreement, and public/direct agreement. The intended production default
+   provider remains `openai`.
+5. Pass a bounded remote `/chat` smoke test. Prove two healthy authenticated Prometheus targets,
+   no scrape errors, and all six families: `dspace_build_info`, `dspace_dchat_requests_total`,
+   `dspace_dependency_requests_total`, `dspace_http_request_duration_seconds_bucket`,
+   `dspace_http_requests_total`, and `dspace_instrumentation_up`. Exercise a real server-observed
+   chat/dependency journey where needed to produce truthful samples.
+6. Finalize the exact staging evidence to a non-overwritable destination.
+7. Only after all prior gates pass may a separate repository task add a one-shot production
+   revision-10 successor promotion. That future work must still reject `--reuse-values`, values
+   drift, staging configuration, rendered Secrets, and unproved runtime or metrics results.
+
+The `dspace-prod-metrics-pull-policy-recover` operation remains ineligible for this incident. Its
+fail-closed metrics verifier and preflight must remain intact; do not rerun, weaken, bypass, or
+repurpose it as an application promotion. Do not roll back or uninstall Helm and do not read,
+rotate, or delete the metrics Secret. Issues #2325 and #2329 stay closed unless a human decides
+otherwise; issue #2408 is unrelated and must not be modified or conflated with this preparation.

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -399,7 +399,7 @@ verification uses the same command with `env=prod` and a production candidate or
 | Release | `dspace` |
 | Namespace | `dspace` |
 | App config | `docs/examples/apps/dspace.env` |
-| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (chart `3.1.1` for application `3.1.0`); production `docs/apps/dspace.prod.version` (`3.0.3`, chart-only application 3.0.1 maintenance) |
+| Chart version pins | Shared/default `docs/apps/dspace.version`; staging `docs/apps/dspace.staging.version` (preparation pin `3.1.2` for application `3.1.1`); production `docs/apps/dspace.prod.version` (`3.0.3`, chart-only application 3.0.1 maintenance) |
 | Production tag pin | `docs/apps/dspace.prod.tag` |
 | Verify paths | `/config.json`, `/healthz`, `/livez` |
 

--- a/docs/apps/dspace.promotion-target.json
+++ b/docs/apps/dspace.promotion-target.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 2,
+  "app": "dspace",
+  "applicationVersion": "3.1.1",
+  "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "imageTag": "main-22f506e",
+  "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+  "chartVersion": "3.1.2",
+  "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+  "semanticTag": "v3.1.1"
+}

--- a/docs/apps/dspace.staging.version
+++ b/docs/apps/dspace.staging.version
@@ -1,2 +1,2 @@
-# DSPACE staging chart pin. Chart 3.1.1 packages DSPACE application 3.1.0 and supplies the required immutable OCI provenance.
-3.1.1
+# DSPACE staging chart pin. Chart 3.1.2 packages the reviewed DSPACE 3.1.1 candidate.
+3.1.2

--- a/scripts/dspace_promotion_plan.py
+++ b/scripts/dspace_promotion_plan.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Fail-closed, offline-only planning for the DSPACE 3.1.1 promotion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from scripts import dspace_manifest_rollback as rollback
+from scripts import dspace_release_manifest as release
+
+TARGET = Path("docs/apps/dspace.promotion-target.json")
+BASELINE = Path("deployment-evidence/dspace/prod/main-1a31a56-20260801T093443Z.json")
+MAINTENANCE = Path("docs/apps/dspace.prod-metrics-chart-target.json")
+CHART = "oci://ghcr.io/democratizedspace/charts/dspace"
+FAMILIES = (
+    "dspace_build_info",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "dspace_http_requests_total",
+    "dspace_instrumentation_up",
+)
+
+
+class PlanError(ValueError):
+    """Planning input is incomplete, unsafe, or inconsistent."""
+
+
+def obj(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PlanError(f"cannot read bounded JSON report {path}") from exc
+    if not isinstance(value, dict):
+        raise PlanError("bounded report must be an object")
+    return value
+
+
+def exact(value: dict[str, Any], fields: set[str], name: str) -> None:
+    if set(value) != fields:
+        raise PlanError(f"{name} schema fields are not exact")
+
+
+def target(path: Path = TARGET) -> dict[str, Any]:
+    value = obj(path)
+    try:
+        release.validate(value)
+    except release.ManifestError as exc:
+        raise PlanError(f"invalid promotion target: {exc}") from exc
+    reviewed = obj(TARGET)
+    if value != reviewed:
+        raise PlanError("promotion target differs from the reviewed coordinates")
+    if value["imageTag"] != f"main-{value['sourceRevision'][:7]}":
+        raise PlanError("deployment coordinate must be the immutable branch image tag")
+    return value
+
+
+def artifact_report(value: dict[str, Any], selected: dict[str, Any]) -> None:
+    fields = {
+        "schemaVersion",
+        "applicationVersion",
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "imagePlatforms",
+        "imageSourceRevision",
+        "chartVersion",
+        "chartDigest",
+        "chartSourceRevision",
+        "chartAppVersion",
+        "applicationReleaseTag",
+        "chartTag",
+    }
+    exact(value, fields, "artifact provenance report")
+    expected = {
+        key: selected[key]
+        for key in (
+            "applicationVersion",
+            "sourceRevision",
+            "imageTag",
+            "imageDigest",
+            "chartVersion",
+            "chartDigest",
+            "chartSourceRevision",
+        )
+    }
+    expected.update(
+        {
+            "schemaVersion": 1,
+            "imagePlatforms": ["linux/amd64", "linux/arm64"],
+            "imageSourceRevision": selected["sourceRevision"],
+            "chartAppVersion": selected["applicationVersion"],
+            "applicationReleaseTag": selected["semanticTag"],
+            "chartTag": f"chart-v{selected['chartVersion']}",
+        }
+    )
+    if value != expected:
+        raise PlanError("artifact provenance does not match every reviewed coordinate")
+
+
+def source_report(value: dict[str, Any], selected: dict[str, Any]) -> None:
+    exact(
+        value,
+        {"schemaVersion", "sourceRevision", "privacySafe", "metricDefinitions"},
+        "source report",
+    )
+    definitions = value.get("metricDefinitions")
+    if (
+        value.get("schemaVersion") != 1
+        or value.get("sourceRevision") != selected["sourceRevision"]
+        or value.get("privacySafe") is not True
+        or not isinstance(definitions, dict)
+        or set(definitions) != set(FAMILIES)
+        or any(flag is not True for flag in definitions.values())
+    ):
+        raise PlanError("source report does not prove all privacy-safe metric definitions")
+
+
+def classifier(value: dict[str, Any]) -> None:
+    fields = {
+        "schemaVersion",
+        "classification",
+        "healthyTargets",
+        "scrapeErrors",
+        "publicMetricsStatus",
+        "secretContractExists",
+        "defaultMetricSamples",
+        "requiredFamilySamples",
+        "clusterMutationPerformed",
+    }
+    exact(value, fields, "classifier report")
+    samples = value.get("requiredFamilySamples")
+    defaults = value.get("defaultMetricSamples")
+    if (
+        value.get("schemaVersion") != 1
+        or value.get("classification") != "IMMUTABLE_APP_LACKS_REQUIRED_DSPACE_METRICS"
+        or value.get("healthyTargets") != 2
+        or value.get("scrapeErrors") != []
+        or value.get("publicMetricsStatus") != 401
+        or value.get("secretContractExists") is not True
+        or value.get("clusterMutationPerformed") is not False
+        or not isinstance(defaults, dict)
+        or not defaults
+        or any(count != 2 for count in defaults.values())
+        or not isinstance(samples, dict)
+        or set(samples) != set(FAMILIES)
+        or any(count != 0 for count in samples.values())
+    ):
+        raise PlanError("classifier report is incomplete, unsafe, or inconsistent")
+
+
+def failed(path: Path) -> None:
+    baseline = release.validate(release._object(BASELINE), True)
+    maintenance = rollback.chart_maintenance_target(baseline, MAINTENANCE)
+    try:
+        rollback.failed_reconciliation(path, maintenance)
+    except (rollback.RollbackError, release.ManifestError) as exc:
+        raise PlanError(f"failed reconciliation is not the preserved incident: {exc}") from exc
+
+
+def staging_evidence(value: dict[str, Any], selected: dict[str, Any]) -> None:
+    coordinates = (
+        "applicationVersion",
+        "sourceRevision",
+        "chartSourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartVersion",
+        "chartDigest",
+        "semanticTag",
+    )
+    if value.get("environment") != "staging" or any(
+        value.get(k) != selected[k] for k in coordinates
+    ):
+        raise PlanError("historical staging evidence cannot authorize these coordinates")
+    standard = dict(value)
+    standard["verificationResults"] = [
+        item
+        for item in value.get("verificationResults", [])
+        if isinstance(item, dict)
+        and item.get("check") not in {"prometheusTargets", "applicationMetrics"}
+    ]
+    try:
+        release.validate(standard, True)
+    except release.ManifestError as exc:
+        raise PlanError(f"staging evidence is not finalized: {exc}") from exc
+    if value.get("expectedDefaultChatProvider") != "openai":
+        raise PlanError("staging evidence must prove the intended openai provider")
+    runtime = value.get("runtimeVerification", {})
+    if (
+        any(
+            runtime.get(k) != selected[v]
+            for k, v in (
+                ("applicationVersion", "applicationVersion"),
+                ("runtimeSourceRevision", "sourceRevision"),
+                ("frontendSourceRevision", "sourceRevision"),
+            )
+        )
+        or runtime.get("defaultProvider") != "openai"
+    ):
+        raise PlanError("staging runtime and frontend identity do not match")
+    journeys = {
+        item.get("name"): item.get("passed")
+        for item in runtime.get("journeys", [])
+        if isinstance(item, dict)
+    }
+    checks = {
+        item.get("check"): item.get("passed")
+        for item in value.get("verificationResults", [])
+        if isinstance(item, dict)
+    }
+    if (
+        journeys.get("/chat") is not True
+        or checks.get("remoteChatSmoke") is not True
+        or checks.get("prometheusTargets") is not True
+        or checks.get("applicationMetrics") is not True
+    ):
+        raise PlanError("staging smoke and metrics results are mandatory")
+
+
+def render(helm: str, selected: dict[str, Any], environment: str) -> str:
+    values = [
+        "docs/examples/dspace.values.dev.yaml",
+        f"docs/examples/dspace.values.{environment}.yaml",
+    ]
+    command = [
+        helm,
+        "template",
+        "dspace",
+        f"{CHART}@{selected['chartDigest']}",
+        "--namespace",
+        "dspace",
+    ]
+    for path in values:
+        command.extend(["-f", path])
+    command.extend(
+        [
+            "--set-string",
+            f"image.repository={release.IMAGE_REF}",
+            "--set-string",
+            f"image.tag={selected['imageTag']}",
+            "--set",
+            "image.pullPolicy=Always",
+            "--set",
+            "replicaCount=2",
+        ]
+    )
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode:
+        raise PlanError(f"offline Helm render failed for {environment}: {result.stderr.strip()}")
+    output = result.stdout
+    if re.search(r"(?m)^kind:\s*Secret\s*$", output):
+        raise PlanError("rendered Secret resources are forbidden")
+    if (
+        selected["imageTag"] not in output
+        or "imagePullPolicy: Always" not in output
+        or not re.search(r"(?m)^\s*replicas:\s*2\s*$", output)
+    ):
+        raise PlanError("render does not pin the exact image, Always policy, and two replicas")
+    if environment == "prod" and (
+        "staging.democratized.space" in output
+        or "staging.token.place" in output
+        or "sugarkube-int" in output
+    ):
+        raise PlanError("production render contains staging-only configuration")
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", type=Path, default=TARGET)
+    parser.add_argument("--artifact-report", type=Path, required=True)
+    parser.add_argument("--source-report", type=Path, required=True)
+    parser.add_argument("--classifier-report", type=Path, required=True)
+    parser.add_argument("--failed-reconciliation", type=Path, required=True)
+    parser.add_argument("--staging-evidence", type=Path)
+    parser.add_argument("--helm-command", default="helm")
+    args = parser.parse_args(argv)
+    selected = target(args.target)
+    artifact_report(obj(args.artifact_report), selected)
+    source_report(obj(args.source_report), selected)
+    classifier(obj(args.classifier_report))
+    failed(args.failed_reconciliation)
+    if args.staging_evidence:
+        staging_evidence(obj(args.staging_evidence), selected)
+    renders = {env: render(args.helm_command, selected, env) for env in ("staging", "prod")}
+    plan = {
+        "schemaVersion": 1,
+        "operation": "dspacePromotionPreparation",
+        "mutationPerformed": False,
+        "target": selected,
+        "stagingEvidenceStatus": "exact-finalized" if args.staging_evidence else "required",
+        "renders": {
+            env: {"sha256": __import__("hashlib").sha256(text.encode()).hexdigest()}
+            for env, text in renders.items()
+        },
+        "nextAction": "obtain genuine approval and create an exact fresh staging candidate",
+    }
+    print(json.dumps(plan, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dspace_promotion_plan.py
+++ b/tests/test_dspace_promotion_plan.py
@@ -1,0 +1,182 @@
+"""Preparation-only DSPACE 3.1.1 promotion policy tests."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_promotion_plan as plan
+
+
+def reviewed() -> dict[str, object]:
+    return json.loads(plan.TARGET.read_text(encoding="utf-8"))
+
+
+def test_reviewed_target_has_exact_coordinates_and_separate_revisions() -> None:
+    assert reviewed() == {
+        "schemaVersion": 2,
+        "app": "dspace",
+        "applicationVersion": "3.1.1",
+        "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "imageTag": "main-22f506e",
+        "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+        "chartVersion": "3.1.2",
+        "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+        "semanticTag": "v3.1.1",
+    }
+    assert Path("docs/apps/dspace.staging.version").read_text().splitlines()[-1] == "3.1.2"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "sourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartSourceRevision",
+        "chartVersion",
+        "chartDigest",
+    ],
+)
+def test_altered_reviewed_coordinate_is_rejected(tmp_path: Path, field: str) -> None:
+    changed = reviewed()
+    changed[field] = "changed"
+    path = tmp_path / "target.json"
+    path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(plan.PlanError):
+        plan.target(path)
+
+
+def classifier() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "classification": "IMMUTABLE_APP_LACKS_REQUIRED_DSPACE_METRICS",
+        "healthyTargets": 2,
+        "scrapeErrors": [],
+        "publicMetricsStatus": 401,
+        "secretContractExists": True,
+        "defaultMetricSamples": {"process_cpu_user_seconds_total": 2},
+        "requiredFamilySamples": {family: 0 for family in plan.FAMILIES},
+        "clusterMutationPerformed": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda x: x["requiredFamilySamples"].pop(plan.FAMILIES[0]),
+        lambda x: x.update(healthyTargets=1),
+        lambda x: x.update(scrapeErrors=["timeout"]),
+        lambda x: x.update(secretValue="forbidden"),
+        lambda x: x.update(clusterMutationPerformed=True),
+    ],
+)
+def test_classifier_is_strict_and_never_accepts_secret_values(mutation) -> None:
+    value = classifier()
+    mutation(value)
+    with pytest.raises(plan.PlanError):
+        plan.classifier(value)
+
+
+def test_historical_staging_evidence_cannot_authorize_successor() -> None:
+    old = json.loads(
+        Path("deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json").read_text()
+    )
+    with pytest.raises(plan.PlanError, match="historical"):
+        plan.staging_evidence(old, reviewed())
+
+
+def test_exact_synthetic_final_staging_evidence_is_accepted() -> None:
+    value = json.loads(
+        Path("deployment-evidence/dspace/staging/main-018687f-20260805T035722Z.json").read_text()
+    )
+    selected = reviewed()
+    for key in (
+        "applicationVersion",
+        "sourceRevision",
+        "chartSourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartVersion",
+        "chartDigest",
+        "semanticTag",
+    ):
+        value[key] = selected[key]
+    value["expectedDefaultChatProvider"] = "openai"
+    value["runtimeSourceRevision"] = selected["sourceRevision"]
+    for pod in value["pods"]:
+        pod["imageID"] = f"ghcr.io/democratizedspace/dspace@{selected['imageDigest']}"
+    runtime = value["runtimeVerification"]
+    runtime.update(
+        applicationVersion="3.1.1",
+        runtimeSourceRevision=selected["sourceRevision"],
+        frontendSourceRevision=selected["sourceRevision"],
+        defaultProvider="openai",
+    )
+    for check in value["verificationResults"]:
+        if check["check"] in {"defaultProvider", "remoteChatSmoke"}:
+            check["passed"] = True
+    value["verificationResults"].extend(
+        [
+            {
+                "check": "prometheusTargets",
+                "passed": True,
+                "details": "exactly two healthy authenticated targets; no scrape errors",
+            },
+            {
+                "check": "applicationMetrics",
+                "passed": True,
+                "details": "all six required families including server-observed journeys",
+            },
+        ]
+    )
+    plan.staging_evidence(value, selected)
+    for path, wrong in (("expectedDefaultChatProvider", "token-place"),):
+        changed = copy.deepcopy(value)
+        changed[path] = wrong
+        with pytest.raises(plan.PlanError):
+            plan.staging_evidence(changed, selected)
+
+
+def fake_helm(tmp_path: Path, body: str) -> Path:
+    command = tmp_path / "helm"
+    command.write_text("#!/bin/sh\nprintf '%b\\n' " + repr(body) + "\n", encoding="utf-8")
+    command.chmod(0o755)
+    return command
+
+
+def test_offline_render_is_exact_and_contains_no_mutation_command(tmp_path: Path) -> None:
+    body = "kind: Deployment\nspec:\n  replicas: 2\n  template:\n    spec:\n      containers:\n      - image: ghcr.io/democratizedspace/dspace:main-22f506e\n        imagePullPolicy: Always\n"
+    output = plan.render(str(fake_helm(tmp_path, body)), reviewed(), "prod")
+    assert "replicas: 2" in output
+    source = Path("scripts/dspace_promotion_plan.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "helm upgrade",
+        "kubectl apply",
+        "kubectl delete",
+        "kubectl patch",
+        "rollout restart",
+    ):
+        assert forbidden not in source
+    assert 'sub.add_parser("finalize")' not in source
+
+
+@pytest.mark.parametrize("unsafe", ["kind: Secret\n", "staging.token.place\n"])
+def test_production_render_rejects_secret_and_staging_data(tmp_path: Path, unsafe: str) -> None:
+    body = (
+        "kind: Deployment\nspec:\n  replicas: 2\nimage: main-22f506e\nimagePullPolicy: Always\n"
+        + unsafe
+    )
+    with pytest.raises(plan.PlanError):
+        plan.render(str(fake_helm(tmp_path, body)), reviewed(), "prod")
+
+
+def test_old_pull_policy_recovery_remains_fail_closed() -> None:
+    source = Path("scripts/dspace_manifest_rollback.py").read_text(encoding="utf-8")
+    assert "runtime-and-metrics-preflight" in source
+    assert "recovery runtime preflight" in source
+    assert "live values have drift beyond the sole recoverable pull policy" in source

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -149,7 +149,7 @@ def test_dspace_chart_pins_resolve_staging_and_prod_versions() -> None:
     prod = load_config("dspace", "prod")
 
     assert staging["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.staging.version"
-    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.1"
+    assert _first_pin_value(REPO_ROOT / staging["SUGARKUBE_VERSION_FILE"]) == "3.1.2"
     assert prod["SUGARKUBE_VERSION_FILE"] == "docs/apps/dspace.prod.version"
     assert _first_pin_value(REPO_ROOT / prod["SUGARKUBE_VERSION_FILE"]) == "3.0.3"
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -193,7 +193,7 @@ if [ "${{1:-}}" = upgrade ]; then
   done
 fi
 if [[ "$*" == *"status dspace --namespace dspace -o json" ]]; then
-  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
+  chart_version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.2}}"
   if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then chart_version=3.0.3; fi
   description="$(cat {str(tmp_path / "helm-description")!r} 2>/dev/null || true)"
   revision=7
@@ -227,7 +227,7 @@ if [[ "$*" == show\ chart* ]]; then
   if [[ "$*" == *"charts/dspace"* ]]; then
     version="${{*: -1}}"
     if [[ "$version" == oci://*@sha256:* ]]; then
-      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.1}}"
+      version="${{SUGARKUBE_STUB_CHART_VERSION:-3.1.2}}"
       if [ -z "${{SUGARKUBE_STUB_CHART_VERSION:-}}" ] && [ "${{SUGARKUBE_STUB_NODE_ENV:-staging}}" = prod ]; then version=3.0.3; fi
     fi
     printf 'apiVersion: v2\nname: dspace\nversion: %s\nappVersion: main-abcdef0\n' "$version"
@@ -2963,7 +2963,7 @@ def _write_dspace_candidate(
         "sourceRevision": "abcdef0123456789abcdef0123456789abcdef01",
         "imageTag": "main-abcdef0",
         "imageDigest": image_digest or "sha256:" + "1" * 64,
-        "chartVersion": "3.1.1" if environment == "staging" else "3.0.3",
+        "chartVersion": "3.1.2" if environment == "staging" else "3.0.3",
         "chartDigest": "sha256:" + "2" * 64,
         "semanticTag": "v3.2.0",
         "recordType": "candidate",
@@ -3624,7 +3624,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
 
     _write_dspace_candidate(prod_manifest, "prod")
     prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
-    prod_record["chartVersion"] = "3.1.1"
+    prod_record["chartVersion"] = "3.1.2"
     prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     config = tmp_path / "dspace.env"
     config.write_text(
@@ -3634,7 +3634,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
                 "SUGARKUBE_RELEASE=dspace",
                 "SUGARKUBE_NAMESPACE=dspace",
                 "SUGARKUBE_CHART=oci://ghcr.io/democratizedspace/charts/dspace",
-                "SUGARKUBE_VERSION=3.1.1",
+                "SUGARKUBE_VERSION=3.1.2",
                 "SUGARKUBE_PROD_TAG_FILE=docs/apps/dspace.prod.tag",
                 "SUGARKUBE_VALUES_DEV=docs/examples/dspace.values.dev.yaml",
                 "SUGARKUBE_VALUES_STAGING=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml",
@@ -3644,7 +3644,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
         + "\n",
         encoding="utf-8",
     )
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.1"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.2"
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
     runtime_log = Path(env["RUNTIME_VERIFIER_LOG"])
     runtime_log.write_text("", encoding="utf-8")
@@ -3746,11 +3746,11 @@ def test_dspace_prod_staging_gate_failures_stop_before_production_work(
 
     _write_dspace_candidate(prod_manifest, "prod")
     prod_record = json.loads(prod_manifest.read_text(encoding="utf-8"))
-    prod_record["chartVersion"] = "3.1.1"
+    prod_record["chartVersion"] = "3.1.2"
     prod_manifest.write_text(json.dumps(prod_record) + "\n", encoding="utf-8")
     env = generic_app_stub_env.copy()
     env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
-    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.1"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.2"
     if staging_record_kind == "revision":
         env["SUGARKUBE_STUB_STAGING_HELM_REVISION"] = "8"
     for name in ("helm.log", "kubectl.log", "commands.log", "runtime-verifier.log"):


### PR DESCRIPTION
### Motivation

- Record a reviewed, machine-readable promotion target for the immutable DSPACE 3.1.1 image and chart 3.1.2 while preserving the immutable production baseline and existing failed reconciliation evidence. 
- Provide a fail-closed, offline planning/preflight tool that validates provenance, classifier and bounded runtime reports, and renders sanitized staging/production manifests without performing any Helm/Kubernetes mutation. 
- Add operator documentation and tests to make this preparation reviewable and auditable without contacting or changing live clusters, Secrets, or published evidence.

### Description

- Add `docs/apps/dspace.promotion-target.json` containing the reviewed immutable coordinates for application `3.1.1` / image `main-22f506e` and chart `3.1.2` with separate application and chart source revisions. 
- Advance only the staging chart pin in `docs/apps/dspace.staging.version` from `3.1.1` to `3.1.2` and update a short note in `docs/apps/dspace.md` to show this is a preparation pin; production pins and all production evidence remain unchanged. 
- Add `scripts/dspace_promotion_plan.py`, a fail-closed, offline-only planner that: validates exact artifact provenance and source reports; validates the preserved failed reconciliation via existing helpers; enforces classifier/source/runtime schema strictness; requires `image.pullPolicy=Always`, two replicas, rejects semantic tags/`--reuse-values`, rejects rendered Secrets and staging-only data in production, and prints a sanitized non-mutating plan. 
- Add tests `tests/test_dspace_promotion_plan.py` covering reviewed-target schema, rejection of coordinate drift, classifier strictness (no Secret values), rejection of historical staging evidence as authorization, acceptance of a synthetic finalized staging fixture only when all coordinates, provider (`openai`), runtime identity, smoke and metrics checks match, offline render expectations, and that the planner issues no mutation commands. 
- Add operator-facing documentation `docs/apps/dspace-3.1.1-promotion-preparation.md` describing scope (preparation only), required future sequence (genuine approval, fresh staging candidate, guarded staging deploy, smoke/metrics requirements, finalized staging evidence, then a separate production promotion task), and explicit statement that the existing `dspace-prod-metrics-pull-policy-recover` remains ineligible and must not be weakened or repurposed.

### Testing

- Ran focused unit suites and end-to-end repository checks: 
  - `python3 -m pytest -q tests/test_dspace_promotion_plan.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_dspace_runtime_values.py tests/test_dspace_runtime_verifier.py` and additional relevant suites; test run reported the repository test set used in development completed successfully (tests passed locally in this environment). 
  - `python3 -m pytest -q tests/test_generic_app_just_recipes.py` (updated staging-chart expectations) passed. 
  - `python3 scripts/observability_app_metrics.py validate` reported "Application metrics inventory is valid." 
  - `python3 scripts/app_config.py json --app dspace --env staging` and `--env prod` executed successfully. 
  - Formatting and imports checked: `black` and `isort` run on new files; `just --unstable --fmt --check` and `git diff --check` returned no repository errors. 
  - Secret-scan `git diff --cached | ./scripts/scan-secrets.py` ran and returned clean. 
- External artifact verification performed where possible: GHCR image index fetch returned the expected image-index digest and showed both `linux/amd64` and `linux/arm64` manifests and the index digest matched `sha256:467890df...`; chart OCI manifest fetch returned HTTP 401 for anonymous access in this environment, so chart digest/provenance verification could not be completed here and remains an operator-supplied required report for the planner. 
- Not-run / environment-limited checks: `pre-commit run --all-files`, `pyspelling`, and `linkchecker` were not available in the running environment and therefore were not executed here. 

Residual notes and risks

- This PR is strictly preparation-only: no cluster changes, no evidence finalization, no artifact publication, and no production promotion were performed. 
- Chart provenance verification (OCI manifest) requires authenticated access to GHCR in CI/operator environment; the planner continues to require an operator-supplied artifact provenance report when external verification is unavailable. 
- The preserved recovery and rollback helpers were reused (not weakened or repurposed) and the planner explicitly preserves fail-closed checks for the existing `dspace-prod-metrics-pull-policy-recover` flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eb71f7d78832fad7b8a5a98fc392f)