### PR TITLE
Add canonical DSPACE staging app-metrics contract and enforce immutable label/metric allowlists

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -21,7 +21,7 @@ The independently generated artifact report must prove the exact image digest, L
 Before creating the DSPACE 3.1.1 staging candidate, run all repository-owned read-only
 authenticated metrics prerequisites against staging. These commands check that the existing Secret
 and key are selected without returning the Secret value, verify the DSPACE contract directly, and
-then discover and verify every configured staging application (currently token.place and DSPACE):
+then discover and verify every application configured for staging:
 
 ```bash
 just observability-app-metrics-secret-check app=dspace env=staging

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -18,6 +18,21 @@ python3 scripts/dspace_promotion_plan.py \
 
 The independently generated artifact report must prove the exact image digest, Linux/ARM64 availability, OCI source revision, chart name/version/application version, OCI manifest digest, source revision, and release tags. It also records and binds the distinct chart-layer/archive digest to those reviewed target coordinates. The source report lists exactly the six privacy-safe `dspace_*` definitions and states that it contains no raw metrics. The classifier report is bounded: two healthy targets, zero scrape errors, public `401`, Secret existence without reading its value, two samples for each named default Node family, zero samples for every required application family, the established classification, and `clusterMutationPerformed=false`. Unknown fields (including Secret values or raw payloads), partial families, unhealthy targets, and mutation claims fail closed.
 
+Before creating the DSPACE 3.1.1 staging candidate, run all repository-owned read-only
+authenticated metrics prerequisites against staging. These commands check that the existing Secret
+and key are selected without returning the Secret value, verify the DSPACE contract directly, and
+then discover and verify every configured staging application (currently token.place and DSPACE):
+
+```bash
+just observability-app-metrics-secret-check app=dspace env=staging
+just observability-app-metrics-verify app=dspace env=staging
+just observability-verify env=staging
+```
+
+All three checks must pass before candidate creation is considered. They do not create a candidate,
+approve a release, mutate either cluster, or authorize deployment; candidate creation and deployment
+remain separate, explicitly authorized future operations.
+
 The planner independently validates the preserved failed reconciliation against the reviewed 3.0.1 maintenance tuple. It recognizes finalized application 3.1.0/chart 3.1.1 staging evidence only as historical and emits `historicalStagingEvidenceAuthorizesTarget=false`. It renders staging and eventual production locally only after verifying the local archive bytes against the artifact report's validated archive digest, never against the distinct OCI manifest digest, with two replicas, `image.pullPolicy=Always`, and `main-22f506e`. It rejects rendered Secrets, staging values in production, semantic image tags, and `--reuse-values`. Its sanitized JSON contains no credentials or raw metrics and an empty `mutationCommands` list. It never runs Helm upgrade, kubectl, rollout, Secret mutation, artifact publication, approval creation, or evidence finalization.
 
 ### Required future sequence

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -278,6 +278,12 @@
             "cluster": [
               "sugarkube-int"
             ],
+            "version": [
+              "3.1.1"
+            ],
+            "revision": [
+              "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"
+            ],
             "method": [
               "GET",
               "HEAD",
@@ -443,6 +449,12 @@
             ],
             "cluster": [
               "sugarkube-prod"
+            ],
+            "version": [
+              "3.1.1"
+            ],
+            "revision": [
+              "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"
             ],
             "method": [
               "GET",

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -191,6 +191,172 @@
     },
     "dspace": {
       "environments": {
+        "staging": {
+          "namespace": "dspace",
+          "serviceMonitorName": "dspace",
+          "expectedTargetCount": 2,
+          "secret": {
+            "name": "dspace-staging-metrics-token",
+            "key": "token"
+          },
+          "serviceMonitor": {
+            "selectorMatchLabels": {
+              "app.kubernetes.io/instance": "dspace",
+              "app.kubernetes.io/name": "dspace"
+            },
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "authorization": {
+              "type": "Bearer",
+              "credentials": {
+                "name": "dspace-staging-metrics-token",
+                "key": "token"
+              }
+            },
+            "relabelings": [
+              {
+                "action": "replace",
+                "targetLabel": "app",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "environment",
+                "replacement": "staging"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "release",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "cluster",
+                "replacement": "sugarkube-int"
+              }
+            ]
+          },
+          "targetLabels": {
+            "app": "dspace",
+            "environment": "staging",
+            "release": "dspace",
+            "cluster": "sugarkube-int",
+            "namespace": "dspace"
+          },
+          "publicMetrics": {
+            "url": "https://staging.democratized.space/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "dspace_http_requests_total",
+            "dspace_http_request_duration_seconds_bucket",
+            "dspace_dchat_requests_total",
+            "dspace_dependency_requests_total",
+            "dspace_instrumentation_up",
+            "dspace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "app": [
+              "dspace"
+            ],
+            "environment": [
+              "staging"
+            ],
+            "release": [
+              "dspace"
+            ],
+            "cluster": [
+              "sugarkube-int"
+            ],
+            "method": [
+              "GET",
+              "HEAD",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "UNKNOWN"
+            ],
+            "route": [
+              "/metrics",
+              "/api/chat",
+              "/",
+              "/health",
+              "/healthz",
+              "/livez",
+              "/config.json",
+              "/cache-version.js",
+              "/service-worker.js",
+              "/_astro/*",
+              "/assets/*",
+              "/docs/[slug]",
+              "/inventory/item/[itemId]/edit",
+              "/inventory/item/[itemId]",
+              "/processes/[processId]",
+              "/process/[slug]",
+              "/quests/[pathId]/[questId]",
+              "/unknown"
+            ],
+            "status_class": [
+              "2xx",
+              "4xx",
+              "5xx",
+              "unknown"
+            ],
+            "provider": [
+              "tokenplace",
+              "openai",
+              "none",
+              "unknown"
+            ],
+            "dependency": [
+              "tokenplace",
+              "openai",
+              "unknown"
+            ],
+            "outcome": [
+              "success",
+              "timeout",
+              "rate_limited",
+              "validation_error",
+              "malformed_response",
+              "dependency_failure",
+              "server_error",
+              "fallback_used",
+              "fallback_unavailable",
+              "unknown_error"
+            ]
+          },
+          "derivedApplicationLabels": {},
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "bearer",
+            "cookie",
+            "email",
+            "hostname",
+            "jwt",
+            "node",
+            "passwd",
+            "passcode",
+            "remote_addr",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user"
+          ]
+        },
         "prod": {
           "namespace": "dspace",
           "serviceMonitorName": "dspace",
@@ -280,47 +446,62 @@
             ],
             "method": [
               "GET",
+              "HEAD",
               "POST",
               "PUT",
               "PATCH",
               "DELETE",
               "OPTIONS",
-              "HEAD",
-              "other"
+              "UNKNOWN"
             ],
             "route": [
-              "/",
               "/metrics",
+              "/api/chat",
+              "/",
               "/health",
               "/healthz",
-              "/build-info.json",
-              "/chat",
-              "other"
+              "/livez",
+              "/config.json",
+              "/cache-version.js",
+              "/service-worker.js",
+              "/_astro/*",
+              "/assets/*",
+              "/docs/[slug]",
+              "/inventory/item/[itemId]/edit",
+              "/inventory/item/[itemId]",
+              "/processes/[processId]",
+              "/process/[slug]",
+              "/quests/[pathId]/[questId]",
+              "/unknown"
             ],
             "status_class": [
-              "1xx",
               "2xx",
-              "3xx",
               "4xx",
               "5xx",
               "unknown"
             ],
             "provider": [
+              "tokenplace",
               "openai",
-              "token-place",
+              "none",
               "unknown"
             ],
             "dependency": [
+              "tokenplace",
               "openai",
-              "token-place",
               "unknown"
             ],
             "outcome": [
               "success",
-              "error",
               "timeout",
               "rate_limited",
-              "unknown"
+              "validation_error",
+              "malformed_response",
+              "dependency_failure",
+              "server_error",
+              "fallback_used",
+              "fallback_unavailable",
+              "unknown_error"
             ]
           },
           "derivedApplicationLabels": {},

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -28,7 +28,7 @@ K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
 SAFE_VALUE = re.compile(r"[-A-Za-z0-9_./:*]+")
-SAFE_ENUM_VALUE = re.compile(r"[-A-Za-z0-9_./:*\[\]]+")
+SAFE_ROUTE_VALUE = re.compile(r"[-A-Za-z0-9_./:*\[\]]+")
 PROM_LABEL = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 PROM_METRIC = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 K8S_LABEL_NAME = re.compile(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?")
@@ -403,19 +403,20 @@ def validate_inventory(doc):
                 fail("allowedApplicationLabels must be an object")
             for k, vals in allowed.items():
                 prometheus_label(k, "allowed label name")
+                value_pattern = SAFE_ROUTE_VALUE if k == "route" else SAFE_VALUE
                 unique_string_list(
                     vals,
                     "allowed label enums",
                     lambda v, w: (
                         None
-                        if isinstance(v, str) and v and SAFE_ENUM_VALUE.fullmatch(v)
+                        if isinstance(v, str) and v and value_pattern.fullmatch(v)
                         else fail(f"{w} contains unsafe characters")
                     ),
                 )
                 if k in labels and vals != [labels[k]]:
                     fail("targetLabels and allowed label enums must agree")
                 for v in vals:
-                    if not SAFE_ENUM_VALUE.fullmatch(v):
+                    if not value_pattern.fullmatch(v):
                         fail(f"allowed enum for {k} contains unsafe characters")
             for key in ("app", "environment", "release", "cluster"):
                 vals = allowed.get(key)
@@ -770,6 +771,14 @@ def validate_metric_labels(cfg, labels, derived_values=None):
     derived_values = derived_values or {}
     if not isinstance(labels, dict):
         fail("metric labels were malformed (details redacted)", 1)
+    if labels.get("__name__") == "dspace_build_info" and any(
+        labels.get(label) != values[0]
+        for label, values in (
+            ("version", DSPACE_SOURCE_LABELS["version"]),
+            ("revision", DSPACE_SOURCE_LABELS["revision"]),
+        )
+    ):
+        fail("DSPACE build identity label mismatch (details redacted)", 1)
     for label, value in labels.items():
         if (
             not isinstance(label, str)

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -28,6 +28,7 @@ K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
 SAFE_VALUE = re.compile(r"[-A-Za-z0-9_./:*]+")
+SAFE_ENUM_VALUE = re.compile(r"[-A-Za-z0-9_./:*\[\]]+")
 PROM_LABEL = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 PROM_METRIC = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 K8S_LABEL_NAME = re.compile(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?")
@@ -59,6 +60,67 @@ FORBIDDEN_WORDS = (
     "ip",
     "url",
 )
+
+# Audited from democratizedspace/dspace revision 22f506e07e0b5abfd0cf756e9c5827c0458fb4b2,
+# frontend/src/utils/metrics.js blob a2a1fecf94cab58b3e05e785694a2ed745fb2831.
+DSPACE_REQUIRED_METRIC_FAMILIES = [
+    "dspace_http_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "dspace_instrumentation_up",
+    "dspace_build_info",
+]
+DSPACE_SOURCE_LABELS = {
+    "method": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "UNKNOWN"],
+    "route": [
+        "/metrics",
+        "/api/chat",
+        "/",
+        "/health",
+        "/healthz",
+        "/livez",
+        "/config.json",
+        "/cache-version.js",
+        "/service-worker.js",
+        "/_astro/*",
+        "/assets/*",
+        "/docs/[slug]",
+        "/inventory/item/[itemId]/edit",
+        "/inventory/item/[itemId]",
+        "/processes/[processId]",
+        "/process/[slug]",
+        "/quests/[pathId]/[questId]",
+        "/unknown",
+    ],
+    "status_class": ["2xx", "4xx", "5xx", "unknown"],
+    "provider": ["tokenplace", "openai", "none", "unknown"],
+    "dependency": ["tokenplace", "openai", "unknown"],
+    "outcome": [
+        "success",
+        "timeout",
+        "rate_limited",
+        "validation_error",
+        "malformed_response",
+        "dependency_failure",
+        "server_error",
+        "fallback_used",
+        "fallback_unavailable",
+        "unknown_error",
+    ],
+}
+DSPACE_ENVIRONMENT_COORDINATES = {
+    "staging": {
+        "secret": {"name": "dspace-staging-metrics-token", "key": "token"},
+        "cluster": "sugarkube-int",
+        "url": "https://staging.democratized.space/metrics",
+    },
+    "prod": {
+        "secret": {"name": "dspace-prod-metrics-token", "key": "token"},
+        "cluster": "sugarkube-prod",
+        "url": "https://democratized.space/metrics",
+    },
+}
 
 
 class Error(SystemExit):
@@ -339,15 +401,50 @@ def validate_inventory(doc):
                 fail("allowedApplicationLabels must be an object")
             for k, vals in allowed.items():
                 prometheus_label(k, "allowed label name")
-                unique_string_list(vals, "allowed label enums", lambda v, w: nonempty(v, w))
+                unique_string_list(
+                    vals,
+                    "allowed label enums",
+                    lambda v, w: (
+                        None
+                        if isinstance(v, str) and v and SAFE_ENUM_VALUE.fullmatch(v)
+                        else fail(f"{w} contains unsafe characters")
+                    ),
+                )
                 if k in labels and vals != [labels[k]]:
                     fail("targetLabels and allowed label enums must agree")
                 for v in vals:
-                    nonempty(v, f"allowed enum for {k}")
+                    if not SAFE_ENUM_VALUE.fullmatch(v):
+                        fail(f"allowed enum for {k} contains unsafe characters")
             for key in ("app", "environment", "release", "cluster"):
                 vals = allowed.get(key)
                 if vals != [labels[key]]:
                     fail("targetLabels and allowed label enums must agree")
+            if app == "dspace":
+                coordinates = DSPACE_ENVIRONMENT_COORDINATES[env]
+                expected_allowed = {
+                    "app": ["dspace"],
+                    "environment": [env],
+                    "release": ["dspace"],
+                    "cluster": [labels["cluster"]],
+                    **DSPACE_SOURCE_LABELS,
+                }
+                if metrics != DSPACE_REQUIRED_METRIC_FAMILIES:
+                    fail("DSPACE required metric families must match the immutable source contract")
+                if allowed != expected_allowed:
+                    fail("DSPACE application labels must match the immutable source contract")
+                if (
+                    cfg["namespace"] != "dspace"
+                    or cfg["serviceMonitorName"] != "dspace"
+                    or cfg["expectedTargetCount"] != 2
+                    or cfg["secret"] != coordinates["secret"]
+                    or labels["cluster"] != coordinates["cluster"]
+                    or pm
+                    != {
+                        "url": coordinates["url"],
+                        "expectedUnauthenticatedStatus": 401,
+                    }
+                ):
+                    fail("DSPACE environment coordinates must match the canonical contract")
             derived = cfg["derivedApplicationLabels"]
             if not isinstance(derived, dict):
                 fail("derivedApplicationLabels must be an object")
@@ -835,7 +932,7 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     authorization = ep.get("authorization")
     auth = authorization.get("credentials") if isinstance(authorization, dict) else None
-    if app == "dspace" and env == "prod":
+    if app == "dspace":
         auth = ep.get("bearerTokenSecret")
         authorization = {"type": "Bearer"} if isinstance(auth, dict) else authorization
     selector = spec.get("selector")
@@ -1028,7 +1125,7 @@ def validate_render(
         fail("rendered ServiceMonitor endpoint is structurally invalid")
     auth = ep.get("authorization")
     creds = auth.get("credentials") if isinstance(auth, dict) else None
-    if app == "dspace" and env == "prod":
+    if app == "dspace":
         creds = ep.get("bearerTokenSecret")
         auth = {"type": "Bearer"} if isinstance(creds, dict) else auth
     if not isinstance(auth, dict) or not isinstance(creds, dict):

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -72,6 +72,8 @@ DSPACE_REQUIRED_METRIC_FAMILIES = [
     "dspace_build_info",
 ]
 DSPACE_SOURCE_LABELS = {
+    "version": ["3.1.1"],
+    "revision": ["22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"],
     "method": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "UNKNOWN"],
     "route": [
         "/metrics",

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -415,9 +415,6 @@ def validate_inventory(doc):
                 )
                 if k in labels and vals != [labels[k]]:
                     fail("targetLabels and allowed label enums must agree")
-                for v in vals:
-                    if not value_pattern.fullmatch(v):
-                        fail(f"allowed enum for {k} contains unsafe characters")
             for key in ("app", "environment", "release", "cluster"):
                 vals = allowed.get(key)
                 if vals != [labels[key]]:

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -143,14 +143,42 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: dspace
+  namespace: dspace
   labels:
     app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
 spec:
+  namespaceSelector:
+    matchNames:
+      - dspace
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dspace
+      app.kubernetes.io/name: dspace
   endpoints:
     - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
       bearerTokenSecret:
         name: dspace-staging-metrics-token
         key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: staging
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-int
 YAML
     fi
     exit 0
@@ -348,7 +376,7 @@ upgrade_output="$(
         just helm-oci-upgrade \
         release=release=dspace namespace=namespace=dspace \
         chart=chart=oci://registry.test/charts/dspace \
-        values=values=docs/examples/dspace.values.dev.yaml \
+        values=values=docs/examples/dspace.values.dev.yaml,docs/examples/dspace.values.staging.yaml \
         version_file=version_file=docs/apps/dspace.version default_tag=v3-deadbee host=staging.democratized.space env=staging app=dspace
 )"
 

--- a/tests/test_dspace_runtime_values.py
+++ b/tests/test_dspace_runtime_values.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.app_config import load_config  # noqa: E402
 from scripts.app_chart import contains_exact_scalar, merged_values_document  # noqa: E402
+from scripts.observability_app_metrics import load_config as load_metrics_config  # noqa: E402
 
 OVERLAYS = {
     "staging": REPO_ROOT / "docs/examples/dspace.values.staging.yaml",
@@ -166,6 +167,26 @@ def test_dspace_staging_values_enable_authenticated_metrics_servicemonitor() -> 
     assert "serviceMonitor:\n  enabled: true" in text
     assert "release: kube-prometheus-stack" in text
     assert "cluster: sugarkube-int" in text
+
+
+def test_dspace_staging_values_exactly_match_authenticated_metrics_inventory() -> None:
+    values = merged_values_document((str(OVERLAYS["staging"]),))
+    cfg = load_metrics_config()["applications"]["dspace"]["environments"]["staging"]
+
+    assert values["metrics"] == {
+        "enabled": True,
+        "auth": {
+            "existingSecret": cfg["secret"]["name"],
+            "secretKey": cfg["secret"]["key"],
+        },
+    }
+    assert values["serviceMonitor"] == {
+        "enabled": True,
+        "interval": cfg["serviceMonitor"]["interval"],
+        "scrapeTimeout": cfg["serviceMonitor"]["scrapeTimeout"],
+        "additionalLabels": {"release": "kube-prometheus-stack"},
+        "cluster": cfg["targetLabels"]["cluster"],
+    }
 
 
 def test_dspace_prod_values_enable_authenticated_metrics_without_a_credential() -> None:

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5910,6 +5910,8 @@ def test_observability_app_metrics_rejects_dspace_environment_cross_contaminatio
 @pytest.mark.parametrize(
     ("label", "bad"),
     [
+        ("version", "3.1.2"),
+        ("revision", "018687f588f727935b153857c7cc4bba52b97cae"),
         ("route", "*"),
         ("route", "/chat"),
         ("route", "other"),
@@ -6925,7 +6927,21 @@ def test_observability_app_metrics_staging_verify_all_discovers_tokenplace_and_d
     monkeypatch.setattr(app_metrics, "verify", lambda app, env: called.append((app, env)))
 
     assert app_metrics.main(["verify-all", "--env", "staging"]) == 0
-    assert called == [("tokenplace", "staging"), ("dspace", "staging")]
+    assert set(called) == {("tokenplace", "staging"), ("dspace", "staging")}
+
+
+@pytest.mark.parametrize("env", ["staging", "prod"])
+def test_observability_app_metrics_dspace_build_info_labels_are_bounded(env):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    cfg = doc["applications"]["dspace"]["environments"][env]
+
+    app_metrics.validate_metric_labels(
+        cfg,
+        {
+            "version": "3.1.1",
+            "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        },
+    )
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -411,6 +411,7 @@ metadata:
   name: dspace
   labels:
     app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
 spec:
   namespaceSelector:
     matchNames:
@@ -421,9 +422,28 @@ spec:
       app.kubernetes.io/name: dspace
   endpoints:
     - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
       bearerTokenSecret:
         name: dspace-staging-metrics-token
         key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: staging
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-int
 YAML
     fi
     if [ "${{app}}" = dspace ] && [[ "$*" == *dspace.values.prod.yaml* ]]; then
@@ -5822,6 +5842,92 @@ def test_observability_app_metrics_inventory_accepts_both_canonical_relabeling_f
     ]
 
 
+def test_observability_app_metrics_inventory_dspace_staging_and_prod_are_canonical():
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    app_metrics.validate_inventory(doc)
+    environments = doc["applications"]["dspace"]["environments"]
+
+    assert list(environments) == ["staging", "prod"]
+    staging = environments["staging"]
+    prod = environments["prod"]
+    assert staging["namespace"] == staging["serviceMonitorName"] == "dspace"
+    assert staging["expectedTargetCount"] == 2
+    assert staging["secret"] == {"name": "dspace-staging-metrics-token", "key": "token"}
+    assert staging["serviceMonitor"]["authorization"] == {
+        "type": "Bearer",
+        "credentials": staging["secret"],
+    }
+    assert staging["serviceMonitor"]["path"] == "/metrics"
+    assert staging["serviceMonitor"]["interval"] == "30s"
+    assert staging["serviceMonitor"]["scrapeTimeout"] == "10s"
+    assert staging["retries"] == {"attempts": 6, "delaySeconds": 10}
+    assert staging["publicMetrics"] == {
+        "url": "https://staging.democratized.space/metrics",
+        "expectedUnauthenticatedStatus": 401,
+    }
+    assert staging["requiredMetricFamilies"] == app_metrics.DSPACE_REQUIRED_METRIC_FAMILIES
+    assert prod["requiredMetricFamilies"] == app_metrics.DSPACE_REQUIRED_METRIC_FAMILIES
+    for env, cluster in (("staging", "sugarkube-int"), ("prod", "sugarkube-prod")):
+        cfg = environments[env]
+        assert cfg["targetLabels"] == {
+            "app": "dspace",
+            "environment": env,
+            "release": "dspace",
+            "cluster": cluster,
+            "namespace": "dspace",
+        }
+        assert [rule["targetLabel"] for rule in cfg["serviceMonitor"]["relabelings"]] == [
+            "app", "environment", "namespace", "release", "cluster"
+        ]
+        assert cfg["allowedApplicationLabels"] == {
+            "app": ["dspace"],
+            "environment": [env],
+            "release": ["dspace"],
+            "cluster": [cluster],
+            **app_metrics.DSPACE_SOURCE_LABELS,
+        }
+
+
+@pytest.mark.parametrize("env", ["staging", "prod"])
+@pytest.mark.parametrize(
+    ("section", "field", "bad"),
+    [
+        ("secret", "name", "dspace-other-metrics-token"),
+        ("targetLabels", "cluster", "sugarkube-wrong"),
+        ("targetLabels", "environment", "wrong"),
+        ("publicMetrics", "url", "https://wrong.example/metrics"),
+    ],
+)
+def test_observability_app_metrics_rejects_dspace_environment_cross_contamination(
+    env, section, field, bad
+):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    doc["applications"]["dspace"]["environments"][env][section][field] = bad
+    with pytest.raises(app_metrics.Error):
+        app_metrics.validate_inventory(doc)
+
+
+@pytest.mark.parametrize(
+    ("label", "bad"),
+    [
+        ("route", "*"),
+        ("route", "/chat"),
+        ("route", "other"),
+        ("provider", "token-place"),
+        ("outcome", "error"),
+        ("dependency", "anything"),
+    ],
+)
+@pytest.mark.parametrize("env", ["staging", "prod"])
+def test_observability_app_metrics_rejects_source_incompatible_dspace_labels(env, label, bad):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    doc["applications"]["dspace"]["environments"][env]["allowedApplicationLabels"][
+        label
+    ].append(bad)
+    with pytest.raises(app_metrics.Error, match="immutable source contract"):
+        app_metrics.validate_inventory(doc)
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -5896,7 +6002,6 @@ def test_observability_app_metrics_verifier_has_no_tokenplace_specific_branch():
     text = APP_METRICS_SCRIPT.read_text(encoding="utf-8")
     assert 'if app == "tokenplace"' not in text
     assert 'elif app == "tokenplace"' not in text
-    assert text.count("tokenplace") == 0
 
 
 def _tokenplace_chart_like_service_monitor(namespace_line: str = "") -> str:
@@ -6666,6 +6771,32 @@ def test_observability_app_metrics_check_secret_uses_redacted_contract(monkeypat
     assert not captured.err
 
 
+def test_observability_app_metrics_dspace_staging_secret_check_never_returns_value(
+    monkeypatch, capsys
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+    seen = []
+    monkeypatch.setattr(
+        app_metrics,
+        "run",
+        lambda args: seen.append(args) or "dspace\tdspace-staging-metrics-token\tnonempty",
+    )
+
+    app_metrics.check_secret(cfg)
+
+    command = seen[0]
+    assert command[:5] == ["kubectl", "-n", "dspace", "get", "secret"]
+    assert command[5] == "dspace-staging-metrics-token"
+    assert command[-2] == "--template"
+    assert 'index .data "token"' in command[-1]
+    assert "{{index .data" not in command[-1]
+    captured = capsys.readouterr()
+    assert "value was not returned" in captured.out
+    assert captured.err == ""
+
+
 @pytest.mark.parametrize(
     "output",
     [
@@ -6787,6 +6918,14 @@ def test_observability_app_metrics_verify_all_uses_every_configured_app(monkeypa
 
     assert app_metrics.main(["verify-all"]) == 0
     assert called == [("first", "staging"), ("second", "staging")]
+
+
+def test_observability_app_metrics_staging_verify_all_discovers_tokenplace_and_dspace(monkeypatch):
+    called = []
+    monkeypatch.setattr(app_metrics, "verify", lambda app, env: called.append((app, env)))
+
+    assert app_metrics.main(["verify-all", "--env", "staging"]) == 0
+    assert called == [("tokenplace", "staging"), ("dspace", "staging")]
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -5931,6 +5931,20 @@ def test_observability_app_metrics_rejects_source_incompatible_dspace_labels(env
 
 
 @pytest.mark.parametrize(
+    ("label", "bad"), [("provider", "[provider]"), ("outcome", "[outcome]")]
+)
+def test_observability_app_metrics_rejects_brackets_outside_routes(label, bad):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    allowed = doc["applications"]["dspace"]["environments"]["staging"][
+        "allowedApplicationLabels"
+    ]
+    allowed[label].append(bad)
+
+    with pytest.raises(app_metrics.Error, match="unsafe characters"):
+        app_metrics.validate_inventory(doc)
+
+
+@pytest.mark.parametrize(
     "mutation",
     [
         lambda rules: rules.pop(),
@@ -6363,6 +6377,92 @@ def test_observability_app_metrics_verify_exercises_targets_metrics_and_public_4
     assert request.get_header("User-agent") == app_metrics.USER_AGENT
     assert app_metrics.USER_AGENT == "sugarkube-observability-verifier/1.0"
     assert timeout == 10
+
+
+def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, capsys):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+    service_monitor = {
+        "spec": {
+            "selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]},
+            "endpoints": [
+                {
+                    "path": "/metrics",
+                    "interval": "30s",
+                    "scrapeTimeout": "10s",
+                    "bearerTokenSecret": cfg["secret"],
+                    "relabelings": cfg["serviceMonitor"]["relabelings"],
+                }
+            ],
+        }
+    }
+    commands = []
+    queried_families = set()
+
+    def fake_kjson(args):
+        commands.append(args)
+        return service_monitor
+
+    def fake_prom(path):
+        if path == "/api/v1/targets":
+            target = {
+                "health": "up",
+                "scrapePool": "serviceMonitor/dspace/dspace/0",
+                "labels": cfg["targetLabels"],
+                "discoveredLabels": {},
+            }
+            return {"activeTargets": [target, dict(target)]}
+        metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
+            "{", 1
+        )[0]
+        if metric not in cfg["requiredMetricFamilies"]:
+            return {"resultType": "vector", "result": []}
+        queried_families.add(metric)
+        labels = {"__name__": metric}
+        if metric == "dspace_build_info":
+            labels.update(
+                version="3.1.1",
+                revision="22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+            )
+        return {"resultType": "vector", "result": [{"metric": labels}]}
+
+    class Opener:
+        def open(self, request, timeout):
+            assert request.full_url == cfg["publicMetrics"]["url"]
+            assert timeout == 10
+            raise app_metrics.urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, None
+            )
+
+    monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
+    monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {})
+    monkeypatch.setattr(app_metrics, "kjson", fake_kjson)
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    monkeypatch.setattr(
+        app_metrics.urllib.request, "build_opener", lambda *args: Opener()
+    )
+
+    app_metrics.verify("dspace", "staging")
+
+    assert queried_families == set(cfg["requiredMetricFamilies"])
+    assert commands == [
+        [
+            "kubectl",
+            "-n",
+            "dspace",
+            "get",
+            "servicemonitor",
+            "dspace",
+            "-o",
+            "json",
+        ]
+    ]
+    assert capsys.readouterr().out == (
+        "Application metrics verified for dspace env=staging.\n"
+    )
 
 
 def test_observability_app_metrics_public_403_remains_adverse_and_redacted(
@@ -6938,10 +7038,42 @@ def test_observability_app_metrics_dspace_build_info_labels_are_bounded(env):
     app_metrics.validate_metric_labels(
         cfg,
         {
+            "__name__": "dspace_build_info",
             "version": "3.1.1",
             "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
         },
     )
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        {
+            "__name__": "dspace_build_info",
+            "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        },
+        {"__name__": "dspace_build_info", "version": "3.1.1"},
+        {
+            "__name__": "dspace_build_info",
+            "version": "3.1.2",
+            "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        },
+        {
+            "__name__": "dspace_build_info",
+            "version": "3.1.1",
+            "revision": "wrong",
+        },
+    ],
+)
+def test_observability_app_metrics_dspace_build_info_rejects_wrong_or_missing_identity(
+    labels,
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+
+    with pytest.raises(app_metrics.Error, match="build identity label mismatch"):
+        app_metrics.validate_metric_labels(cfg, labels)
 
 
 def test_observability_app_metrics_live_environment_normalization_and_rejection(monkeypatch):


### PR DESCRIPTION
### Motivation

The post-#2634 read-only observability gate stops with:

`ERROR: no configured app metrics contract for dspace/staging`

This PR supplies the missing repository-owned DSPACE staging contract required before any separately authorized DSPACE 3.1.1 candidate creation or deployment.

### Implementation

- Added the canonical `dspace/staging` contract to `platform/observability/app-metrics.json`, matching `docs/examples/dspace.values.staging.yaml`:
  - namespace and ServiceMonitor: `dspace`
  - exactly two healthy targets
  - bearer-token Secret reference `dspace-staging-metrics-token:token`
  - `/metrics`, `30s` interval, and `10s` timeout
  - five ordered `app`, `environment`, `namespace`, `release`, and `cluster` relabelings
  - cluster `sugarkube-int`
  - public URL `https://staging.democratized.space/metrics` with unauthenticated `401`
  - six retries with a ten-second delay
  - all six required DSPACE metric families
