### PR TITLE
Add canonical DSPACE staging app-metrics contract and tighten DSPACE label allowlists

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -24,12 +24,26 @@ The planner independently validates the preserved failed reconciliation against 
 
 This preparation is not approval or deployment evidence. A future operator must, in order:
 
-1. Record genuine operator approval metadata for the exact 3.1.1/3.1.2 coordinates.
-2. Create a fresh staging candidate for those coordinates and deploy it through the existing guarded release-manifest machinery.
-3. Prove exactly two Ready replicas at the reviewed image digest; matching runtime and frontend source identity; public/direct agreement; and the intended eventual production provider `openai`.
-4. Run a bounded remote `/chat` smoke and prove two healthy authenticated Prometheus targets with no scrape errors. Prove all six required families: `dspace_build_info`, `dspace_dchat_requests_total`, `dspace_dependency_requests_total`, `dspace_http_request_duration_seconds_bucket`, `dspace_http_requests_total`, and `dspace_instrumentation_up`. Where counters require traffic, capture a real server-observed chat/dependency journey without response bodies, tokens, Secret values, or raw metrics payloads.
-5. Finalize fresh, non-overwritable staging evidence only after every check succeeds. The optional `--staging-proof` input accepts it only when every coordinate, `openai`, identity, metrics, and smoke result matches.
-6. Only a separate future repository task may add a guarded, one-shot successor to production Helm revision 10. The old classifier and historical staging evidence cannot authorize it.
+1. After this repository contract has merged, run the repository-owned read-only staging
+   prerequisites. The Secret check proves only the configured name/key and never returns its value;
+   the single-app check verifies DSPACE; and the full staging check discovers and verifies both
+   token.place and DSPACE:
+
+   ```bash
+   just observability-app-metrics-secret-check app=dspace env=staging
+   just observability-app-metrics-verify app=dspace env=staging
+   just observability-verify env=staging
+   ```
+
+   All three checks must pass freshly before creating the DSPACE 3.1.1 staging candidate. These
+   commands do not create a candidate, approve a release, deploy an application, or mutate either
+   cluster.
+2. Record genuine operator approval metadata for the exact 3.1.1/3.1.2 coordinates.
+3. Create a fresh staging candidate for those coordinates and deploy it through the existing guarded release-manifest machinery.
+4. Prove exactly two Ready replicas at the reviewed image digest; matching runtime and frontend source identity; public/direct agreement; and the intended eventual production provider `openai`.
+5. Run a bounded remote `/chat` smoke and prove two healthy authenticated Prometheus targets with no scrape errors. Prove all six required families: `dspace_build_info`, `dspace_dchat_requests_total`, `dspace_dependency_requests_total`, `dspace_http_request_duration_seconds_bucket`, `dspace_http_requests_total`, and `dspace_instrumentation_up`. Where counters require traffic, capture a real server-observed chat/dependency journey without response bodies, tokens, Secret values, or raw metrics payloads.
+6. Finalize fresh, non-overwritable staging evidence only after every check succeeds. The optional `--staging-proof` input accepts it only when every coordinate, `openai`, identity, metrics, and smoke result matches.
+7. Only a separate future repository task may add a guarded, one-shot successor to production Helm revision 10. The old classifier and historical staging evidence cannot authorize it.
 
 The existing `dspace-prod-metrics-pull-policy-recover` operation remains ineligible for this incident: application 3.0.1 cannot supply the required metrics. Preserve its preflight and verifier unchanged; do not rerun, weaken, bypass, or repurpose it as an application promotion. Do not roll back or uninstall Helm, and do not read, rotate, or delete the metrics Secret. Issues #2325 and #2329 remain closed unless a human chooses otherwise, and issue #2408 is separate and must not be modified or conflated.
 

