### PR TITLE
Require and validate buildTimestamp in DSPACE modern build-info verifier

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,7 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -87,6 +87,7 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+BUILD_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$")
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -218,14 +219,14 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError):
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    if not isinstance(value, dict) or set(value) not in (BUILD_FIELDS, BUILD_FIELDS - {"image"}):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +237,21 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not 1 <= len(build_timestamp) <= 40
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        timestamp_format = (
+            "%Y-%m-%dT%H:%M:%SZ" if "." not in build_timestamp else "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        datetime.strptime(build_timestamp, timestamp_format)
+    except ValueError:
+        fail(category)
+    return version, revision, runtime_image or image, build_timestamp
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +459,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, ...] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -235,7 +235,7 @@ def identity(
     ):
         fail(category)
     runtime_image = value.get("image")
-    if runtime_image is not None and runtime_image != image:
+    if "image" in value and runtime_image != image:
         fail(category)
     build_timestamp = value.get("buildTimestamp")
     if (

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1145,7 +1145,14 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": "f" * 40,
+            "shortRevision": "fffffff",
+            "buildTimestamp": BUILD_TIMESTAMP,
+        }
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1161,7 +1168,9 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (
+            (value[0], value[1], "different", value[3]) if category == "public identity" else value
+        )
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
@@ -1642,8 +1651,28 @@ def test_modern_identity_accepts_exact_dspace_311_payload() -> None:
     payload = modern_payload(
         version="3.1.1", revision=revision, image=image, timestamp="2026-08-15T19:38:47.123Z"
     )
-    assert verifier.identity(payload.encode(), "3.1.1", revision, image, "direct identity")[-1] == (
-        "2026-08-15T19:38:47.123Z"
+    assert verifier.identity(payload.encode(), "3.1.1", revision, image, "direct identity") == (
+        "3.1.1",
+        revision,
+        image,
+        "2026-08-15T19:38:47.123Z",
+    )
+
+
+def test_modern_identity_accepts_omitted_image() -> None:
+    payload = json.loads(modern_payload())
+    del payload["image"]
+    assert verifier.identity(
+        json.dumps(payload).encode(),
+        "3.1.0",
+        SHA,
+        "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        "direct identity",
+    ) == (
+        "3.1.0",
+        SHA,
+        "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        BUILD_TIMESTAMP,
     )
 
 
@@ -1660,6 +1689,37 @@ def test_modern_identity_rejects_null_image_without_leaking() -> None:
         )
     assert str(raised.value) == "direct identity"
     assert SENTINEL not in str(raised.value)
