### PR TITLE
Require and validate DSPACE modern `buildTimestamp` in verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,7 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -87,6 +87,9 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+BUILD_TIMESTAMP_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{3})?Z$"
+)
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -218,7 +221,7 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
@@ -226,6 +229,20 @@ def identity(
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
     if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+        fail(category)
+    timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(timestamp, str)
+        or not timestamp
+        or len(timestamp) > 40
+        or BUILD_TIMESTAMP_RE.fullmatch(timestamp) is None
+    ):
+        fail(category)
+    try:
+        datetime.strptime(
+            timestamp, "%Y-%m-%dT%H:%M:%S.%fZ" if "." in timestamp else "%Y-%m-%dT%H:%M:%SZ"
+        )
+    except ValueError:
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +253,7 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    return version, revision, runtime_image or image, timestamp
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-16T05:20:19.123Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -1102,10 +1104,145 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
     assert SENTINEL not in str(raised.value)
 
 
+def modern_build_payload(timestamp: object = BUILD_TIMESTAMP, **changes: object) -> bytes:
+    value = {
+        "version": "3.1.1",
+        "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "shortRevision": "22f506e",
+        "buildTimestamp": timestamp,
+        "image": "ghcr.io/democratizedspace/dspace:main-22f506e",
+        **changes,
+    }
+    return json.dumps(value).encode()
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["2026-08-16T05:20:19Z", "2026-08-16T05:20:19.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_upstream_build_timestamp(timestamp: str) -> None:
+    assert verifier.identity(
+        modern_build_payload(timestamp),
+        "3.1.1",
+        "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "ghcr.io/democratizedspace/dspace:main-22f506e",
+        "direct identity",
+    ) == (
+        "3.1.1",
+        "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "ghcr.io/democratizedspace/dspace:main-22f506e",
+        timestamp,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        modern_build_payload(extra=SENTINEL),
+        json.dumps(
+            {
+                "version": "3.1.1",
+                "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+                "shortRevision": "22f506e",
+            }
+        ).encode(),
+        modern_build_payload(""),
+        modern_build_payload(123),
+        modern_build_payload("2" * 41 + SENTINEL),
+        modern_build_payload("2026-08-16T05:20:19Z\n" + SENTINEL),
+        modern_build_payload("2026-02-30T05:20:19Z"),
+        modern_build_payload("2026-08-16T05:20:19+00:00"),
+        modern_build_payload("2026-08-16T05:20:19z"),
+        modern_build_payload("2026-08-16T05:20:19.12Z"),
+        modern_build_payload("2026-08-16T05:20:19.1234Z"),
+    ],
+    ids=(
+        "unknown-field",
+        "missing",
+        "empty",
+        "non-string",
+        "overlong",
+        "control-character",
+        "impossible-date",
+        "offset-timezone",
+        "non-utc",
+        "short-fraction",
+        "long-fraction",
+    ),
+)
+def test_modern_identity_rejects_invalid_timestamp_without_echoing_values(payload: bytes) -> None:
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            payload,
+            "3.1.1",
+            "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+            "ghcr.io/democratizedspace/dspace:main-22f506e",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_builds": {
+                    "dspace-2": json.dumps(
+                        {
+                            "version": "3.1.0",
+                            "revision": SHA,
+                            "shortRevision": SHA[:7],
+                            "buildTimestamp": "2026-08-16T05:20:20Z",
+                            "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_build": json.dumps(
+                    {
+                        "version": "3.1.0",
+                        "revision": SHA,
+                        "shortRevision": SHA[:7],
+                        "buildTimestamp": "2026-08-16T05:20:20Z",
+                        "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                    }
+                )
+            },
+            "public identity",
+        ),
+    ],
+    ids=("replica-timestamp", "public-timestamp"),
+)
+def test_verify_fails_closed_on_modern_build_timestamp_disagreement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
+
+
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": "f" * 40,
+            "shortRevision": "fffffff",
+            "buildTimestamp": BUILD_TIMESTAMP,
+        }
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1121,7 +1258,7 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (*value[:3], "2000-01-01T00:00:00Z") if category == "public identity" else value
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):


### PR DESCRIPTION
### Motivation

- Staging runs DSPACE app `3.1.1` (chart `3.1.2`, Helm revision 29) whose immutable frontend returns a modern `build-info-v1` payload including a required `buildTimestamp`, and the existing verifier rejected the live response as an unknown-field failure. 
- The upstream canonical contract (file `frontend/src/utils/buildIdentity.js`) emits fields `version`, `revision`, `shortRevision`, required `buildTimestamp`, and optional `image`; the verifier must accept that contract to verify the already-deployed staging release without any Helm mutation.

### Description

- Add `buildTimestamp` to the modern `build-info-v1` parser only by extending `BUILD_FIELDS` and validating the field in `scripts/dspace_runtime_verifier.py` without changing emitted result schemas, `CAPABILITIES`, `RESULT_FIELDS`, journey names, or legacy `/build-meta.json` handling. 
- Validate `buildTimestamp` as a bounded canonical UTC timestamp: JSON string, nonempty, <= 40 chars, no control/trailing characters, real calendar date, and exact formats `YYYY-MM-DDTHH:MM:SSZ` or `YYYY-MM-DDTHH:MM:SS.sssZ` (no offsets, non-UTC forms, or arbitrary fractional precision). The regex and `datetime.strptime` checks enforce this. 
- Include the normalized timestamp in the verifier’s internal direct-replica / public identity tuple so any timestamp disagreement between replicas or between direct and public responses fails closed, while the verifier’s emitted JSON remains unchanged. 
- Preserve all legacy behavior (required `build-meta.json` contract and legacy coordinate selection) and keep failure categories and redaction rules intact. 
- Add focused regression tests in `tests/test_dspace_runtime_verifier.py` covering the exact DSPACE 3.1.1 modern payload, accepted second- and millisecond-precision timestamps, every requested malformed timestamp class, unknown-field rejection, replica/public timestamp disagreement, continued legacy behavior, and redaction on new failure paths.

### Testing

- Ran the focused verifier suite: `python -m pytest -q tests/test_dspace_runtime_verifier.py` — 194 passed. (passed)
- Ran related suites touched by imports/integration: `python -m pytest -q tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — passed. (passed)
- Verified offline `capabilities` output and ordering with `python scripts/dspace_runtime_verifier.py capabilities --environment staging --release dspace --namespace dspace` and an exact JSON assertion. (passed)
- Ran `git diff --check` and repository secret scan `git diff --cached | ./scripts/scan-secrets.py`. (passed)
- Ran pre-commit hooks for changed files: trailing-whitespace and end-of-file fixes on the modified files were applied; `pre-commit run --all-files` is blocked by pre-existing repository-wide whitespace/flake8 issues outside this PR and therefore was not used to modify unrelated files. (informational)
- `pyspelling -c .spellcheck.yaml` could not run in this environment because `aspell` is not installed; no docs were changed. (not run)

Residual notes and safety guarantees

- The change is strictly verification-only: it enables the existing staging `3.1.1` deployment to be classified and verified without performing any Helm upgrade, redeploy, evidence reservation mutation, or production change. Finalization of the existing revision-29 reservation remains a separately authorized operator action.
- Diff is minimal and contains no operational evidence or credentials; secrets scan on the staged diff passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f34aea48832f89a4c57e33d88dc6)