### PR TITLE
Validate immutable DSPACE 3.1.1 staging metrics contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -47,7 +47,8 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-int"
               }
-            ]
+            ],
+            "targetLabels": []
           },
           "targetLabels": {
             "app": "tokenplace",
@@ -185,7 +186,9 @@
               "env": "TOKENPLACE_IMAGE_TAG",
               "normalizer": "identity"
             }
-          }
+          },
+          "transferredTargetLabels": {},
+          "metadataOnlyMetricFamilies": {}
         }
       }
     },
@@ -240,6 +243,15 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-int"
               }
+            ],
+            "targetLabels": [
+              "app.kubernetes.io/name",
+              "app.kubernetes.io/instance",
+              "app.kubernetes.io/managed-by",
+              "dspace.dev/app",
+              "dspace.dev/environment",
+              "dspace.dev/release",
+              "dspace.dev/cluster"
             ]
           },
           "targetLabels": {
@@ -361,7 +373,20 @@
             "token",
             "url",
             "user"
-          ]
+          ],
+          "transferredTargetLabels": {
+            "app_kubernetes_io_name": "dspace",
+            "app_kubernetes_io_instance": "dspace",
+            "app_kubernetes_io_managed_by": "Helm",
+            "dspace_dev_app": "dspace",
+            "dspace_dev_environment": "staging",
+            "dspace_dev_release": "dspace",
+            "dspace_dev_cluster": "sugarkube-int"
+          },
+          "metadataOnlyMetricFamilies": {
+            "dspace_dchat_requests_total": "counter",
+            "dspace_dependency_requests_total": "counter"
+          }
         },
         "prod": {
           "namespace": "dspace",
@@ -412,7 +437,8 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-prod"
               }
-            ]
+            ],
+            "targetLabels": []
           },
           "targetLabels": {
             "app": "dspace",
@@ -533,7 +559,9 @@
             "token",
             "url",
             "user"
-          ]
+          ],
+          "transferredTargetLabels": {},
+          "metadataOnlyMetricFamilies": {}
         }
       }
     }

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -999,7 +999,9 @@ def metadata_declares_family(
         tuple(sorted(labels.items())) for labels in expected_targets
     }:
         fail("Prometheus metadata did not identify the exact scrape targets (details redacted)", 1)
-    if any(entry.get("metric") != metric for entry in entries):
+    # Filtered target-metadata responses omit ``metric`` because the request's
+    # exact metric parameter already identifies the family.
+    if any("metric" in entry and entry["metric"] != metric for entry in entries):
         fail("Prometheus metadata did not identify the exact metric family (details redacted)", 1)
     if any(entry.get("type") != expected_type for entry in entries):
         fail("Prometheus metadata metric type mismatch (details redacted)", 1)

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -869,8 +869,6 @@ def validate_metric_labels(cfg, labels, derived_values=None):
             or any(w in low for w in FORBIDDEN_WORDS)
         ):
             fail("forbidden application metric label observed (details redacted)", 1)
-        if is_transferred and value != cfg["transferredTargetLabels"][label]:
-            fail("transferred target metric label mismatch (details redacted)", 1)
         if (
             label in cfg["allowedApplicationLabels"]
             and value not in cfg["allowedApplicationLabels"][label]
@@ -974,14 +972,26 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
     return found
 
 
-def metadata_declares_family(metric: str, expected_type: str) -> bool:
-    data = prom("/api/v1/metadata?metric=" + urllib.parse.quote(metric))
-    if set(data) != {metric}:
-        fail("Prometheus metadata did not identify the exact metric family (details redacted)", 1)
-    entries = data[metric]
-    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
+def metadata_declares_family(
+    cfg: dict[str, Any], targets: list[dict[str, Any]], metric: str, expected_type: str
+) -> bool:
+    selector = promql_selector(cfg["targetLabels"])
+    query = urllib.parse.urlencode({"match_target": selector, "metric": metric})
+    entries = prom("/api/v1/targets/metadata?" + query)
+    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
         fail("Prometheus metadata response is structurally invalid (details redacted)", 1)
-    if entries[0].get("type") != expected_type:
+    expected_targets = [target.get("labels") for target in targets]
+    declared_targets = [entry.get("target") for entry in entries]
+    if (
+        len(entries) != cfg["expectedTargetCount"]
+        or any(not isinstance(labels, dict) for labels in expected_targets + declared_targets)
+        or {tuple(sorted(labels.items())) for labels in declared_targets}
+        != {tuple(sorted(labels.items())) for labels in expected_targets}
+    ):
+        fail("Prometheus metadata did not identify the exact scrape targets (details redacted)", 1)
+    if any(entry.get("metric") != metric for entry in entries):
+        fail("Prometheus metadata did not identify the exact metric family (details redacted)", 1)
+    if any(entry.get("type") != expected_type for entry in entries):
         fail("Prometheus metadata metric type mismatch (details redacted)", 1)
     return True
 
@@ -1083,7 +1093,7 @@ def verify(app, env):
     if missing:
         metadata_only = cfg.get("metadataOnlyMetricFamilies", {})
         for metric in sorted(missing & set(metadata_only)):
-            if metadata_declares_family(metric, metadata_only[metric]):
+            if metadata_declares_family(cfg, targets, metric, metadata_only[metric]):
                 found.add(metric)
         missing = required - found
     if missing:

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -71,6 +71,28 @@ DSPACE_REQUIRED_METRIC_FAMILIES = [
     "dspace_instrumentation_up",
     "dspace_build_info",
 ]
+DSPACE_STAGING_TARGET_LABELS = [
+    "app.kubernetes.io/name",
+    "app.kubernetes.io/instance",
+    "app.kubernetes.io/managed-by",
+    "dspace.dev/app",
+    "dspace.dev/environment",
+    "dspace.dev/release",
+    "dspace.dev/cluster",
+]
+DSPACE_STAGING_TRANSFERRED_LABELS = {
+    "app_kubernetes_io_name": "dspace",
+    "app_kubernetes_io_instance": "dspace",
+    "app_kubernetes_io_managed_by": "Helm",
+    "dspace_dev_app": "dspace",
+    "dspace_dev_environment": "staging",
+    "dspace_dev_release": "dspace",
+    "dspace_dev_cluster": "sugarkube-int",
+}
+DSPACE_STAGING_METADATA_ONLY_FAMILIES = {
+    "dspace_dchat_requests_total": "counter",
+    "dspace_dependency_requests_total": "counter",
+}
 DSPACE_SOURCE_LABELS = {
     "version": ["3.1.1"],
     "revision": ["22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"],
@@ -293,6 +315,8 @@ def validate_inventory(doc):
                     "allowedApplicationLabels",
                     "derivedApplicationLabels",
                     "forbiddenApplicationLabels",
+                    "transferredTargetLabels",
+                    "metadataOnlyMetricFamilies",
                 },
                 f"{app}/{env}",
             )
