### PR TITLE
Validate and enforce DSPACE modern `buildTimestamp` in runtime verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,7 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -91,6 +91,7 @@ HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECA
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
+BUILD_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$")
 
 
 class VerificationError(ValueError):
@@ -218,7 +219,7 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
@@ -226,6 +227,8 @@ def identity(
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
     if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+        fail(category)
+    if not {"version", "revision", "shortRevision", "buildTimestamp"} <= set(value):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +239,23 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value["buildTimestamp"]
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or any(ord(character) < 32 or ord(character) == 127 for character in build_timestamp)
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        parsed_timestamp = datetime.fromisoformat(build_timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    timespec = "milliseconds" if "." in build_timestamp else "seconds"
+    if parsed_timestamp.isoformat(timespec=timespec).replace("+00:00", "Z") != build_timestamp:
+        fail(category)
+    return version, revision, build_timestamp, runtime_image or image
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +463,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -463,7 +463,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str, str] | None = None
+    replica_identity: tuple[str, str, str] | tuple[str, str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1583,6 +1583,8 @@ def test_modern_identity_accepts_canonical_timestamp(timestamp: str) -> None:
         "2026-08-01T12:00:00.1Z",
         "2026-08-01T12:00:00.1234Z",
         "2026-08-01t12:00:00Z",
+        "2026-08-01T24:00:00Z",
+        "2026-08-01T24:00:00.000Z",
     ],
     ids=(
         "empty",
@@ -1595,6 +1597,8 @@ def test_modern_identity_accepts_canonical_timestamp(timestamp: str) -> None:
         "one-fractional-digit",
         "four-fractional-digits",
         "parseable-noncanonical",
+        "next-day-seconds",
+        "next-day-milliseconds",
     ),
 )
 def test_modern_identity_rejects_invalid_timestamp_without_leaking(timestamp: object) -> None:

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-01T12:00:00Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -1105,7 +1107,14 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": "f" * 40,
+            "shortRevision": "fffffff",
+            "buildTimestamp": BUILD_TIMESTAMP,
+        }
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1121,7 +1130,11 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (
+            (*value[:2], "2026-08-02T12:00:00Z", value[3])
+            if category == "public identity"
+            else value
+        )
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
@@ -1519,6 +1532,7 @@ def test_deployment_requires_matching_helm_annotations(annotation: str, value: s
 def test_build_identity_requires_canonical_coordinates(
     payload: dict[str, str], category: str
 ) -> None:
+    payload["buildTimestamp"] = BUILD_TIMESTAMP
     with pytest.raises(verifier.VerificationError, match=category):
         verifier.identity(
             json.dumps(payload).encode(),
@@ -1527,6 +1541,134 @@ def test_build_identity_requires_canonical_coordinates(
             "ghcr.io/democratizedspace/dspace:main-abcdef0",
             category,
         )
+
+
+def modern_build_payload(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+    }
+    payload.update(changes)
+    return payload
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [BUILD_TIMESTAMP, "2026-08-01T12:00:00.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_timestamp(timestamp: str) -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    assert verifier.identity(
+        json.dumps(modern_build_payload(buildTimestamp=timestamp)).encode(),
+        "3.1.0",
+        SHA,
+        image,
+        "direct identity",
+    ) == ("3.1.0", SHA, timestamp, image)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "",
+        1,
+        "2" * 41,
+        "2026-08-01T12:00:00Z\n",
+        "2026-02-30T12:00:00Z",
+        "2026-08-01T12:00:00",
+        "2026-08-01T12:00:00+00:00",
+        "2026-08-01T12:00:00.1Z",
+        "2026-08-01T12:00:00.1234Z",
+        "2026-08-01t12:00:00Z",
+    ],
+    ids=(
+        "empty",
+        "nonstring",
+        "oversized",
+        "control-character",
+        "malformed-calendar",
+        "timezone-naive",
+        "utc-offset",
+        "one-fractional-digit",
+        "four-fractional-digits",
+        "parseable-noncanonical",
+    ),
+)
+def test_modern_identity_rejects_invalid_timestamp_without_leaking(timestamp: object) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(modern_build_payload(buildTimestamp=timestamp)).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+
+
+def test_modern_identity_requires_timestamp_and_rejects_extra_field() -> None:
+    missing = modern_build_payload()
+    del missing["buildTimestamp"]
+    for payload in (missing, modern_build_payload(unexpected=SENTINEL)):
+        with pytest.raises(verifier.VerificationError) as raised:
+            verifier.identity(
+                json.dumps(payload).encode(),
+                "3.1.0",
+                SHA,
+                "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                "public identity",
+            )
+        assert str(raised.value) == "public identity"
+        assert SENTINEL not in str(raised.value)
+
+
+def test_modern_identity_optional_image_behavior_is_unchanged() -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    with_image = modern_build_payload(image=image)
+    without_image = modern_build_payload()
+    for payload in (with_image, without_image):
+        assert verifier.identity(
+            json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+        ) == ("3.1.0", SHA, BUILD_TIMESTAMP, image)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_builds": {
+                    "dspace-2": json.dumps(
+                        modern_build_payload(buildTimestamp="2026-08-02T12:00:00Z")
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_build": json.dumps(
+                    modern_build_payload(buildTimestamp="2026-08-02T12:00:00Z")
+                )
+            },
+            "public identity",
+        ),
+    ],
+    ids=("replica-timestamp", "public-timestamp"),
+)
+def test_verify_rejects_modern_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
 
 
 def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- The runtime verifier rejected valid modern `/build-info.json` payloads because `buildTimestamp` was not part of the enforced modern identity schema and therefore caused valid staging revisions to fail verification. 
