### PR TITLE
Validate and enforce DSPACE modern `buildTimestamp` in runtime verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,8 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
+REQUIRED_BUILD_FIELDS = BUILD_FIELDS - {"image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -87,6 +88,9 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+BUILD_TIMESTAMP_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{3})?Z$"
+)
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -218,14 +222,18 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    if (
+        not isinstance(value, dict)
+        or not REQUIRED_BUILD_FIELDS <= set(value)
+        or set(value) - BUILD_FIELDS
+    ):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +244,22 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or any(ord(character) < 32 or ord(character) == 127 for character in build_timestamp)
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        datetime.fromisoformat(build_timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    # The exact shape check excludes every normalization accepted by the parser;
+    # successful parsing therefore proves that this spelling represents itself.
+    return version, revision, build_timestamp, runtime_image or image
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +467,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,18 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-01T12:00:00Z"
+
+
+def modern_identity_payload(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+    }
+    payload.update(changes)
+    return payload
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -134,12 +146,17 @@ def _verify_setup(
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
-    def build(image: str = canonical, revision: str = SHA) -> str:
+    def build(
+        image: str = canonical,
+        revision: str = SHA,
+        build_timestamp: str = BUILD_TIMESTAMP,
+    ) -> str:
         return json.dumps(
             {
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": build_timestamp,
                 "image": image,
             }
         )
@@ -1105,7 +1122,9 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        modern_identity_payload(revision="f" * 40, shortRevision="fffffff")
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1121,7 +1140,11 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (
+            (*value[:2], "2026-08-01T12:00:01Z", value[3])
+            if category == "public identity"
+            else value
+        )
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
@@ -1521,12 +1544,104 @@ def test_build_identity_requires_canonical_coordinates(
 ) -> None:
     with pytest.raises(verifier.VerificationError, match=category):
         verifier.identity(
-            json.dumps(payload).encode(),
+            json.dumps({**payload, "buildTimestamp": BUILD_TIMESTAMP}).encode(),
             "3.1.0",
             SHA,
             "ghcr.io/democratizedspace/dspace:main-abcdef0",
             category,
         )
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    [BUILD_TIMESTAMP, "2026-08-01T12:00:00.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+@pytest.mark.parametrize("include_image", [False, True], ids=("no-image", "image"))
+def test_modern_identity_accepts_canonical_timestamp_and_optional_image(
+    build_timestamp: str, include_image: bool
+) -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    payload = modern_identity_payload(buildTimestamp=build_timestamp)
+    if include_image:
+        payload["image"] = image
+
+    assert verifier.identity(json.dumps(payload).encode(), "3.1.0", SHA, image, "identity") == (
+        "3.1.0",
+        SHA,
+        build_timestamp,
+        image,
+    )
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    [
+        "",
+        1,
+        "2026-08-01T12:00:00Z" + "x" * 20,
+        "2026-08-01T12:00:00Z\n",
+        "2026-02-30T12:00:00Z",
+        "2026-08-01T12:00:00",
+        "2026-08-01T12:00:00+01:00",
+        "2026-08-01T12:00:00.1Z",
+        "2026-08-01T12:00:00.123456Z",
+        "2026-08-01T12:00:00+00:00",
+    ],
+    ids=(
+        "empty",
+        "nonstring",
+        "oversized",
+        "control-character",
+        "malformed-calendar",
+        "timezone-naive",
+        "non-utc-offset",
+        "one-fractional-digit",
+        "six-fractional-digits",
+        "parseable-noncanonical",
+    ),
+)
+def test_modern_identity_rejects_invalid_timestamp_without_leaking(
+    build_timestamp: object,
+) -> None:
+    payload = modern_identity_payload(buildTimestamp=build_timestamp)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(json.dumps(payload).encode(), "3.1.0", SHA, "image", "identity")
+    assert str(raised.value) == "identity"
+    if build_timestamp:
+        assert str(build_timestamp) not in str(raised.value)
+
+
+def test_modern_identity_requires_timestamp_and_rejects_extra_field() -> None:
+    missing = modern_identity_payload()
+    del missing["buildTimestamp"]
+    for payload in (missing, modern_identity_payload(extra=SENTINEL)):
+        with pytest.raises(verifier.VerificationError) as raised:
+            verifier.identity(json.dumps(payload).encode(), "3.1.0", SHA, "image", "identity")
+        assert str(raised.value) == "identity"
+        assert SENTINEL not in str(raised.value)
+
+
+def test_verify_rejects_replica_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    second = json.dumps(modern_identity_payload(buildTimestamp="2026-08-01T12:00:01Z"))
+    args, _ = _verify_setup(
+        monkeypatch, tmp_path, overrides={"direct_builds": {"dspace-2": second}}
+    )
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "pod/replica identity"
+
+
+def test_verify_rejects_public_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    public = json.dumps(modern_identity_payload(buildTimestamp="2026-08-01T12:00:01Z"))
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"public_build": public})
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "public identity"
 
 
 def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1609,7 +1724,13 @@ def test_fetch_success_and_network_failures_are_bounded(
         (
             lambda: verifier.identity(
                 json.dumps(
-                    {"version": "v", "revision": SHA, "shortRevision": SHA[:7], "extra": SENTINEL}
+                    {
+                        "version": "v",
+                        "revision": SHA,
+                        "shortRevision": SHA[:7],
+                        "buildTimestamp": BUILD_TIMESTAMP,
+                        "extra": SENTINEL,
+                    }
                 ).encode(),
                 "v",
                 SHA,


### PR DESCRIPTION
### Motivation

- The runtime verifier for the DSPACE modern `build-info-v1` identity was rejecting valid payloads because `buildTimestamp` was not part of the enforced identity schema and comparisons; the upstream application requires and canonicalizes `buildTimestamp` and the verifier must fail-closed to that immutable contract. 

### Description

- Require `buildTimestamp` as a required modern identity field and keep `image` as the only optional field by extending `BUILD_FIELDS` and introducing `REQUIRED_BUILD_FIELDS` in `scripts/dspace_runtime_verifier.py`.
- Validate `buildTimestamp` precisely with a regex for the allowed shapes (`YYYY-MM-DDTHH:MM:SSZ` or `YYYY-MM-DDTHH:MM:SS.mmmZ`), enforce type/length/control-character bounds, parse with `datetime.fromisoformat` to ensure it represents a valid instant, and include the validated timestamp in the normalized `identity()` return value so replica/public comparisons include it.
- Preserve legacy identity behavior and all legacy coordinate constants unchanged, and extend replica identity typing so `identity()` returns the timestamp along with previous identity fields used for equality checks.
- Update `tests/test_dspace_runtime_verifier.py` to exercise the new contract end-to-end by adding a `buildTimestamp` fixture, a `modern_identity_payload()` helper, focused tests for canonical seconds and millisecond timestamps, and regression cases covering missing/empty/non-string/oversized/control-character/malformed/timezone/fractional-precision/noncanonical timestamps, unexpected extra-field rejection, optional `image` behavior, replica timestamp disagreement (`pod/replica identity`), and public/direct timestamp disagreement (`public identity`).

Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

### Testing

- Compiled the verifier with `python3 -m compileall scripts/dspace_runtime_verifier.py` and the module compiled successfully.
- Ran unit tests for the verifier with `pytest -q tests/test_dspace_runtime_verifier.py` and all tests passed (`196 passed`).
- Ran related manifest/values tests with `pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_dspace_runtime_values.py` and they passed (`388 passed`).
- Ran a focused coverage run `python3 -m coverage run --branch -m pytest -q tests/test_dspace_runtime_verifier.py` and reported coverage for `scripts/dspace_runtime_verifier.py` at about `95%` with no missing lines or branches in the modified `identity()` logic.
- Ran `git diff --check` and repository secret scan `git diff | ./scripts/scan-secrets.py` on the staged changes; both checks passed for the scoped changes.
- Attempted `pre-commit run --all-files` and observed repository-wide, pre-existing YAML and lint findings unrelated to this change; unrelated auto-edits were reverted so only the scoped verifier files were committed.

This change implements the authoritative modern `build-info-v1` contract: require exactly `version`, `revision`, `shortRevision`, and `buildTimestamp` (string, nonempty, <=40 chars, no control chars, literal `Z`, seconds or exactly three fractional digits, valid instant), allow `image` optionally, reject any other extra field, and compare `buildTimestamp` across replicas and public identity using existing bounded error categories; no cluster, Secret, evidence, deployment coordinate, application source, or unrelated GitHub metadata was mutated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f1cfb5ec832fac5e15471f6a34d9)