@@ -317,6 +341,7 @@ def validate_inventory(doc):
                     "scrapeTimeout",
                     "authorization",
                     "relabelings",
+                    "targetLabels",
                 },
                 "serviceMonitor",
             )
@@ -342,6 +367,15 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
+            service_monitor_target_labels = sm["targetLabels"]
+            if not isinstance(service_monitor_target_labels, list):
+                fail("serviceMonitor.targetLabels must be an array")
+            if service_monitor_target_labels:
+                unique_string_list(
+                    service_monitor_target_labels,
+                    "serviceMonitor.targetLabels",
+                    k8s_label_key,
+                )
             labels = cfg["targetLabels"]
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
@@ -398,6 +432,24 @@ def validate_inventory(doc):
                     fail("retry settings must be bounded integers")
             metrics = cfg["requiredMetricFamilies"]
             unique_string_list(metrics, "requiredMetricFamilies", prometheus_metric)
+            transferred = cfg["transferredTargetLabels"]
+            if not isinstance(transferred, dict):
+                fail("transferredTargetLabels must be an object")
+            for k, v in transferred.items():
+                prometheus_label(k, "transferred target label name")
+                nonempty(v, "transferred target label value")
+            metadata_only = cfg["metadataOnlyMetricFamilies"]
+            if not isinstance(metadata_only, dict):
+                fail("metadataOnlyMetricFamilies must be an object")
+            for metric, metric_type in metadata_only.items():
+                prometheus_metric(metric, "metadata-only metric family")
+                if metric not in metrics or metric_type not in {
+                    "counter",
+                    "gauge",
+                    "histogram",
+                    "summary",
+                }:
+                    fail("metadata-only metric family contract is invalid")
             allowed = cfg["allowedApplicationLabels"]
             if not isinstance(allowed, dict):
                 fail("allowedApplicationLabels must be an object")
@@ -445,6 +497,22 @@ def validate_inventory(doc):
                     }
                 ):
                     fail("DSPACE environment coordinates must match the canonical contract")
+                expected_sm_targets = DSPACE_STAGING_TARGET_LABELS if env == "staging" else []
+                expected_transferred = DSPACE_STAGING_TRANSFERRED_LABELS if env == "staging" else {}
+                expected_metadata_only = (
+                    DSPACE_STAGING_METADATA_ONLY_FAMILIES if env == "staging" else {}
+                )
+                if (
+                    sm["targetLabels"] != expected_sm_targets
+                    or transferred != expected_transferred
+                    or metadata_only != expected_metadata_only
+                ):
+                    fail("DSPACE transferred-label and zero-series contracts must be exact")
+            elif sm["targetLabels"] or transferred or metadata_only:
+                fail(
+                    "transferred-label and zero-series contracts are not enabled "
+                    "for this application"
+                )
             derived = cfg["derivedApplicationLabels"]
             if not isinstance(derived, dict):
                 fail("derivedApplicationLabels must be an object")
@@ -776,6 +844,9 @@ def validate_metric_labels(cfg, labels, derived_values=None):
         )
     ):
         fail("DSPACE build identity label mismatch (details redacted)", 1)
+    for label, expected in cfg.get("transferredTargetLabels", {}).items():
+        if labels.get(label) != expected:
+            fail("transferred target metric label mismatch (details redacted)", 1)
     for label, value in labels.items():
         if (
             not isinstance(label, str)
@@ -785,8 +856,10 @@ def validate_metric_labels(cfg, labels, derived_values=None):
             fail("metric labels were malformed (details redacted)", 1)
         low = label.lower()
         is_standard = label in STANDARD_LABELS
+        is_transferred = label in cfg.get("transferredTargetLabels", {})
         if (
             not is_standard
+            and not is_transferred
             and label not in cfg["allowedApplicationLabels"]
             and label not in cfg.get("derivedApplicationLabels", {})
         ):
@@ -796,6 +869,8 @@ def validate_metric_labels(cfg, labels, derived_values=None):
             or any(w in low for w in FORBIDDEN_WORDS)
         ):
             fail("forbidden application metric label observed (details redacted)", 1)
