### PR TITLE
Fix DSPACE modern build timestamp verification

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,8 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp"}
+OPTIONAL_BUILD_FIELDS = {"image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -87,6 +88,9 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+BUILD_TIMESTAMP_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{3})?Z$"
+)
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -218,14 +222,18 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    if (
+        not isinstance(value, dict)
+        or not BUILD_FIELDS <= set(value)
+        or set(value) - BUILD_FIELDS - OPTIONAL_BUILD_FIELDS
+    ):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +244,20 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or any(ord(character) < 32 or ord(character) == 127 for character in build_timestamp)
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        datetime.fromisoformat(build_timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    return version, revision, runtime_image or image, build_timestamp
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +465,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, str, str] | tuple[str, str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-01T12:00:00.123Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -1105,7 +1107,14 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": "f" * 40,
+            "shortRevision": "fffffff",
+            "buildTimestamp": BUILD_TIMESTAMP,
+        }
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1121,7 +1130,7 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (*value[:3], "2026-08-02T12:00:00Z") if category == "public identity" else value
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
@@ -1502,14 +1511,39 @@ def test_deployment_requires_matching_helm_annotations(annotation: str, value: s
 @pytest.mark.parametrize(
     "payload,category",
     [
-        ({"version": "wrong", "revision": SHA, "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": "wrong", "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": SHA, "shortRevision": "wrong"}, "public identity"),
+        (
+            {
+                "version": "wrong",
+                "revision": SHA,
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": "wrong",
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": SHA,
+                "shortRevision": "wrong",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
         (
             {
                 "version": "3.1.0",
                 "revision": SHA,
                 "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": f"ghcr.io/democratizedspace/dspace:main-abcdef0@{DIGEST}",
             },
             "public identity",
@@ -1527,6 +1561,133 @@ def test_build_identity_requires_canonical_coordinates(
             "ghcr.io/democratizedspace/dspace:main-abcdef0",
             category,
         )
+
+
+def _modern_identity_payload(**changes: object) -> dict[str, object]:
+    return {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+        **changes,
+    }
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["2026-08-01T12:00:00Z", BUILD_TIMESTAMP],
+    ids=("seconds", "milliseconds"),
+)
+@pytest.mark.parametrize("include_image", [False, True], ids=("without-image", "with-image"))
+def test_modern_identity_accepts_canonical_timestamps_and_optional_image(
+    timestamp: str, include_image: bool
+) -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    payload = _modern_identity_payload(buildTimestamp=timestamp)
+    if include_image:
+        payload["image"] = image
+
+    assert verifier.identity(
+        json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+    ) == ("3.1.0", SHA, image, timestamp)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "",
+        123,
+        "2026-08-01T12:00:00Z" + "x" * 21,
+        "2026-08-01T12:00:00Z\n",
+        "2026-02-30T12:00:00Z",
+        "2026-08-01T12:00:00",
+        "2026-08-01T12:00:00+00:00",
+        "2026-08-01T12:00:00.1Z",
+        "2026-08-01T12:00:00.1234Z",
+        "2026-08-01T24:00:00Z",
+    ],
+    ids=(
+        "empty",
+        "nonstring",
+        "oversized",
+        "control-character",
+        "malformed-calendar",
+        "timezone-naive",
+        "non-utc-offset",
+        "one-fractional-digit",
+        "four-fractional-digits",
+        "parseable-noncanonical",
+    ),
+)
+def test_modern_identity_rejects_invalid_timestamp_without_leaking(timestamp: object) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(_modern_identity_payload(buildTimestamp=timestamp)).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+    if timestamp:
+        assert str(timestamp) not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"version": "3.1.0", "revision": SHA, "shortRevision": SHA[:7]},
+        _modern_identity_payload(extra=SENTINEL),
+    ],
+    ids=("missing-timestamp", "unexpected-field"),
+)
+def test_modern_identity_requires_exact_base_fields(payload: dict[str, object]) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "public identity",
+        )
+    assert str(raised.value) == "public identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_builds": {
+                    "dspace-2": json.dumps(
+                        _modern_identity_payload(buildTimestamp="2026-08-02T12:00:00Z")
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_build": json.dumps(
+                    _modern_identity_payload(buildTimestamp="2026-08-02T12:00:00Z")
+                )
+            },
+            "public identity",
+        ),
+    ],
+    ids=("replica-timestamp", "public-timestamp"),
+)
+def test_verify_rejects_modern_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
 
 
 def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation

- The runtime verifier rejected valid modern `/build-info.json` payloads because `buildTimestamp` was not accepted by the modern identity allowlist, blocking finalization of an otherwise-valid staging deployment.
- Implement the authoritative upstream contract: require a canonical UTC `buildTimestamp` and fail-closed for any deviation while preserving legacy behavior.

### Description

- Require exactly `version`, `revision`, `shortRevision`, and `buildTimestamp` for the modern `build-info-v1` identity and continue to accept `image` only as an optional field, rejecting any unexpected fields by failing closed (changes in `scripts/dspace_runtime_verifier.py`).
- Validate `buildTimestamp` as a string ≤ 40 characters with no control characters matching the canonical ISO UTC forms `YYYY-MM-DDTHH:MM:SSZ` or `YYYY-MM-DDTHH:MM:SS.mmmZ`, ensure it parses to a valid instant, and include the validated timestamp in the normalized identity returned by `identity()` (changes in `scripts/dspace_runtime_verifier.py`).
- Ensure the verifier compares the normalized timestamp across direct pod identities (replicas) and against the public identity so replica disagreements fail as `pod/replica identity` and public/direct disagreements fail as `public identity` (changes in `scripts/dspace_runtime_verifier.py`).
- Update and extend tests to exercise the new contract and disagreements, and to exercise `identity()` in the full verification path (changes in `tests/test_dspace_runtime_verifier.py`).

### Testing

- Ran `python3 -m compileall scripts/dspace_runtime_verifier.py` which succeeded. 
- Ran `pytest -q tests/test_dspace_runtime_verifier.py` and `pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_dspace_runtime_values.py`, all tests passed (197 and 388 tests respectively in this environment). 
- Ran coverage for the verifier with `python3 -m coverage run --branch -m pytest -q tests/test_dspace_runtime_verifier.py` and `python3 -m coverage report -m scripts/dspace_runtime_verifier.py`, yielding 95% file coverage for `scripts/dspace_runtime_verifier.py` and exercising all new branches introduced for timestamp validation. 
- Ran repository checks: `git diff | ./scripts/scan-secrets.py` and `git diff --check` (no secrets or diff issues detected for the scoped changes); `pre-commit run --all-files` ran but failed on unrelated, pre-existing repository-wide YAML/lint findings (these are unrelated to the scoped verifier change and automatic whitespace/EOF edits were reverted before committing). 

Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

No cluster, Helm release, Secret, evidence record, candidate/reservation/finalization state, or other runtime/deployment metadata was modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f1c2b98c832fa0e6655b57ffba44)