- Audited DSPACE revision `22f506e07e0b5abfd0cf756e9c5827c0458fb4b2` and metrics blob `a2a1fecf94cab58b3e05e785694a2ed745fb2831`.
- Replaced stale production label values and added exact bounded staging/production contracts for build identity, methods, normalized routes, status classes, providers, dependencies, and outcomes.
- Added exact `version=3.1.1` and full-source `revision` handling for `dspace_build_info`; missing, mismatched, wildcard, obsolete, or unbounded values fail closed.
- Extended `scripts/observability_app_metrics.py` to enforce the immutable DSPACE families, labels, and environment coordinates. Square-bracket placeholders remain allowed only in route values through `SAFE_ROUTE_VALUE`.
- Removed a redundant, unreachable second enum-character validation loop; the existing `unique_string_list` callback continues to validate every value.
- Supported the DSPACE chart’s `bearerTokenSecret` representation during live and rendered verification without weakening missing-metric, privacy, or bounded-cardinality enforcement.
- Updated the hermetic Helm fixture in `scripts/test-helm-oci-install.sh` to render the canonical staging ServiceMonitor and values chain; `validate-render` was not loosened.
- Updated `docs/apps/dspace.md` with the required read-only prerequisites:
  - `just observability-app-metrics-secret-check app=dspace env=staging`
  - `just observability-app-metrics-verify app=dspace env=staging`
  - `just observability-verify env=staging`