+        if is_transferred and value != cfg["transferredTargetLabels"][label]:
+            fail("transferred target metric label mismatch (details redacted)", 1)
         if (
             label in cfg["allowedApplicationLabels"]
             and value not in cfg["allowedApplicationLabels"][label]
@@ -899,6 +974,18 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
     return found
 
 
+def metadata_declares_family(metric: str, expected_type: str) -> bool:
+    data = prom("/api/v1/metadata?metric=" + urllib.parse.quote(metric))
+    if set(data) != {metric}:
+        fail("Prometheus metadata did not identify the exact metric family (details redacted)", 1)
+    entries = data[metric]
+    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
+        fail("Prometheus metadata response is structurally invalid (details redacted)", 1)
+    if entries[0].get("type") != expected_type:
+        fail("Prometheus metadata metric type mismatch (details redacted)", 1)
+    return True
+
+
 def verify(app, env):
     app = normalize_application_argument(app)
     env = normalize_live_env(env)
@@ -962,6 +1049,8 @@ def verify(app, env):
         fail("ServiceMonitor endpoint/auth contract mismatch", 1)
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("ServiceMonitor selector mismatch", 1)
+    if spec.get("targetLabels", []) != cfg["serviceMonitor"]["targetLabels"]:
+        fail("ServiceMonitor targetLabels mismatch", 1)
     targets = []
     attempts = cfg["retries"]["attempts"]
     for i in range(attempts):
@@ -991,6 +1080,12 @@ def verify(app, env):
         if i + 1 < attempts:
             time.sleep(cfg["retries"]["delaySeconds"])
     missing = required - found
+    if missing:
+        metadata_only = cfg.get("metadataOnlyMetricFamilies", {})
+        for metric in sorted(missing & set(metadata_only)):
+            if metadata_declares_family(metric, metadata_only[metric]):
+                found.add(metric)
+        missing = required - found
     if missing:
         fail(f"required metric family missing: {sorted(missing)[0]}", 1)
 
@@ -1125,6 +1220,8 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
+    if spec.get("targetLabels", []) != cfg["serviceMonitor"]["targetLabels"]:
+        fail("rendered ServiceMonitor targetLabels mismatch")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -737,12 +737,12 @@ def install_secret(cfg):
     print("Application metrics Secret installed or rotated (value not displayed).")
 
 
-def prom(path):
+def prom(path, expected_data_type=dict):
     doc = kjson(["kubectl", "get", "--raw", PROM + path])
     if doc.get("status") != "success":
         fail("Prometheus API status was not success (response redacted)", 1)
     data = doc.get("data")
-    if not isinstance(data, dict):
+    if not isinstance(data, expected_data_type):
         fail("Prometheus API response is structurally invalid (response redacted)", 1)
     return data
 
@@ -977,17 +977,27 @@ def metadata_declares_family(
 ) -> bool:
     selector = promql_selector(cfg["targetLabels"])
     query = urllib.parse.urlencode({"match_target": selector, "metric": metric})
-    entries = prom("/api/v1/targets/metadata?" + query)
-    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
+    entries = prom("/api/v1/targets/metadata?" + query, list)
+    if not all(isinstance(entry, dict) for entry in entries):
         fail("Prometheus metadata response is structurally invalid (details redacted)", 1)
     expected_targets = [target.get("labels") for target in targets]
     declared_targets = [entry.get("target") for entry in entries]
+    target_label_maps = expected_targets + declared_targets
     if (
         len(entries) != cfg["expectedTargetCount"]
-        or any(not isinstance(labels, dict) for labels in expected_targets + declared_targets)
-        or {tuple(sorted(labels.items())) for labels in declared_targets}
-        != {tuple(sorted(labels.items())) for labels in expected_targets}
+        or any(
+            not isinstance(labels, dict)
+            or any(
+                not isinstance(key, str) or not isinstance(value, str)
+                for key, value in labels.items()
+            )
+            for labels in target_label_maps
+        )
     ):
+        fail("Prometheus metadata did not identify the exact scrape targets (details redacted)", 1)
+    if {tuple(sorted(labels.items())) for labels in declared_targets} != {
+        tuple(sorted(labels.items())) for labels in expected_targets
+    }:
         fail("Prometheus metadata did not identify the exact scrape targets (details redacted)", 1)
     if any(entry.get("metric") != metric for entry in entries):
         fail("Prometheus metadata did not identify the exact metric family (details redacted)", 1)

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -155,6 +155,14 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: dspace
       app.kubernetes.io/name: dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   endpoints:
     - port: http
       path: /metrics

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6407,7 +6407,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
         }
     }
     commands = []
-    queried_families = set()
+    query_events = []
 
     def fake_kjson(args):
         commands.append(args)
@@ -6424,7 +6424,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
             return {"activeTargets": [target, dict(target)]}
         if path.startswith("/api/v1/targets/metadata?"):
             metric = app_metrics.urllib.parse.parse_qs(path.split("?", 1)[1])["metric"][0]