- Upstream DSPACE requires a canonical UTC `buildTimestamp` and the verifier must enforce that contract strictly and fail closed for nonconforming values.

### Description
- Require `buildTimestamp` as a required modern identity field by adding it to `BUILD_FIELDS` and returning the validated timestamp from `identity()` so the normalized identity contains it. 
- Add strict timestamp validation using `BUILD_TIMESTAMP_RE` and `datetime.fromisoformat` to enforce type, non-empty, control-character bounds, max length (<=40), literal `Z`, seconds or exactly three fractional digits, valid calendar instant, and canonical serialization. 
- Preserve optional `image` behavior and reject any unexpected extra fields; legacy identity behavior and legacy coordinate constants remain unchanged. 
- Update tests and fixtures in `tests/test_dspace_runtime_verifier.py` so the full verification path exercises `buildTimestamp()` and add focused regression tests for canonical seconds/milliseconds, missing/invalid/oversized/control-character/timezone/fractional/noncanonical cases, extra-field rejection, optional-image behavior, replica/public timestamp disagreement, and end-to-end verification.
- Files changed: `scripts/dspace_runtime_verifier.py` and `tests/test_dspace_runtime_verifier.py`.

### Testing
- Ran `python3 -m compileall scripts/dspace_runtime_verifier.py` and compilation succeeded. 
- Ran unit tests with `pytest -q tests/test_dspace_runtime_verifier.py` and the file-level suite passed (195 passed). 
- Ran broader suites with `pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_dspace_runtime_values.py` and those passed (388 passed). 
- Ran a coverage-instrumented test run for the verifier and achieved ~95% coverage for `scripts/dspace_runtime_verifier.py` with the requested branches exercised; the coverage-run command used was `pytest -q tests/test_dspace_runtime_verifier.py --cov=scripts.dspace_runtime_verifier --cov-branch --cov-report=term-missing`. 
- Ran repository checks `git diff --check` and `git diff | ./scripts/scan-secrets.py` which passed for the committed changes, and `git diff --cached | ./scripts/scan-secrets.py` was also checked. 
- Attempted `pre-commit run --all-files`; pre-commit exposed unrelated, pre-existing repository-wide YAML/lint findings and applied broad whitespace/EOF fixes which were restored before committing, so no unrelated files were left modified in the final commit. 
- Push/PR creation was not performed from this environment due to missing GitHub credentials. 

Contract implemented: the modern `build-info-v1` identity now requires exactly `version`, `revision`, `shortRevision`, and `buildTimestamp`, allows `image` optionally, rejects unexpected extra fields, validates `buildTimestamp` against the canonical UTC rules, and includes the validated timestamp in the normalized identity returned by `identity()`; replica and public identity comparisons therefore include the timestamp and fail with the existing bounded categories on disagreement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f1caf278832faae8f146a2dfeafe)