### PR TITLE
Fix DSPACE modern build timestamp verification

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,7 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -91,6 +91,7 @@ HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECA
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
 POD_SETTLE_INTERVAL_SECONDS = 2.0
+BUILD_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$")
 
 
 class VerificationError(ValueError):
@@ -218,14 +219,19 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    required_fields = BUILD_FIELDS - {"image"}
+    if (
+        not isinstance(value, dict)
+        or set(value) - BUILD_FIELDS
+        or not required_fields.issubset(value)
+    ):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +242,24 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        timestamp_format = (
+            "%Y-%m-%dT%H:%M:%SZ"
+            if "." not in build_timestamp
+            else "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        datetime.strptime(build_timestamp, timestamp_format)
+    except ValueError:
+        fail(category)
+    return version, revision, runtime_image or image, build_timestamp
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +467,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, str, str] | tuple[str, str, str, str] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-16T05:20:19.123Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -1128,6 +1130,55 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         verifier.verify(args)
 
 
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_builds": {
+                    "dspace-2": json.dumps(
+                        {
+                            "version": "3.1.0",
+                            "revision": SHA,
+                            "shortRevision": SHA[:7],
+                            "buildTimestamp": "2026-08-16T05:20:20Z",
+                            "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_build": json.dumps(
+                    {
+                        "version": "3.1.0",
+                        "revision": SHA,
+                        "shortRevision": SHA[:7],
+                        "buildTimestamp": "2026-08-16T05:20:20Z",
+                        "image": "ghcr.io/democratizedspace/dspace:main-abcdef0",
+                    }
+                )
+            },
+            "public identity",
+        ),
+    ],
+    ids=("replicas", "direct-public"),
+)
+def test_modern_build_timestamp_disagreement_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
+    assert SENTINEL not in str(raised.value)
+
+
 def test_verify_redacts_nonzero_chat_output(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1527,6 +1578,80 @@ def test_build_identity_requires_canonical_coordinates(
             "ghcr.io/democratizedspace/dspace:main-abcdef0",
             category,
         )
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    ["2026-08-16T05:20:19Z", "2026-08-16T05:20:19.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_utc_build_timestamp(build_timestamp: str) -> None:
+    payload = {
+        "version": "3.1.1",
+        "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+        "shortRevision": "22f506e",
+        "buildTimestamp": build_timestamp,
+        "image": "ghcr.io/democratizedspace/dspace:main-22f506e",
+    }
+
+    assert verifier.identity(
+        json.dumps(payload).encode(),
+        payload["version"],
+        payload["revision"],
+        payload["image"],
+        "direct identity",
+    ) == (payload["version"], payload["revision"], payload["image"], build_timestamp)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("", id="empty"),
+        pytest.param(123, id="non-string"),
+        pytest.param("2" * 41, id="overlong"),
+        pytest.param("2026-08-16T05:20:19Z\n" + SENTINEL, id="control-character"),
+        pytest.param("2026-02-30T05:20:19Z", id="impossible-date"),
+        pytest.param("2026-08-16T05:20:19+00:00", id="offset-timezone"),
+        pytest.param("2026-08-16T05:20:19", id="non-utc"),
+        pytest.param("2026-08-16T05:20:19.12Z", id="short-fraction"),
+        pytest.param("2026-08-16T05:20:19.1234Z", id="long-fraction"),
+    ],
+)
+def test_modern_identity_rejects_bad_build_timestamps_without_leaking(
+    timestamp: object,
+) -> None:
+    payload: dict[str, object] = {
+        "version": "3.1.1",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": timestamp,
+    }
+    if timestamp is None:
+        del payload["buildTimestamp"]
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(), "3.1.1", SHA, "expected-image", "direct identity"
+        )
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_modern_identity_still_rejects_unknown_fields_without_leaking() -> None:
+    payload = {
+        "version": "3.1.1",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+        "unexpected": SENTINEL,
+    }
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(), "3.1.1", SHA, "expected-image", "public identity"
+        )
+    assert str(raised.value) == "public identity"
+    assert SENTINEL not in str(raised.value)
 
 
 def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation

- The modern `build-info-v1` identity parser lagged the upstream DSPACE contract which returns `version`, `revision`, `shortRevision`, and a canonical UTC `buildTimestamp` (exactly `YYYY-MM-DDTHH:MM:SSZ` or `YYYY-MM-DDTHH:MM:SS.sssZ`) plus optional `image`, causing valid staging responses to be rejected as unknown-field failures. 
- Staging is already running the deployed DSPACE application `3.1.1` (chart `3.1.2`, Helm revision `29`) with two Ready replicas at `ghcr.io/democratizedspace/dspace:main-22f506e` (pinned digest) and `image.pullPolicy=Always`, and this change must only fix verification so the existing reservation can be finalized later without any cluster or Helm mutation. 

### Description

- Require the modern `build-info-v1` payload to include `buildTimestamp` while keeping `image` optional and leaving all legacy `/build-meta.json` handling and immutable coordinate selection unchanged. 
- Validate `buildTimestamp` as a JSON string, non-empty, <= 40 characters, with no control characters, matching either second precision `YYYY-MM-DDTHH:MM:SSZ` or millisecond precision `YYYY-MM-DDTHH:MM:SS.sssZ`, and being a real calendar UTC timestamp. 
- Include the normalized `buildTimestamp` in the verifier’s internal identity tuple used for replica-vs-replica and replica-vs-public agreement so any timestamp disagreement fails closed, while not adding `buildTimestamp` to the emitted result schema (`CAPABILITIES`, `RESULT_FIELDS`, journeys, and public output are unchanged). 
- Add focused regression tests for the exact DSPACE 3.1.1 modern payload, accepted seconds and milliseconds forms, all rejected timestamp classes (missing, empty, non-string, overlong, control characters, impossible dates, offset timezones, non-UTC, and noncanonical fractional precision), unknown fields, replica/public timestamp disagreement, legacy behavior preservation, and redaction on new failure paths. 

### Testing

- Ran `pytest -q tests/test_dspace_runtime_verifier.py` which passed locally with `192 passed in 17.42s`. 
- Ran a broader test subset `pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_generate_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` which completed with `1072 passed, 1 warning` (pre-existing escape-sequence warning). 
- Verified the offline capabilities output with `python3 scripts/dspace_runtime_verifier.py capabilities --environment staging --release dspace --namespace dspace` and confirmed it emits the exact existing ordered capabilities schema. 
- Ran repository checks `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` against the diff with no secrets or diff-check failures. 
- Attempted `pre-commit run --all-files` but `pre-commit` was not installed in the execution environment; `bash scripts/checks.sh` was run and surfaced pre-existing repository-wide lint findings unrelated to this focused change while the focused and integration pytest suites passed. 

Notes: the merge-base ancestor `9a28419b67963c43bed5b24373f729f796ed1117` was verified before edits and newer work was preserved; this PR is verification-only and does not perform any Helm/Kubernetes/evidence/reservation mutations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f462945c832fad54db6e65305ff5)