-            queried_families.add(metric)
+            query_events.append(("metadata", metric))
             return [
                 {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
                 {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
@@ -6432,11 +6432,11 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
         metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
             "{", 1
         )[0]
+        query_events.append(("sample", metric))
         if metric not in cfg["requiredMetricFamilies"]:
             return {"resultType": "vector", "result": []}
         if metric in cfg["metadataOnlyMetricFamilies"]:
             return {"resultType": "vector", "result": []}
-        queried_families.add(metric)
         labels = {"__name__": metric, **cfg["transferredTargetLabels"]}
         if metric == "dspace_build_info":
             labels.update(
@@ -6459,13 +6459,25 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
     monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {})
     monkeypatch.setattr(app_metrics, "kjson", fake_kjson)
     monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    sleeps = []
+    monkeypatch.setattr(app_metrics.time, "sleep", lambda seconds: sleeps.append(seconds))
     monkeypatch.setattr(
         app_metrics.urllib.request, "build_opener", lambda *args: Opener()
     )
 
     app_metrics.verify("dspace", "staging")
 
-    assert queried_families == set(cfg["requiredMetricFamilies"])
+    metadata_events = [event for event in query_events if event[0] == "metadata"]
+    assert metadata_events == [
+        ("metadata", "dspace_dchat_requests_total"),
+        ("metadata", "dspace_dependency_requests_total"),
+    ]
+    assert all(event[0] == "sample" for event in query_events[:-2])
+    sampled = {metric for kind, metric in query_events if kind == "sample"}
+    assert set(cfg["requiredMetricFamilies"]) <= sampled
+    assert sleeps == [cfg["retries"]["delaySeconds"]] * (
+        cfg["retries"]["attempts"] - 1
+    )
     assert commands == [
         [
             "kubectl",
@@ -8132,6 +8144,83 @@ def test_observability_app_metrics_strict_inventory_boundaries_are_controlled(
     assert message in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda cfg: cfg["serviceMonitor"].update(targetLabels={}), "must be an array"),
+        (
+            lambda cfg: cfg["serviceMonitor"].update(
+                targetLabels=[*cfg["serviceMonitor"]["targetLabels"], cfg["serviceMonitor"]["targetLabels"][0]]
+            ),
+            "nonempty unique",
+        ),
+        (lambda cfg: cfg.update(transferredTargetLabels=[]), "must be an object"),
+        (
+            lambda cfg: cfg.update(transferredTargetLabels={"bad-label": "value"}),
+            "Prometheus label name",
+        ),
+        (
+            lambda cfg: cfg.update(transferredTargetLabels={"valid_label": ""}),
+            "nonempty string",
+        ),
+        (
+            lambda cfg: cfg["transferredTargetLabels"].update(dspace_dev_cluster="wrong"),
+            "contracts must be exact",
+        ),
+        (lambda cfg: cfg.update(metadataOnlyMetricFamilies=[]), "must be an object"),
+        (
+            lambda cfg: cfg.update(metadataOnlyMetricFamilies={"bad-metric": "counter"}),
+            "Prometheus metric name",
+        ),
+        (
+            lambda cfg: cfg.update(metadataOnlyMetricFamilies={"not_required_total": "counter"}),
+            "contract is invalid",
+        ),
+        (
+            lambda cfg: cfg.update(
+                metadataOnlyMetricFamilies={"dspace_dchat_requests_total": "info"}
+            ),
+            "contract is invalid",
+        ),
+    ],
+    ids=[
+        "target-labels-not-array",
+        "target-labels-duplicate",
+        "transferred-not-object",
+        "transferred-malformed-name",
+        "transferred-malformed-value",
+        "transferred-drift",
+        "metadata-not-object",
+        "metadata-malformed-family",
+        "metadata-non-required-family",
+        "metadata-unsupported-type",
+    ],
+)
+def test_dspace_staging_new_inventory_contract_branches(mutation, message):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    mutation(doc["applications"]["dspace"]["environments"]["staging"])
+    with pytest.raises(app_metrics.Error, match=message):
+        app_metrics.validate_inventory(doc)
+
+
+@pytest.mark.parametrize(
+    ("app", "env", "field", "value"),
+    [
+        ("tokenplace", "staging", "transferredTargetLabels", {"label": "value"}),
+        ("tokenplace", "staging", "metadataOnlyMetricFamilies", {"tokenplace_build_info": "gauge"}),
+        ("dspace", "prod", "transferredTargetLabels", {"label": "value"}),
+        ("dspace", "prod", "metadataOnlyMetricFamilies", {"dspace_build_info": "gauge"}),
+    ],
+)
+def test_inventory_rejects_transfer_or_metadata_contract_outside_dspace_staging(
+    app, env, field, value
+):
+    doc = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    doc["applications"][app]["environments"][env][field] = value
+    with pytest.raises(app_metrics.Error, match="contracts"):
+        app_metrics.validate_inventory(doc)
+
+
 def _dspace_staging_chart_like_service_monitor() -> str:
     target_labels = "\n".join(
         f"    - {label}" for label in app_metrics.DSPACE_STAGING_TARGET_LABELS
@@ -8190,6 +8279,90 @@ def test_dspace_transferred_labels_require_all_exact_values_and_reject_unlisted_
         app_metrics.validate_metric_labels(cfg, wrong)
     with pytest.raises(app_metrics.Error, match="unbounded application metric label"):
         app_metrics.validate_metric_labels(cfg, labels | {"dspace_dev_unlisted": "value"})
+    with pytest.raises(app_metrics.Error, match="label enum mismatch"):
+        app_metrics.validate_metric_labels(cfg, labels | {"method": "TRACE"})
+    forbidden_cfg = json.loads(json.dumps(cfg))
+    forbidden_cfg["allowedApplicationLabels"]["authorization"] = ["redacted"]
+    with pytest.raises(app_metrics.Error, match="forbidden application metric label"):
+        app_metrics.validate_metric_labels(
+            forbidden_cfg, labels | {"authorization": "redacted"}
+        )
+
+
+@pytest.mark.parametrize(
+    "metric",
+    ["dspace_dchat_requests_total", "dspace_dependency_requests_total"],
+)
+def test_dspace_zero_series_capable_families_prefer_samples(monkeypatch, metric):
+    cfg = app_metrics.appcfg("dspace", "staging")
+    labels = {"__name__": metric, **cfg["transferredTargetLabels"]}
+    paths = []
+
+    def fake_prom(path):
+        paths.append(path)
+        queried = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
+            "{", 1
+        )[0]
+        result = [{"metric": labels}] if queried == metric else []
+        return {"resultType": "vector", "result": result}
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert metric in app_metrics.query_required_families(cfg, {})
+    assert not any("metadata" in path for path in paths)
+
+    for changed in (next(iter(cfg["transferredTargetLabels"])), "dspace_dev_cluster"):
+        invalid = dict(labels)
+        if changed == "dspace_dev_cluster":
+            invalid[changed] = "wrong"
+        else:
+            del invalid[changed]
+        monkeypatch.setattr(
+            app_metrics,
+            "prom",
+            lambda path, invalid=invalid: {
+                "resultType": "vector",
+                "result": [{"metric": invalid}],
+            },
+        )
+        with pytest.raises(app_metrics.Error, match="transferred target metric label mismatch"):
+            app_metrics.query_required_families(cfg, {})
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda labels: [labels[1], labels[0], *labels[2:]],
+        lambda labels: labels[:-1],
+        lambda labels: [*labels, labels[-1]],
+        lambda labels: [*labels, "example.dev/unexpected"],
+    ],
+    ids=["reordered", "missing", "duplicate", "extra"],
+)
+def test_dspace_live_verifier_rejects_inexact_target_labels_before_queries(
+    monkeypatch, mutation
+):
+    cfg = app_metrics.appcfg("dspace", "staging")
+    spec = {
+        "selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]},
+        "targetLabels": mutation(cfg["serviceMonitor"]["targetLabels"]),
+        "endpoints": [{
+            "path": cfg["serviceMonitor"]["path"],
+            "interval": cfg["serviceMonitor"]["interval"],
+            "scrapeTimeout": cfg["serviceMonitor"]["scrapeTimeout"],
+            "bearerTokenSecret": cfg["secret"],
+            "relabelings": cfg["serviceMonitor"]["relabelings"],
+        }],
+    }
+    monkeypatch.setattr(app_metrics, "appcfg", lambda app, env: cfg)
+    monkeypatch.setattr(app_metrics, "assert_context", lambda: None)
+    monkeypatch.setattr(app_metrics, "check_secret", lambda cfg: None)
+    monkeypatch.setattr(app_metrics, "derive_build_labels_live", lambda cfg: {})
+    monkeypatch.setattr(app_metrics, "kjson", lambda args: {"spec": spec})
+    monkeypatch.setattr(
+        app_metrics, "prom", lambda path: pytest.fail(f"unexpected metric query: {path}")
+    )
+    with pytest.raises(app_metrics.Error, match="ServiceMonitor targetLabels mismatch"):
+        app_metrics.verify("dspace", "staging")
 
 
 @pytest.mark.parametrize(
@@ -8253,13 +8426,23 @@ def test_metadata_only_family_uses_verified_target_scoped_metadata(monkeypatch):
 
 def test_non_opted_in_missing_family_remains_missing(monkeypatch):
     cfg = app_metrics.appcfg("tokenplace", "staging")
+    cfg = json.loads(json.dumps(cfg))
+    cfg["retries"] = {"attempts": 1, "delaySeconds": 1}
     metadata_queries = []
 
     def fake_prom(path):
-        if path.startswith("/api/v1/metadata"):
+        if path == "/api/v1/targets":
+            return {"activeTargets": [{
+                "health": "up",
+                "scrapePool": "serviceMonitor/tokenplace/tokenplace/0",
+                "labels": cfg["targetLabels"],
+                "discoveredLabels": {},
+            }]}
+        if "metadata" in path:
             metadata_queries.append(path)
         return {"resultType": "vector", "result": []}
 
-    monkeypatch.setattr(app_metrics, "prom", fake_prom)
-    assert app_metrics.query_required_families(cfg, {}) == set()
+    _verify_base(monkeypatch, cfg, fake_prom)
+    with pytest.raises(app_metrics.Error, match="required metric family missing"):
+        app_metrics.verify("tokenplace", "staging")
     assert metadata_queries == []

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6427,8 +6427,8 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
             metric = app_metrics.urllib.parse.parse_qs(path.split("?", 1)[1])["metric"][0]
             query_events.append(("metadata", metric))
             return [
-                {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
-                {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
+                {"target": dict(cfg["targetLabels"]), "type": "counter"},
+                {"target": dict(cfg["targetLabels"]), "type": "counter"},
             ]
         metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
             "{", 1
@@ -8373,6 +8373,8 @@ def test_dspace_live_verifier_rejects_inexact_target_labels_before_queries(
         ("wrong-family", "exact metric family"),
         ("wrong-type", "metric type mismatch"),
         ("malformed-label", "exact scrape targets"),
+        ("non-dict-entry", "structurally invalid"),
+        ("wrong-target-set", "exact scrape targets"),
         ("conflicting-types", "metric type mismatch"),
     ],
 )
@@ -8385,8 +8387,7 @@ def test_metadata_only_family_validation_fails_closed(monkeypatch, entries, mess
     targets = [{"labels": labels} for labels in target_labels]
     response = [
         {
-            "target": labels,
-            "metric": "dspace_dchat_requests_total",
+            "target": dict(labels),
             "type": "counter",
         }
         for labels in target_labels
@@ -8399,6 +8400,10 @@ def test_metadata_only_family_validation_fails_closed(monkeypatch, entries, mess
             entry["type"] = "gauge"
     elif entries == "malformed-label":
         response[0]["target"]["instance"] = ["unhashable"]
+    elif entries == "non-dict-entry":
+        response[0] = "malformed"
+    elif entries == "wrong-target-set":
+        response[1]["target"] = dict(response[0]["target"])
     elif entries == "conflicting-types":
         response[1]["type"] = "gauge"
     else:
@@ -8424,8 +8429,7 @@ def test_metadata_only_family_uses_verified_target_scoped_metadata(monkeypatch):
         assert expected_data_type is list
         return [
             {
-                "target": labels,
-                "metric": "dspace_dchat_requests_total",
+                "target": dict(labels),
                 "type": "counter",
             }
             for labels in target_labels
@@ -8451,8 +8455,7 @@ def test_metadata_only_family_accepts_list_at_real_prom_boundary(monkeypatch):
     ]
     entries = [
         {
-            "target": labels,
-            "metric": "dspace_dchat_requests_total",
+            "target": dict(labels),
             "type": "counter",
         }
         for labels in target_labels

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -420,6 +420,14 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: dspace
       app.kubernetes.io/name: dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   endpoints:
     - port: http
       path: /metrics
@@ -6386,6 +6394,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
     service_monitor = {
         "spec": {
             "selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]},
+            "targetLabels": cfg["serviceMonitor"]["targetLabels"],
             "endpoints": [
                 {
                     "path": "/metrics",
@@ -6413,13 +6422,19 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
                 "discoveredLabels": {},
             }
             return {"activeTargets": [target, dict(target)]}
+        if path.startswith("/api/v1/metadata?"):
+            metric = app_metrics.urllib.parse.parse_qs(path.split("?", 1)[1])["metric"][0]
+            queried_families.add(metric)
+            return {metric: [{"type": "counter"}]}
         metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
             "{", 1
         )[0]
         if metric not in cfg["requiredMetricFamilies"]:
             return {"resultType": "vector", "result": []}
+        if metric in cfg["metadataOnlyMetricFamilies"]:
+            return {"resultType": "vector", "result": []}
         queried_families.add(metric)
-        labels = {"__name__": metric}
+        labels = {"__name__": metric, **cfg["transferredTargetLabels"]}
         if metric == "dspace_build_info":
             labels.update(
                 version="3.1.1",
@@ -7041,6 +7056,7 @@ def test_observability_app_metrics_dspace_build_info_labels_are_bounded(env):
             "__name__": "dspace_build_info",
             "version": "3.1.1",
             "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+            **cfg["transferredTargetLabels"],
         },
     )
 
@@ -8111,3 +8127,97 @@ def test_observability_app_metrics_strict_inventory_boundaries_are_controlled(
     with pytest.raises(app_metrics.Error) as excinfo:
         app_metrics.validate_inventory(doc)
     assert message in str(excinfo.value)
+
+
+def _dspace_staging_chart_like_service_monitor() -> str:
+    target_labels = "\n".join(
+        f"    - {label}" for label in app_metrics.DSPACE_STAGING_TARGET_LABELS
+    )
+    return (
+        _dspace_303_chart_like_service_monitor()
+        .replace("  endpoints:\n", f"  targetLabels:\n{target_labels}\n  endpoints:\n")
+        .replace("dspace-prod-metrics-token", "dspace-staging-metrics-token")
+        .replace("replacement: prod", "replacement: staging")
+        .replace("replacement: sugarkube-prod", "replacement: sugarkube-int")
+    )
+
+
+def test_dspace_staging_render_accepts_exact_ordered_transferred_target_labels(tmp_path: Path):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_staging_chart_like_service_monitor(), encoding="utf-8")
+    app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda labels: [labels[1], labels[0], *labels[2:]],
+        lambda labels: labels[:-1],
+        lambda labels: [*labels, labels[-1]],
+        lambda labels: [*labels, "example.dev/unexpected"],
+    ],
+    ids=["reordered", "missing", "duplicate", "extra"],
+)
+def test_dspace_staging_render_rejects_inexact_target_labels(tmp_path: Path, mutation):
+    rendered = tmp_path / "rendered.yaml"
+    manifest = _dspace_staging_chart_like_service_monitor()
+    original = "\n".join(
+        f"    - {label}" for label in app_metrics.DSPACE_STAGING_TARGET_LABELS
+    )
+    replacement = "\n".join(
+        f"    - {label}" for label in mutation(app_metrics.DSPACE_STAGING_TARGET_LABELS)
+    )
+    rendered.write_text(manifest.replace(original, replacement), encoding="utf-8")
+    with pytest.raises(app_metrics.Error, match="targetLabels mismatch"):
+        app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
+
+
+def test_dspace_transferred_labels_require_all_exact_values_and_reject_unlisted_labels():
+    cfg = app_metrics.appcfg("dspace", "staging")
+    labels = {"__name__": "dspace_instrumentation_up", **cfg["transferredTargetLabels"]}
+    app_metrics.validate_metric_labels(cfg, labels)
+    for label in cfg["transferredTargetLabels"]:
+        missing = dict(labels)
+        del missing[label]
+        with pytest.raises(app_metrics.Error, match="transferred target metric label mismatch"):
+            app_metrics.validate_metric_labels(cfg, missing)
+    wrong = dict(labels)
+    wrong["dspace_dev_cluster"] = "wrong"
+    with pytest.raises(app_metrics.Error, match="transferred target metric label mismatch"):
+        app_metrics.validate_metric_labels(cfg, wrong)
+    with pytest.raises(app_metrics.Error, match="unbounded application metric label"):
+        app_metrics.validate_metric_labels(cfg, labels | {"dspace_dev_unlisted": "value"})
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        ({}, "exact metric family"),
+        ({"other_total": [{"type": "counter"}]}, "exact metric family"),
+        ({"dspace_dchat_requests_total": {}}, "structurally invalid"),
+        ({"dspace_dchat_requests_total": [{"type": "gauge"}]}, "type mismatch"),
+        (
+            {"dspace_dchat_requests_total": [{"type": "counter"}, {"type": "counter"}]},
+            "structurally invalid",
+        ),
+    ],
+    ids=["absent", "wrong-family", "malformed", "wrong-type", "conflicting"],
+)
+def test_metadata_only_family_validation_fails_closed(monkeypatch, response, message):
+    monkeypatch.setattr(app_metrics, "prom", lambda path: response)
+    with pytest.raises(app_metrics.Error, match=message):
+        app_metrics.metadata_declares_family("dspace_dchat_requests_total", "counter")
+
+
+def test_non_opted_in_missing_family_remains_missing(monkeypatch):
+    cfg = app_metrics.appcfg("tokenplace", "staging")
+    metadata_queries = []
+
+    def fake_prom(path):
+        if path.startswith("/api/v1/metadata"):
+            metadata_queries.append(path)
+        return {"resultType": "vector", "result": []}
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.query_required_families(cfg, {}) == set()
+    assert metadata_queries == []

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6422,10 +6422,13 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
                 "discoveredLabels": {},
             }
             return {"activeTargets": [target, dict(target)]}
-        if path.startswith("/api/v1/metadata?"):
+        if path.startswith("/api/v1/targets/metadata?"):
             metric = app_metrics.urllib.parse.parse_qs(path.split("?", 1)[1])["metric"][0]
             queried_families.add(metric)
-            return {metric: [{"type": "counter"}]}
+            return [
+                {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
+                {"target": cfg["targetLabels"], "metric": metric, "type": "counter"},
+            ]
         metric = app_metrics.urllib.parse.unquote(path.rsplit("query=", 1)[-1]).split(
             "{", 1
         )[0]
@@ -8192,21 +8195,60 @@ def test_dspace_transferred_labels_require_all_exact_values_and_reject_unlisted_
 @pytest.mark.parametrize(
     ("response", "message"),
     [
-        ({}, "exact metric family"),
-        ({"other_total": [{"type": "counter"}]}, "exact metric family"),
-        ({"dspace_dchat_requests_total": {}}, "structurally invalid"),
-        ({"dspace_dchat_requests_total": [{"type": "gauge"}]}, "type mismatch"),
+        ({}, "structurally invalid"),
+        ([], "exact scrape targets"),
+        ([{"target": {}, "metric": "other_total", "type": "counter"}], "exact scrape targets"),
         (
-            {"dspace_dchat_requests_total": [{"type": "counter"}, {"type": "counter"}]},
-            "structurally invalid",
+            [{"target": {}, "metric": "dspace_dchat_requests_total", "type": "gauge"}],
+            "exact scrape targets",
+        ),
+        (
+            [{"target": {}, "metric": "dspace_dchat_requests_total", "type": "counter"}],
+            "exact scrape targets",
         ),
     ],
     ids=["absent", "wrong-family", "malformed", "wrong-type", "conflicting"],
 )
 def test_metadata_only_family_validation_fails_closed(monkeypatch, response, message):
+    cfg = app_metrics.appcfg("dspace", "staging")
+    targets = [{"labels": cfg["targetLabels"]}, {"labels": cfg["targetLabels"]}]
     monkeypatch.setattr(app_metrics, "prom", lambda path: response)
     with pytest.raises(app_metrics.Error, match=message):
-        app_metrics.metadata_declares_family("dspace_dchat_requests_total", "counter")
+        app_metrics.metadata_declares_family(
+            cfg, targets, "dspace_dchat_requests_total", "counter"
+        )
+
+
+def test_metadata_only_family_uses_verified_target_scoped_metadata(monkeypatch):
+    cfg = app_metrics.appcfg("dspace", "staging")
+    target_labels = [
+        cfg["targetLabels"] | {"instance": "10.0.0.1:8080"},
+        cfg["targetLabels"] | {"instance": "10.0.0.2:8080"},
+    ]
+    targets = [{"labels": labels} for labels in target_labels]
+    paths = []
+
+    def fake_prom(path):
+        paths.append(path)
+        return [
+            {
+                "target": labels,
+                "metric": "dspace_dchat_requests_total",
+                "type": "counter",
+            }
+            for labels in target_labels
+        ]
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.metadata_declares_family(
+        cfg, targets, "dspace_dchat_requests_total", "counter"
+    )
+    assert paths[0].startswith("/api/v1/targets/metadata?")
+    query = app_metrics.urllib.parse.parse_qs(paths[0].split("?", 1)[1])
+    assert query == {
+        "match_target": [app_metrics.promql_selector(cfg["targetLabels"])],
+        "metric": ["dspace_dchat_requests_total"],
+    }
 
 
 def test_non_opted_in_missing_family_remains_missing(monkeypatch):

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -6413,7 +6413,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
         commands.append(args)
         return service_monitor
 
-    def fake_prom(path):
+    def fake_prom(path, expected_data_type=dict):
         if path == "/api/v1/targets":
             target = {
                 "health": "up",
@@ -6423,6 +6423,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
             }
             return {"activeTargets": [target, dict(target)]}
         if path.startswith("/api/v1/targets/metadata?"):
+            assert expected_data_type is list
             metric = app_metrics.urllib.parse.parse_qs(path.split("?", 1)[1])["metric"][0]
             query_events.append(("metadata", metric))
             return [
@@ -8366,26 +8367,43 @@ def test_dspace_live_verifier_rejects_inexact_target_labels_before_queries(
 
 
 @pytest.mark.parametrize(
-    ("response", "message"),
+    ("entries", "message"),
     [
-        ({}, "structurally invalid"),
         ([], "exact scrape targets"),
-        ([{"target": {}, "metric": "other_total", "type": "counter"}], "exact scrape targets"),
-        (
-            [{"target": {}, "metric": "dspace_dchat_requests_total", "type": "gauge"}],
-            "exact scrape targets",
-        ),
-        (
-            [{"target": {}, "metric": "dspace_dchat_requests_total", "type": "counter"}],
-            "exact scrape targets",
-        ),
+        ("wrong-family", "exact metric family"),
+        ("wrong-type", "metric type mismatch"),
+        ("malformed-label", "exact scrape targets"),
+        ("conflicting-types", "metric type mismatch"),
     ],
-    ids=["absent", "wrong-family", "malformed", "wrong-type", "conflicting"],
 )
-def test_metadata_only_family_validation_fails_closed(monkeypatch, response, message):
+def test_metadata_only_family_validation_fails_closed(monkeypatch, entries, message):
     cfg = app_metrics.appcfg("dspace", "staging")
-    targets = [{"labels": cfg["targetLabels"]}, {"labels": cfg["targetLabels"]}]
-    monkeypatch.setattr(app_metrics, "prom", lambda path: response)
+    target_labels = [
+        cfg["targetLabels"] | {"instance": "10.0.0.1:8080"},
+        cfg["targetLabels"] | {"instance": "10.0.0.2:8080"},
+    ]
+    targets = [{"labels": labels} for labels in target_labels]
+    response = [
+        {
+            "target": labels,
+            "metric": "dspace_dchat_requests_total",
+            "type": "counter",
+        }
+        for labels in target_labels
+    ]
+    if entries == "wrong-family":
+        for entry in response:
+            entry["metric"] = "other_total"
+    elif entries == "wrong-type":
+        for entry in response:
+            entry["type"] = "gauge"
+    elif entries == "malformed-label":
+        response[0]["target"]["instance"] = ["unhashable"]
+    elif entries == "conflicting-types":
+        response[1]["type"] = "gauge"
+    else:
+        response = entries
+    monkeypatch.setattr(app_metrics, "prom", lambda path, expected_data_type=dict: response)
     with pytest.raises(app_metrics.Error, match=message):
         app_metrics.metadata_declares_family(
             cfg, targets, "dspace_dchat_requests_total", "counter"
@@ -8401,8 +8419,9 @@ def test_metadata_only_family_uses_verified_target_scoped_metadata(monkeypatch):
     targets = [{"labels": labels} for labels in target_labels]
     paths = []
 
-    def fake_prom(path):
+    def fake_prom(path, expected_data_type=dict):
         paths.append(path)
+        assert expected_data_type is list
         return [
             {
                 "target": labels,
@@ -8422,6 +8441,44 @@ def test_metadata_only_family_uses_verified_target_scoped_metadata(monkeypatch):
         "match_target": [app_metrics.promql_selector(cfg["targetLabels"])],
         "metric": ["dspace_dchat_requests_total"],
     }
+
+
+def test_metadata_only_family_accepts_list_at_real_prom_boundary(monkeypatch):
+    cfg = app_metrics.appcfg("dspace", "staging")
+    target_labels = [
+        cfg["targetLabels"] | {"instance": "10.0.0.1:8080"},
+        cfg["targetLabels"] | {"instance": "10.0.0.2:8080"},
+    ]
+    entries = [
+        {
+            "target": labels,
+            "metric": "dspace_dchat_requests_total",
+            "type": "counter",
+        }
+        for labels in target_labels
+    ]
+    monkeypatch.setattr(
+        app_metrics,
+        "kjson",
+        lambda args: {"status": "success", "data": entries},
+    )
+
+    assert app_metrics.metadata_declares_family(
+        cfg,
+        [{"labels": labels} for labels in target_labels],
+        "dspace_dchat_requests_total",
+        "counter",
+    )
+
+
+@pytest.mark.parametrize("path", ["/api/v1/query?query=up", "/api/v1/targets"])
+def test_prom_dict_endpoints_reject_list_data(monkeypatch, path):
+    monkeypatch.setattr(
+        app_metrics, "kjson", lambda args: {"status": "success", "data": []}
+    )
+
+    with pytest.raises(app_metrics.Error, match="structurally invalid"):
+        app_metrics.prom(path)
 
 
 def test_non_opted_in_missing_family_remains_missing(monkeypatch):


### PR DESCRIPTION
### Motivation

The immutable DSPACE 3.1.1 staging ServiceMonitor transfers seven ordered Kubernetes target labels. Two required counters may legitimately have no current series until their first qualifying event. The generic verifier must recognize that narrow case without weakening missing-signal or label validation.

### What changed

- Encoded the exact ordered DSPACE staging `ServiceMonitor.spec.targetLabels` contract and all seven projected Prometheus label/value pairs.
- Enforced exact target-label ordering during inventory, rendered-manifest, and live validation.
- Added an inventory-controlled metadata-only fallback exclusively for:
  - `dspace_dchat_requests_total`
  - `dspace_dependency_requests_total`
- Kept normal full label validation whenever either family has samples.
- Scoped metadata lookup to `/api/v1/targets/metadata` using the exact metric and target selector, then required metadata for the exact verified scrape-target set and expected `counter` type.
- Accepted Prometheus’s canonical filtered response, where `metric` is omitted, while rejecting any present incorrect family name.
- Preserved fail-closed rejection of absent or malformed metadata, wrong or conflicting types, wrong targets or families, unlisted projected labels, malformed labels, forbidden labels, and non-opted-in missing families.
- Updated the hermetic Helm fixture and focused regression tests.

### Compatibility and scope

- Changed only:
  - `platform/observability/app-metrics.json`
  - `scripts/observability_app_metrics.py`
  - `scripts/test-helm-oci-install.sh`
  - `tests/test_generic_app_just_recipes.py`
- Preserved token.place’s four-relabeling and missing-series contracts.
- Preserved DSPACE production and promotion coordinates.
- Did not modify `scripts/dspace_runtime_verifier.py` or its tests, including the work merged in #2646.
- Performed no deployment, reconciliation, secret access, or production/staging mutation.

### Verification

- `python3 -m compileall scripts/observability_app_metrics.py`
- `python3 scripts/observability_app_metrics.py validate`
- Focused metadata and verifier regression selection: 12 passed, 510 deselected.
- Full `tests/test_generic_app_just_recipes.py`: 522 passed.
- Focused DSPACE observability/runtime/promotion suites: 406 passed.
- `./scripts/test-helm-oci-install.sh`
- `git diff --check`
- `git diff | ./scripts/scan-secrets.py`
- Latest-head Test Suite, `ci`, unit, OCI parity smoke, and Codecov patch checks completed successfully; Codecov reports all modified coverable lines covered.
- `pre-commit run --all-files` was unavailable in the Codex environment because the executable was not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8257ce33bc832f9b5fca9a6fc8d383)