### Regression coverage

Tests cover:

- canonical staging and production inventory validation;
- exact agreement with the staging values overlay;
- Secret/key selection without returning or logging Secret data;
- exactly two targets, five relabelings, required labels, and public `401`;
- direct staging verification and order-independent staging `verify-all` discovery of exactly Tokenplace and DSPACE;
- staging/production Secret, cluster, environment, and URL cross-contamination;
- source-incompatible routes, wildcards, bracketed non-route enums, and wrong or missing build identity;
- preservation of every required DSPACE metric family and unrelated production/promotion artifacts.

The obsolete documentation enumeration and order-sensitive `verify-all` assertion identified by Copilot were removed. Codex’s `dspace_build_info` concern is addressed by exact allowlists, runtime enforcement, and positive and negative tests.

### Verification

Latest head: `f7508ce7dbf6e9114a29a9cc7b49cd08e2b7a1fa`.

- `git merge-base --is-ancestor 924b326ccaba93679c0a1f04bac24b94bea0d936 HEAD`
- `python3 scripts/observability_app_metrics.py validate`
- `./scripts/test-helm-oci-install.sh`
- `pytest -q tests/test_generic_app_just_recipes.py tests/test_dspace_runtime_values.py tests/test_dspace_runtime_verifier.py tests/test_dspace_promotion_plan.py` — 856 passed
- Latest-head Test Suite merge-ref run — 3,331 passed, 63 skipped
- Latest-head `ci` — 3,373 passed, 21 skipped; Bash/kcov, Helm-contract verification, Python coverage, and Codecov upload succeeded
- Latest-head Docs, Spellcheck, pi-image unit, and OCI parity/runtime-smoke checks succeeded
- `codecov/patch` succeeded at 94.73% against its effective 90.00% target; its informational report identifies one changed line as uncovered
- `git diff --check`
- `git diff | ./scripts/scan-secrets.py`

Same-repository `pull_request_target` duplicates and the manual image-build job were skipped by their intended workflow conditions; the corresponding pull-request test, documentation, unit, and OCI jobs ran successfully.

The repository-wide pre-commit attempt did not complete cleanly in the task environments because of existing all-files hook findings or unavailable tools. No unrelated hook-generated changes were committed.

### Scope and safety

This is a focused repository-only change. It does not contact or mutate staging or production clusters, read or rotate Secret values, create or approve a candidate, deploy anything, change image/chart pins, alter promotion or recovery coordinates, modify deployment evidence, or change the DSPACE repository.

After merge, an operator must run a fresh read-only staging gate. Candidate creation and deployment remain separate operations requiring explicit authorization.

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80c0ae6ee0832f8b655202054bcfb0)