### PR TITLE
Require and validate `buildTimestamp` in DSPACE modern build-info verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,11 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_REQUIRED_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp"}
+BUILD_FIELDS = BUILD_REQUIRED_FIELDS | {"image"}
+BUILD_TIMESTAMP_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{3})?Z$"
+)
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -218,14 +222,18 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    if (
+        not isinstance(value, dict)
+        or not BUILD_REQUIRED_FIELDS <= set(value)
+        or set(value) - BUILD_FIELDS
+    ):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +244,20 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or any(ord(character) < 32 or ord(character) == 127 for character in build_timestamp)
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        datetime.fromisoformat(build_timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        fail(category)
+    return version, revision, build_timestamp, runtime_image or image
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-01T12:00:00Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -770,6 +772,90 @@ def test_modern_identity_failure_never_requests_legacy_surface(
 
 
 @pytest.mark.parametrize(
+    "build_timestamp",
+    [BUILD_TIMESTAMP, "2026-08-01T12:00:00.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_build_timestamp(build_timestamp: str) -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    payload = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": build_timestamp,
+    }
+    assert verifier.identity(
+        json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+    ) == ("3.1.0", SHA, build_timestamp, image)
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("", id="empty"),
+        pytest.param(123, id="nonstring"),
+        pytest.param("2" * 41, id="oversized"),
+        pytest.param("2026-08-01T12:00:00Z\n" + SENTINEL, id="control-character"),
+        pytest.param("2026-08-01T12:00:00Z\x7f" + SENTINEL, id="delete-character"),
+        pytest.param("2026-02-30T12:00:00Z", id="malformed-calendar"),
+        pytest.param("2026-08-01T12:00:00", id="timezone-naive"),
+        pytest.param("2026-08-01T12:00:00+00:00", id="utc-offset"),
+        pytest.param("2026-08-01T12:00:00.12Z", id="two-fractional-digits"),
+        pytest.param("2026-08-01T12:00:00.1234Z", id="four-fractional-digits"),
+        pytest.param("2026-02-29T12:00:00Z", id="parseable-noncanonical"),
+    ],
+)
+def test_modern_identity_rejects_invalid_build_timestamp_without_leaking(
+    build_timestamp: object,
+) -> None:
+    payload: dict[str, object] = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": build_timestamp,
+    }
+    if build_timestamp is None:
+        del payload["buildTimestamp"]
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_modern_identity_allows_only_optional_image() -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-abcdef0"
+    payload = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+    }
+    without_image = verifier.identity(
+        json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+    )
+    payload["image"] = image
+    with_image = verifier.identity(
+        json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+    )
+    assert without_image == with_image == ("3.1.0", SHA, BUILD_TIMESTAMP, image)
+
+    payload["extra"] = SENTINEL
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(), "3.1.0", SHA, image, "direct identity"
+        )
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         b"{",
@@ -1126,6 +1212,44 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
         verifier.verify(args)
+
+
+def test_verify_rejects_direct_replica_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": SHA,
+            "shortRevision": SHA[:7],
+            "buildTimestamp": "2026-08-01T12:00:01Z",
+            "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        }
+    )
+    args, _ = _verify_setup(
+        monkeypatch, tmp_path, overrides={"direct_builds": {"dspace-2": mismatched}}
+    )
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "pod/replica identity"
+
+
+def test_verify_rejects_public_direct_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    public_build = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": SHA,
+            "shortRevision": SHA[:7],
+            "buildTimestamp": "2026-08-01T12:00:01Z",
+            "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        }
+    )
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides={"public_build": public_build})
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == "public identity"
 
 
 def test_verify_redacts_nonzero_chat_output(
@@ -1502,14 +1626,39 @@ def test_deployment_requires_matching_helm_annotations(annotation: str, value: s
 @pytest.mark.parametrize(
     "payload,category",
     [
-        ({"version": "wrong", "revision": SHA, "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": "wrong", "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": SHA, "shortRevision": "wrong"}, "public identity"),
+        (
+            {
+                "version": "wrong",
+                "revision": SHA,
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": "wrong",
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": SHA,
+                "shortRevision": "wrong",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
         (
             {
                 "version": "3.1.0",
                 "revision": SHA,
                 "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": f"ghcr.io/democratizedspace/dspace:main-abcdef0@{DIGEST}",
             },
             "public identity",


### PR DESCRIPTION
### Motivation

- The runtime verifier rejected valid modern `/build-info.json` payloads because the verifier schema lagged the upstream DSPACE contract which requires `buildTimestamp` in canonical UTC form.

### Description

- Require exactly `version`, `revision`, `shortRevision`, and `buildTimestamp` for the modern `build-info-v1` identity while preserving `image` as the only optional field and rejecting any extra fields in the payload, implemented in `identity()` in `scripts/dspace_runtime_verifier.py`.
- Enforce strict timestamp validation using a regex and ISO parsing to require literal UTC `Z`, either seconds or exactly three fractional milliseconds, no control characters, a maximum length of 40, and that the value parses to a valid calendar instant; the verified `buildTimestamp` is included in the normalized identity returned by `identity()` so replica/public comparisons cover the timestamp uniformly.
- Update the verifier signature to return the normalized timestamp and keep existing legacy identity behavior unchanged; update the modern verifier test fixture so the full verification flow exercises `buildTimestamp` through the real `identity()` implementation.
- Add focused tests in `tests/test_dspace_runtime_verifier.py` that cover canonical seconds and millisecond timestamps, missing/empty/non-string/oversized/control-character/malformed/timezone/precision/noncanonical cases, unexpected extra fields, optional `image` behavior, direct-replica timestamp disagreement (failing `pod/replica identity`), and public/direct disagreement (failing `public identity`).

### Testing

- Built and syntax-checked the verifier with `python3 -m compileall scripts/dspace_runtime_verifier.py` which succeeded.
- Ran the verifier unit tests with `pytest -q tests/test_dspace_runtime_verifier.py` and observed `196 passed` (all new branches exercised); coverage for `scripts/dspace_runtime_verifier.py` reported ~95% file coverage from a focused run using `coverage`.
- Ran the related suite checks `pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_dspace_runtime_values.py` which passed (`388 passed`) to ensure no regression outside the verifier scope.
- Executed `git diff --check` and `git diff | ./scripts/scan-secrets.py` (no repository secrets introduced); a repository-wide `pre-commit run --all-files` was attempted but reported pre-existing YAML and lint findings unrelated to this change and not addressed here.

Files changed: `scripts/dspace_runtime_verifier.py`, `tests/test_dspace_runtime_verifier.py`.

No cluster, Secret, candidate/reservation/finalization, deployment coordinate, or other runtime metadata was mutated as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f1cd4c94832f8c9dac14ef0835fb)