+
+
+def test_modern_identity_rejects_mismatched_image_without_leaking(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.loads(modern_payload())
+    payload["image"] = SENTINEL
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+def test_modern_image_validation_does_not_change_legacy_identity() -> None:
+    generated_at = "2026-08-01T12:00:00Z"
+    source = "dspace"
+    payload = json.dumps(
+        {"gitSha": RECOVERY_SHA, "generatedAt": generated_at, "source": source}
+    ).encode()
+    assert verifier.legacy_identity(payload, RECOVERY_SHA, "direct identity") == (
+        RECOVERY_SHA,
+        generated_at,
+        source,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,25 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-15T19:38:47.123Z"
+
+
+def modern_payload(
+    *,
+    version: str = "3.1.0",
+    revision: str = SHA,
+    image: str = "ghcr.io/democratizedspace/dspace:main-abcdef0",
+    timestamp: object = BUILD_TIMESTAMP,
+) -> str:
+    return json.dumps(
+        {
+            "version": version,
+            "revision": revision,
+            "shortRevision": revision[:7],
+            "buildTimestamp": timestamp,
+            "image": image,
+        }
+    )
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -122,9 +141,7 @@ def _verify_setup(
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    coordinates = (
-        verifier.LEGACY_310_COORDINATES if legacy_310 else verifier.LEGACY_303_COORDINATES
-    )
+    coordinates = verifier.LEGACY_310_COORDINATES if legacy_310 else verifier.LEGACY_303_COORDINATES
     is_legacy = legacy or legacy_310
     revision = str(coordinates["sourceRevision"]) if is_legacy else SHA
     digest = str(coordinates["imageDigest"]) if is_legacy else DIGEST
@@ -135,13 +152,10 @@ def _verify_setup(
     declared = f"{canonical}@{digest}" if rollback else canonical
 
     def build(image: str = canonical, revision: str = SHA) -> str:
-        return json.dumps(
-            {
-                "version": version,
-                "revision": revision,
-                "shortRevision": revision[:7],
-                "image": image,
-            }
+        return modern_payload(
+            version=version,
+            revision=revision,
+            image=image,
         )
 
     pods = []
@@ -697,10 +711,7 @@ def test_exact_recovery_uses_legacy_contract_and_truthful_journeys(
     ids=["chart-3.0.2", "chart-3.0.3"],
 )
 def test_exact_recovery_coordinates_use_legacy_contract(coordinates: dict[str, object]) -> None:
-    assert (
-        verifier.identity_contract(dict(coordinates))
-        == verifier.LEGACY_IDENTITY_CONTRACT
-    )
+    assert verifier.identity_contract(dict(coordinates)) == verifier.LEGACY_IDENTITY_CONTRACT
 
 
 def test_exact_310_token_place_uses_legacy_contract_and_truthful_journeys(
@@ -972,6 +983,35 @@ def test_310_legacy_metadata_failures_remain_rejected(
     ids=("public-marker", "direct-marker", "public-json", "direct-json"),
 )
 def test_verify_redacts_failed_http_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
+    captured = capsys.readouterr()
+    assert SENTINEL not in str(raised.value) + captured.out + captured.err
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {"direct_builds": {"dspace-2": modern_payload(timestamp="2026-08-15T19:38:48Z")}},
+            "pod/replica identity",
+        ),
+        (
+            {"public_build": modern_payload(timestamp="2026-08-15T19:38:48Z")},
+            "public identity",
+        ),
+    ],
+    ids=("direct-replicas", "direct-public"),
+)
+def test_modern_build_timestamps_must_agree_without_leaking(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1502,14 +1542,39 @@ def test_deployment_requires_matching_helm_annotations(annotation: str, value: s
 @pytest.mark.parametrize(
     "payload,category",
     [
-        ({"version": "wrong", "revision": SHA, "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": "wrong", "shortRevision": "abcdef0"}, "public identity"),
-        ({"version": "3.1.0", "revision": SHA, "shortRevision": "wrong"}, "public identity"),
+        (
+            {
+                "version": "wrong",
+                "revision": SHA,
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": "wrong",
+                "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
+        (
+            {
+                "version": "3.1.0",
+                "revision": SHA,
+                "shortRevision": "wrong",
+                "buildTimestamp": BUILD_TIMESTAMP,
+            },
+            "public identity",
+        ),
         (
             {
                 "version": "3.1.0",
                 "revision": SHA,
                 "shortRevision": "abcdef0",
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": f"ghcr.io/democratizedspace/dspace:main-abcdef0@{DIGEST}",
             },
             "public identity",
@@ -1547,6 +1612,85 @@ def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.Mon
     with pytest.raises(verifier.VerificationError) as raised:
         verifier.command(["kubectl", SENTINEL])
     assert str(raised.value) == "cluster identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["2026-08-15T19:38:47Z", "2026-08-15T19:38:47.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_utc_build_timestamp(timestamp: str) -> None:
+    payload = modern_payload(timestamp=timestamp)
+    assert verifier.identity(
+        payload.encode(),
+        "3.1.0",
+        SHA,
+        "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        "direct identity",
+    ) == (
+        "3.1.0",
+        SHA,
+        "ghcr.io/democratizedspace/dspace:main-abcdef0",
+        timestamp,
+    )
+
+
+def test_modern_identity_accepts_exact_dspace_311_payload() -> None:
+    revision = "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"
+    image = "ghcr.io/democratizedspace/dspace:main-22f506e"
+    payload = modern_payload(
+        version="3.1.1", revision=revision, image=image, timestamp="2026-08-15T19:38:47.123Z"
+    )
+    assert verifier.identity(payload.encode(), "3.1.1", revision, image, "direct identity")[-1] == (
+        "2026-08-15T19:38:47.123Z"
+    )
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        None,
+        "",
+        1723750727,
+        "2026-08-15T19:38:47.123Z" + "x" * 20,
+        "2026-08-15T19:38:47Z\n" + SENTINEL,
+        "2026-02-30T19:38:47Z",
+        "2026-08-15T19:38:47+00:00",
+        "2026-08-15T19:38:47-04:00",
+        "2026-08-15T19:38:47.1Z",
+        "2026-08-15T19:38:47.1234Z",
+    ],
+    ids=(
+        "missing",
+        "empty",
+        "non-string",
+        "overlong",
+        "control-character",
+        "impossible-date",
+        "offset-utc",
+        "non-utc",
+        "short-fraction",
+        "long-fraction",
+    ),
+)
+def test_modern_identity_rejects_invalid_build_timestamp_without_leaking(
+    timestamp: object,
+) -> None:
+    payload = json.loads(modern_payload())
+    if timestamp is None:
+        del payload["buildTimestamp"]
+    else:
+        payload["buildTimestamp"] = timestamp
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
     assert SENTINEL not in str(raised.value)
 
 
@@ -1609,7 +1753,13 @@ def test_fetch_success_and_network_failures_are_bounded(
         (
             lambda: verifier.identity(
                 json.dumps(
-                    {"version": "v", "revision": SHA, "shortRevision": SHA[:7], "extra": SENTINEL}
+                    {
+                        "version": "v",
+                        "revision": SHA,
+                        "shortRevision": SHA[:7],
+                        "buildTimestamp": BUILD_TIMESTAMP,
+                        "extra": SENTINEL,
+                    }
                 ).encode(),
                 "v",
                 SHA,

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1709,19 +1709,6 @@ def test_modern_identity_rejects_mismatched_image_without_leaking(
     assert SENTINEL not in str(raised.value) + captured.out + captured.err
 
 
-def test_modern_image_validation_does_not_change_legacy_identity() -> None:
-    generated_at = "2026-08-01T12:00:00Z"
-    source = "dspace"
-    payload = json.dumps(
-        {"gitSha": RECOVERY_SHA, "generatedAt": generated_at, "source": source}
-    ).encode()
-    assert verifier.legacy_identity(payload, RECOVERY_SHA, "direct identity") == (
-        RECOVERY_SHA,
-        generated_at,
-        source,
-    )
-
-
 @pytest.mark.parametrize(
     "timestamp",
     [

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -1647,6 +1647,21 @@ def test_modern_identity_accepts_exact_dspace_311_payload() -> None:
     )
 
 
+def test_modern_identity_rejects_null_image_without_leaking() -> None:
+    payload = json.loads(modern_payload())
+    payload["image"] = None
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
 @pytest.mark.parametrize(
     "timestamp",
     [


### PR DESCRIPTION
### Context

DSPACE’s modern `build-info-v1` contract contains required `version`, `revision`, `shortRevision`, and `buildTimestamp` fields plus optional `image`. `buildTimestamp` must be canonical UTC at second or millisecond precision.

PR #2642 has since landed the base `buildTimestamp` parser and validation on `main`. This PR is now a focused follow-up that preserves that implementation while closing the reviewed optional-image edge case and strengthening regression coverage.

The existing staging deployment remains healthy:

- Application `3.1.1`
- Chart `3.1.2`
- Helm revision `29`
- Exactly two Ready pods
- Image `ghcr.io/democratizedspace/dspace:main-22f506e`
- Digest `sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b`
- `image.pullPolicy=Always`

### Changes

- Require a present modern `image` field to exactly match the expected canonical image. An omitted `image` remains valid, while JSON `null` and mismatched values fail with the existing bounded, redacted identity category.
- Add direct regression coverage for null and mismatched images.
- Add an exact DSPACE 3.1.1 payload regression asserting the complete normalized `(version, revision, buildTimestamp, image)` identity.
- Strengthen replica/direct-public timestamp-disagreement coverage by asserting that the actual differing timestamp is absent from exceptions and captured output.
- Preserve `main`’s timestamp parser, tuple order, emitted result schema, ordered capabilities, journey names, legacy `/build-meta.json` behavior, and immutable legacy-coordinate selection.

### Verification

Latest head: `e1813d11d6be24898ba3e08fbf87669335394b91`

- GitHub Actions `ci` run `31984459774`: passed
- GitHub Actions `Test Suite` run `31984459809`: passed
- GitHub Actions `pi-image` run `31984459772`: passed; unrelated conditional build/OCI steps were skipped as expected
- Codecov reports all modified coverable lines covered
- Focused verifier selection: `23 passed`
- Offline `capabilities` output matches the existing exact schema and order
- `git diff --check` passed
- Repository secret scanner passed
- Final diff is limited to:
  - `scripts/dspace_runtime_verifier.py`
  - `tests/test_dspace_runtime_verifier.py`

### Operational scope

This is a verifier-and-tests-only change. It performs no Kubernetes, Helm, deployment, reservation, Secret, or evidence operation and requires no redeploy or Helm upgrade.

Merging this PR does not authorize a staging redeploy, production change, reservation mutation, or evidence finalization. Finalizing the existing revision-29 evidence reservation remains a separately authorized operator action with no Helm mutation.

Production remains untouched at Helm revision `10`, chart `3.0.3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f46a2ccc832fbd0cea8cbe473af7)