--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -191,6 +191,172 @@
     },
     "dspace": {
       "environments": {
+        "staging": {
+          "namespace": "dspace",
+          "serviceMonitorName": "dspace",
+          "expectedTargetCount": 2,
+          "secret": {
+            "name": "dspace-staging-metrics-token",
+            "key": "token"
+          },
+          "serviceMonitor": {
+            "selectorMatchLabels": {
+              "app.kubernetes.io/instance": "dspace",
+              "app.kubernetes.io/name": "dspace"
+            },
+            "path": "/metrics",
+            "interval": "30s",
+            "scrapeTimeout": "10s",
+            "authorization": {
+              "type": "Bearer",
+              "credentials": {
+                "name": "dspace-staging-metrics-token",
+                "key": "token"
+              }
+            },
+            "relabelings": [
+              {
+                "action": "replace",
+                "targetLabel": "app",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "environment",
+                "replacement": "staging"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "namespace",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "release",
+                "replacement": "dspace"
+              },
+              {
+                "action": "replace",
+                "targetLabel": "cluster",
+                "replacement": "sugarkube-int"
+              }
+            ]
+          },
+          "targetLabels": {
+            "app": "dspace",
+            "environment": "staging",
+            "release": "dspace",
+            "cluster": "sugarkube-int",
+            "namespace": "dspace"
+          },
+          "publicMetrics": {
+            "url": "https://staging.democratized.space/metrics",
+            "expectedUnauthenticatedStatus": 401
+          },
+          "retries": {
+            "attempts": 6,
+            "delaySeconds": 10
+          },
+          "requiredMetricFamilies": [
+            "dspace_http_requests_total",
+            "dspace_http_request_duration_seconds_bucket",
+            "dspace_dchat_requests_total",
+            "dspace_dependency_requests_total",
+            "dspace_instrumentation_up",
+            "dspace_build_info"
+          ],
+          "allowedApplicationLabels": {
+            "app": [
+              "dspace"
+            ],
+            "environment": [
+              "staging"
+            ],
+            "release": [
+              "dspace"
+            ],
+            "cluster": [
+              "sugarkube-int"
+            ],
+            "method": [
+              "GET",
+              "HEAD",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE",
+              "OPTIONS",
+              "UNKNOWN"
+            ],
+            "route": [
+              "/metrics",
+              "/api/chat",
+              "/",
+              "/health",
+              "/healthz",
+              "/livez",
+              "/config.json",
+              "/cache-version.js",
+              "/service-worker.js",
+              "/_astro/*",
+              "/assets/*",
+              "/docs/[slug]",
+              "/inventory/item/[itemId]/edit",
+              "/inventory/item/[itemId]",
+              "/processes/[processId]",
+              "/process/[slug]",
+              "/quests/[pathId]/[questId]",
+              "/unknown"
+            ],
+            "status_class": [
+              "2xx",
+              "4xx",
+              "5xx",
+              "unknown"
+            ],
+            "provider": [
+              "tokenplace",
+              "openai",
+              "none",
+              "unknown"
+            ],
+            "dependency": [
+              "tokenplace",
+              "openai",
+              "unknown"
+            ],
+            "outcome": [
+              "success",
+              "timeout",
+              "rate_limited",
+              "validation_error",
+              "malformed_response",
+              "dependency_failure",
+              "server_error",
+              "fallback_used",
+              "fallback_unavailable",
+              "unknown_error"
+            ]
+          },
+          "derivedApplicationLabels": {},
+          "forbiddenApplicationLabels": [
+            "authorization",
+            "bearer",
+            "cookie",
+            "email",
+            "hostname",
+            "jwt",
+            "node",
+            "passwd",
+            "passcode",
+            "remote_addr",
+            "secret",
+            "session",
+            "token",
+            "url",
+            "user"
+          ]
+        },
         "prod": {
           "namespace": "dspace",
           "serviceMonitorName": "dspace",
@@ -280,47 +446,62 @@
             ],
             "method": [
               "GET",
+              "HEAD",
               "POST",
               "PUT",
               "PATCH",
               "DELETE",
               "OPTIONS",
-              "HEAD",
-              "other"
+              "UNKNOWN"
             ],
             "route": [
-              "/",
               "/metrics",
+              "/api/chat",
+              "/",
               "/health",
               "/healthz",
-              "/build-info.json",
-              "/chat",
-              "other"
+              "/livez",
+              "/config.json",
+              "/cache-version.js",
+              "/service-worker.js",
+              "/_astro/*",
+              "/assets/*",
+              "/docs/[slug]",
+              "/inventory/item/[itemId]/edit",
+              "/inventory/item/[itemId]",
+              "/processes/[processId]",
+              "/process/[slug]",
+              "/quests/[pathId]/[questId]",
+              "/unknown"
             ],
             "status_class": [
-              "1xx",
               "2xx",
-              "3xx",
               "4xx",
               "5xx",
               "unknown"
             ],
             "provider": [
+              "tokenplace",
               "openai",
-              "token-place",
+              "none",
               "unknown"
             ],
             "dependency": [
+              "tokenplace",
               "openai",
-              "token-place",
               "unknown"
             ],
             "outcome": [
               "success",
-              "error",
               "timeout",
               "rate_limited",
-              "unknown"
+              "validation_error",
+              "malformed_response",
+              "dependency_failure",
+              "server_error",
+              "fallback_used",
+              "fallback_unavailable",
+              "unknown_error"
             ]
           },
           "derivedApplicationLabels": {},

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -28,6 +28,10 @@ K8S_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 DURATION = re.compile(r"[1-9][0-9]*[smh]")
 STATUS = re.compile(r"[1-5][0-9][0-9]")
 SAFE_VALUE = re.compile(r"[-A-Za-z0-9_./:*]+")
+SAFE_ROUTE_VALUE = re.compile(
+    r"/(?:[-A-Za-z0-9_.*]+|\[[A-Za-z][A-Za-z0-9]*\])"
+    r"(?:/(?:[-A-Za-z0-9_.*]+|\[[A-Za-z][A-Za-z0-9]*\]))*"
+)
 PROM_LABEL = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
 PROM_METRIC = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 K8S_LABEL_NAME = re.compile(r"[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?")
@@ -59,6 +63,14 @@ FORBIDDEN_WORDS = (
     "ip",
     "url",
 )
+DSPACE_REQUIRED_METRIC_FAMILIES = [
+    "dspace_http_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "dspace_instrumentation_up",
+    "dspace_build_info",
+]
 
 
 class Error(SystemExit):
@@ -107,6 +119,12 @@ def nonempty(v, where):
         fail(f"{where} must be a nonempty string")
     if not SAFE_VALUE.fullmatch(v):
         fail(f"{where} contains unsafe characters")
+
+
+def allowed_enum_value(v, where, label):
+    if label == "route" and isinstance(v, str) and SAFE_ROUTE_VALUE.fullmatch(v):
+        return
+    nonempty(v, where)
 
 
 def integer(v, where, low, high=None):
@@ -295,6 +313,7 @@ def validate_inventory(doc):
                 or labels["namespace"] != cfg["namespace"]
             ):
                 fail("targetLabels must match ServiceMonitor and namespace")
+
             def replacement(target_label, replacement):
                 return {
                     "action": "replace",
@@ -339,11 +358,15 @@ def validate_inventory(doc):
                 fail("allowedApplicationLabels must be an object")
             for k, vals in allowed.items():
                 prometheus_label(k, "allowed label name")
-                unique_string_list(vals, "allowed label enums", lambda v, w: nonempty(v, w))
+                unique_string_list(
+                    vals,
+                    "allowed label enums",
+                    lambda v, w, label=k: allowed_enum_value(v, w, label),
+                )
                 if k in labels and vals != [labels[k]]:
                     fail("targetLabels and allowed label enums must agree")
                 for v in vals:
-                    nonempty(v, f"allowed enum for {k}")
+                    allowed_enum_value(v, f"allowed enum for {k}", k)
             for key in ("app", "environment", "release", "cluster"):
                 vals = allowed.get(key)
                 if vals != [labels[key]]:
@@ -381,6 +404,26 @@ def validate_inventory(doc):
             conflicts = set(forbidden) & (set(allowed) | set(derived))
             if conflicts:
                 fail("forbidden labels conflict with allowed or derived labels")
+            if app == "dspace":
+                expected_environment = {
+                    "staging": {
+                        "secret": "dspace-staging-metrics-token",
+                        "cluster": "sugarkube-int",
+                        "url": "https://staging.democratized.space/metrics",
+                    },
+                    "prod": {
+                        "secret": "dspace-prod-metrics-token",
+                        "cluster": "sugarkube-prod",
+                        "url": "https://democratized.space/metrics",
+                    },
+                }[env]
+                if (
+                    cfg["secret"]["name"] != expected_environment["secret"]
+                    or labels["cluster"] != expected_environment["cluster"]
+                    or pm["url"] != expected_environment["url"]
+                    or metrics != DSPACE_REQUIRED_METRIC_FAMILIES
+                ):
+                    fail("DSPACE environment or immutable source metrics contract mismatch")
 
 
 def normalize_live_env(env: str) -> str:
@@ -835,7 +878,7 @@ def verify(app, env):
         fail("ServiceMonitor response is structurally invalid", 1)
     authorization = ep.get("authorization")
     auth = authorization.get("credentials") if isinstance(authorization, dict) else None
-    if app == "dspace" and env == "prod":
+    if app == "dspace":
         auth = ep.get("bearerTokenSecret")
         authorization = {"type": "Bearer"} if isinstance(auth, dict) else authorization
     selector = spec.get("selector")
@@ -994,9 +1037,7 @@ def validate_render(
     sms = []
     for candidate in named_sms:
         metadata = candidate["metadata"]
-        rendered_ns = (
-            metadata.get("namespace") if "namespace" in metadata else release_namespace
-        )
+        rendered_ns = metadata.get("namespace") if "namespace" in metadata else release_namespace
         if rendered_ns == cfg["namespace"]:
             sms.append(candidate)
     if len(sms) != 1:
@@ -1028,7 +1069,7 @@ def validate_render(
         fail("rendered ServiceMonitor endpoint is structurally invalid")
     auth = ep.get("authorization")
     creds = auth.get("credentials") if isinstance(auth, dict) else None
-    if app == "dspace" and env == "prod":
+    if app == "dspace":
         creds = ep.get("bearerTokenSecret")
         auth = {"type": "Bearer"} if isinstance(creds, dict) else auth
     if not isinstance(auth, dict) or not isinstance(creds, dict):

--- a/tests/test_dspace_staging_app_metrics.py
+++ b/tests/test_dspace_staging_app_metrics.py
@@ -1,0 +1,203 @@
+"""Regression coverage for the canonical DSPACE staging metrics contract."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import app_chart
+from scripts import observability_app_metrics as metrics
+
+ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = ROOT / "platform/observability/app-metrics.json"
+REQUIRED = [
+    "dspace_http_requests_total",
+    "dspace_http_request_duration_seconds_bucket",
+    "dspace_dchat_requests_total",
+    "dspace_dependency_requests_total",
+    "dspace_instrumentation_up",
+    "dspace_build_info",
+]
+ROUTES = [
+    "/metrics",
+    "/api/chat",
+    "/",
+    "/health",
+    "/healthz",
+    "/livez",
+    "/config.json",
+    "/cache-version.js",
+    "/service-worker.js",
+    "/_astro/*",
+    "/assets/*",
+    "/docs/[slug]",
+    "/inventory/item/[itemId]/edit",
+    "/inventory/item/[itemId]",
+    "/processes/[processId]",
+    "/process/[slug]",
+    "/quests/[pathId]/[questId]",
+    "/unknown",
+]
+
+
+def inventory():
+    return json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+
+def test_dspace_staging_and_prod_inventory_contracts_are_exact():
+    doc = inventory()
+    metrics.validate_inventory(doc)
+    environments = doc["applications"]["dspace"]["environments"]
+    assert list(environments) == ["staging", "prod"]
+    staging, prod = environments["staging"], environments["prod"]
+    assert staging["namespace"] == staging["serviceMonitorName"] == "dspace"
+    assert staging["expectedTargetCount"] == prod["expectedTargetCount"] == 2
+    assert staging["secret"] == {"name": "dspace-staging-metrics-token", "key": "token"}
+    assert staging["serviceMonitor"]["authorization"] == {
+        "type": "Bearer",
+        "credentials": staging["secret"],
+    }
+    assert staging["serviceMonitor"]["selectorMatchLabels"] == {
+        "app.kubernetes.io/instance": "dspace",
+        "app.kubernetes.io/name": "dspace",
+    }
+    assert staging["serviceMonitor"]["path"] == "/metrics"
+    assert staging["serviceMonitor"]["interval"] == "30s"
+    assert staging["serviceMonitor"]["scrapeTimeout"] == "10s"
+    assert [r["targetLabel"] for r in staging["serviceMonitor"]["relabelings"]] == [
+        "app",
+        "environment",
+        "namespace",
+        "release",
+        "cluster",
+    ]
+    assert staging["targetLabels"] == {
+        "app": "dspace",
+        "environment": "staging",
+        "release": "dspace",
+        "cluster": "sugarkube-int",
+        "namespace": "dspace",
+    }
+    assert staging["publicMetrics"] == {
+        "url": "https://staging.democratized.space/metrics",
+        "expectedUnauthenticatedStatus": 401,
+    }
+    assert staging["retries"] == {"attempts": 6, "delaySeconds": 10}
+    assert staging["requiredMetricFamilies"] == prod["requiredMetricFamilies"] == REQUIRED
+    assert staging["forbiddenApplicationLabels"] == prod["forbiddenApplicationLabels"]
+    assert staging["derivedApplicationLabels"] == prod["derivedApplicationLabels"] == {}
+
+
+def test_dspace_staging_inventory_matches_values_overlay():
+    values = app_chart.merged_values_document(("docs/examples/dspace.values.staging.yaml",))
+    cfg = inventory()["applications"]["dspace"]["environments"]["staging"]
+    assert values["environment"] == cfg["targetLabels"]["environment"]
+    assert values["metrics"]["auth"] == {
+        "existingSecret": cfg["secret"]["name"],
+        "secretKey": cfg["secret"]["key"],
+    }
+    assert values["serviceMonitor"]["interval"] == cfg["serviceMonitor"]["interval"]
+    assert values["serviceMonitor"]["scrapeTimeout"] == cfg["serviceMonitor"]["scrapeTimeout"]
+    assert values["serviceMonitor"]["cluster"] == cfg["targetLabels"]["cluster"]
+    assert f'https://{values["ingress"]["host"]}/metrics' == cfg["publicMetrics"]["url"]
+
+
+def test_dspace_labels_match_immutable_source_contract_and_reject_stale_values():
+    shared = {
+        "method": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "UNKNOWN"],
+        "route": ROUTES,
+        "status_class": ["2xx", "4xx", "5xx", "unknown"],
+        "provider": ["tokenplace", "openai", "none", "unknown"],
+        "dependency": ["tokenplace", "openai", "unknown"],
+        "outcome": [
+            "success",
+            "timeout",
+            "rate_limited",
+            "validation_error",
+            "malformed_response",
+            "dependency_failure",
+            "server_error",
+            "fallback_used",
+            "fallback_unavailable",
+            "unknown_error",
+        ],
+    }
+    for cfg in inventory()["applications"]["dspace"]["environments"].values():
+        for label, values in shared.items():
+            assert cfg["allowedApplicationLabels"][label] == values
+        for label, bad in (
+            ("route", "/chat"),
+            ("route", "*"),
+            ("route", "/arbitrary/*"),
+            ("provider", "token-place"),
+            ("dependency", "token-place"),
+            ("outcome", "error"),
+            ("outcome", "anything"),
+        ):
+            with pytest.raises(metrics.Error, match="enum mismatch"):
+                metrics.validate_metric_labels(cfg, {label: bad})
+
+
+@pytest.mark.parametrize(
+    "field,staging_value,prod_value",
+    [
+        ("secret", "dspace-prod-metrics-token", "dspace-staging-metrics-token"),
+        ("cluster", "sugarkube-prod", "sugarkube-int"),
+        ("environment", "prod", "staging"),
+        ("url", "https://democratized.space/metrics", "https://staging.democratized.space/metrics"),
+    ],
+)
+def test_dspace_environment_cross_contamination_is_rejected(field, staging_value, prod_value):
+    for env, value in (("staging", staging_value), ("prod", prod_value)):
+        doc = inventory()
+        cfg = doc["applications"]["dspace"]["environments"][env]
+        if field == "secret":
+            cfg["secret"]["name"] = value
+            cfg["serviceMonitor"]["authorization"]["credentials"]["name"] = value
+        elif field == "url":
+            cfg["publicMetrics"]["url"] = value
+        else:
+            cfg["targetLabels"][field] = value
+        with pytest.raises(metrics.Error):
+            metrics.validate_inventory(doc)
+
+
+def test_dspace_staging_secret_check_returns_only_redacted_status(monkeypatch, capsys):
+    cfg = inventory()["applications"]["dspace"]["environments"]["staging"]
+    seen = []
+    monkeypatch.setattr(
+        metrics,
+        "run",
+        lambda args: seen.append(args) or "dspace\tdspace-staging-metrics-token\tnonempty",
+    )
+    metrics.check_secret(cfg)
+    command = seen[0]
+    assert command[:7] == [
+        "kubectl",
+        "-n",
+        "dspace",
+        "get",
+        "secret",
+        "dspace-staging-metrics-token",
+        "-o",
+    ]
+    assert command[7] == "go-template"
+    assert 'index .data "token"' in command[-1]
+    assert "json" not in command
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == (
+        "Application metrics Secret contract exists " "(value was not returned to the verifier).\n"
+    )
+
+
+def test_staging_verify_and_verify_all_discover_tokenplace_and_dspace(monkeypatch):
+    doc, called = inventory(), []
+    monkeypatch.setattr(metrics, "load_config", lambda: doc)
+    monkeypatch.setattr(metrics, "verify", lambda app, env: called.append((app, env)))
+    monkeypatch.setattr(metrics, "assert_context", lambda: None)
+    assert metrics.main(["verify", "--app", "dspace", "--env", "staging"]) == 0
+    assert called == [("dspace", "staging")]
+    called.clear()
+    assert metrics.main(["verify-all", "--env", "staging"]) == 0
+    assert called == [("tokenplace", "staging"), ("dspace", "staging")]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -411,6 +411,7 @@ metadata:
   name: dspace
   labels:
     app.kubernetes.io/instance: dspace
+    release: kube-prometheus-stack
 spec:
   namespaceSelector:
     matchNames:
@@ -421,9 +422,28 @@ spec:
       app.kubernetes.io/name: dspace
   endpoints:
     - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
       bearerTokenSecret:
         name: dspace-staging-metrics-token
         key: token
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: dspace
+        - action: replace
+          targetLabel: environment
+          replacement: staging
+        - action: replace
+          targetLabel: namespace
+          replacement: dspace
+        - action: replace
+          targetLabel: release
+          replacement: dspace
+        - action: replace
+          targetLabel: cluster
+          replacement: sugarkube-int
 YAML
     fi
     if [ "${{app}}" = dspace ] && [[ "$*" == *dspace.values.prod.yaml* ]]; then


### PR DESCRIPTION
### Motivation

- The observability read-only gate failed with `ERROR: no configured app metrics contract for dspace/staging`; this PR supplies the missing canonical authenticated `dspace/staging` contract so the repository-owned staging verification can proceed. 
- The DSPACE application label allowlists were stale relative to the immutable DSPACE metrics source and required exact bounded values (no wildcards) to prevent verification bypasses.

### Description

- Add a repository-owned `dspace/staging` entry to `platform/observability/app-metrics.json` matching `docs/examples/dspace.values.staging.yaml` including: namespace `dspace`, ServiceMonitor selector/relabelings, expected target count `2`, metrics path `/metrics`, `interval: 30s`, `scrapeTimeout: 10s`, bearer-token authentication using Secret `dspace-staging-metrics-token` key `token`, five canonical relabelings, public metrics URL `https://staging.democratized.space/metrics` expecting unauthenticated `401`, retries `6` / `10s`, and the six required DSPACE families. 
- Derive and lock the bounded `allowedApplicationLabels` for both `dspace/staging` and `dspace/prod` from the immutable DSPACE source revision and blob (`22f506e...` / `a2a1fecf...`), including provider/dependency/outcome/method/status_class/route enums and normalized route set; preserve forbidden-label, privacy, and bounded-cardinality enforcement. 
- Tighten validator logic in `scripts/observability_app_metrics.py` by adding `SAFE_ROUTE_VALUE`, `allowed_enum_value`, `DSPACE_REQUIRED_METRIC_FAMILIES`, and a DSPACE-specific environment consistency check so staging/prod coordinates (Secret, cluster, public URL, required families) are exact. 
- Add focused regression tests in `tests/test_dspace_staging_app_metrics.py`, update `tests/test_generic_app_just_recipes.py` to exercise the exact staging ServiceMonitor rendering, and keep unrelated production promotion coordinates unchanged. 
- Update `docs/apps/dspace.md` to document the repository-owned read-only prerequisites and the exact Just recipes to run before creating a DSPACE 3.1.1 staging candidate: `just observability-app-metrics-secret-check app=dspace env=staging`, `just observability-app-metrics-verify app=dspace env=staging`, and `just observability-verify env=staging`.
- Preserves strict redaction rules: no Secret values are returned or logged, no cluster mutation or Secret rotation is implemented.

### Testing

- Validated inventory and schema with `python3 scripts/observability_app_metrics.py validate` (result: Application metrics inventory is valid). 
- Ran focused regression suites: `pytest -q tests/test_dspace_staging_app_metrics.py tests/test_dspace_runtime_values.py tests/test_dspace_promotion_plan.py tests/test_dspace_runtime_verifier.py` (380 passed) and observability-related generic tests `pytest -q tests/test_generic_app_just_recipes.py -k 'observability_app_metrics'` (174 passed). Additional targeted generic DSPACE promotion tests were exercised and passed during local runs. 
- Ran docs link checks with `linkchecker --no-warnings README.md docs/` (211 URLs checked, 0 errors). 
- Ran repository checks: `git diff --check` and `git diff --cached | ./scripts/scan-secrets.py` (no credentials or secret material introduced). 
- Notes and constraints: attempted `pre-commit run --all-files` but repository-wide pre-existing hooks (trailing-whitespace, some YAML multi-document findings, flake8) prevented a fully clean global run; fixes unrelated to this PR were intentionally not applied. `pyspelling -c .spellcheck.yaml` could not be executed in this environment due to missing `aspell` binary. 

Additional operational notes: the change was prepared on branch `codex/dspace-staging-app-metrics-contract` and committed locally as `be05a2a` (message: "Add DSPACE staging metrics contract"); a `git push` / PR creation attempt failed here because this environment has no GitHub credentials, so the branch + commit are ready locally for push from a machine with credentials. This PR only adds repository-owned read-only checks and tests and performs no cluster mutations, Secret reads/rotations, candidate creation, approval, or deployments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80c0bdd69c832faeaae00869c9f173)