### PR TITLE
Fix DSPACE staging metrics contract verification

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -47,7 +47,8 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-int"
               }
-            ]
+            ],
+            "targetLabels": []
           },
           "targetLabels": {
             "app": "tokenplace",
@@ -185,7 +186,8 @@
               "env": "TOKENPLACE_IMAGE_TAG",
               "normalizer": "identity"
             }
-          }
+          },
+          "metadataOnlyMetricFamilies": {}
         }
       }
     },
@@ -240,6 +242,15 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-int"
               }
+            ],
+            "targetLabels": [
+              "app.kubernetes.io/name",
+              "app.kubernetes.io/instance",
+              "app.kubernetes.io/managed-by",
+              "dspace.dev/app",
+              "dspace.dev/environment",
+              "dspace.dev/release",
+              "dspace.dev/cluster"
             ]
           },
           "targetLabels": {
@@ -342,6 +353,27 @@
               "fallback_used",
               "fallback_unavailable",
               "unknown_error"
+            ],
+            "app_kubernetes_io_name": [
+              "dspace"
+            ],
+            "app_kubernetes_io_instance": [
+              "dspace"
+            ],
+            "app_kubernetes_io_managed_by": [
+              "Helm"
+            ],
+            "dspace_dev_app": [
+              "dspace"
+            ],
+            "dspace_dev_environment": [
+              "staging"
+            ],
+            "dspace_dev_release": [
+              "dspace"
+            ],
+            "dspace_dev_cluster": [
+              "sugarkube-int"
             ]
           },
           "derivedApplicationLabels": {},
@@ -361,7 +393,11 @@
             "token",
             "url",
             "user"
-          ]
+          ],
+          "metadataOnlyMetricFamilies": {
+            "dspace_dchat_requests_total": "counter",
+            "dspace_dependency_requests_total": "counter"
+          }
         },
         "prod": {
           "namespace": "dspace",
@@ -412,7 +448,8 @@
                 "targetLabel": "cluster",
                 "replacement": "sugarkube-prod"
               }
-            ]
+            ],
+            "targetLabels": []
           },
           "targetLabels": {
             "app": "dspace",
@@ -533,7 +570,8 @@
             "token",
             "url",
             "user"
-          ]
+          ],
+          "metadataOnlyMetricFamilies": {}
         }
       }
     }

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -123,6 +123,19 @@ DSPACE_ENVIRONMENT_COORDINATES = {
         "url": "https://democratized.space/metrics",
     },
 }
+DSPACE_STAGING_TRANSFERRED_LABELS = {
+    "app.kubernetes.io/name": ("app_kubernetes_io_name", "dspace"),
+    "app.kubernetes.io/instance": ("app_kubernetes_io_instance", "dspace"),
+    "app.kubernetes.io/managed-by": ("app_kubernetes_io_managed_by", "Helm"),
+    "dspace.dev/app": ("dspace_dev_app", "dspace"),
+    "dspace.dev/environment": ("dspace_dev_environment", "staging"),
+    "dspace.dev/release": ("dspace_dev_release", "dspace"),
+    "dspace.dev/cluster": ("dspace_dev_cluster", "sugarkube-int"),
+}
+DSPACE_STAGING_METADATA_ONLY_FAMILIES = {
+    "dspace_dchat_requests_total": "counter",
+    "dspace_dependency_requests_total": "counter",
+}
 
 
 class Error(SystemExit):
@@ -290,6 +303,7 @@ def validate_inventory(doc):
                     "publicMetrics",
                     "retries",
                     "requiredMetricFamilies",
+                    "metadataOnlyMetricFamilies",
                     "allowedApplicationLabels",
                     "derivedApplicationLabels",
                     "forbiddenApplicationLabels",
@@ -317,6 +331,7 @@ def validate_inventory(doc):
                     "scrapeTimeout",
                     "authorization",
                     "relabelings",
+                    "targetLabels",
                 },
                 "serviceMonitor",
             )
@@ -342,6 +357,15 @@ def validate_inventory(doc):
                 k8s_label_key(k, "selector label name")
                 k8s_label_value(v, "selector label value")
             relabelings = sm["relabelings"]
+            transferred_labels = sm["targetLabels"]
+            if not isinstance(transferred_labels, list):
+                fail("serviceMonitor.targetLabels must be an array")
+            seen_transferred = set()
+            for transferred_label in transferred_labels:
+                k8s_label_key(transferred_label, "serviceMonitor target label")
+                if transferred_label in seen_transferred:
+                    fail("serviceMonitor.targetLabels must be unique")
+                seen_transferred.add(transferred_label)
             labels = cfg["targetLabels"]
             if not isinstance(labels, dict):
                 fail("targetLabels must be an object")
@@ -398,6 +422,15 @@ def validate_inventory(doc):
                     fail("retry settings must be bounded integers")
             metrics = cfg["requiredMetricFamilies"]
             unique_string_list(metrics, "requiredMetricFamilies", prometheus_metric)
+            metadata_only = cfg["metadataOnlyMetricFamilies"]
+            if not isinstance(metadata_only, dict):
+                fail("metadataOnlyMetricFamilies must be an object")
+            for metric, metric_type in metadata_only.items():
+                prometheus_metric(metric, "metadata-only metric family")
+                if metric not in metrics:
+                    fail("metadata-only metric family must also be required")
+                if metric_type not in {"counter", "gauge", "histogram", "summary"}:
+                    fail("metadata-only metric family type is unsupported")
             allowed = cfg["allowedApplicationLabels"]
             if not isinstance(allowed, dict):
                 fail("allowedApplicationLabels must be an object")
@@ -428,10 +461,22 @@ def validate_inventory(doc):
                     "cluster": [labels["cluster"]],
                     **DSPACE_SOURCE_LABELS,
                 }
+                expected_transferred = {}
+                if env == "staging":
+                    expected_transferred = DSPACE_STAGING_TRANSFERRED_LABELS
+                    expected_allowed.update(
+                        {prom_label: [value] for prom_label, value in expected_transferred.values()}
+                    )
                 if metrics != DSPACE_REQUIRED_METRIC_FAMILIES:
                     fail("DSPACE required metric families must match the immutable source contract")
                 if allowed != expected_allowed:
                     fail("DSPACE application labels must match the immutable source contract")
+                if transferred_labels != list(expected_transferred):
+                    fail("DSPACE ServiceMonitor targetLabels must match the ordered contract")
+                if metadata_only != (
+                    DSPACE_STAGING_METADATA_ONLY_FAMILIES if env == "staging" else {}
+                ):
+                    fail("DSPACE metadata-only metric families must match the environment contract")
                 if (
                     cfg["namespace"] != "dspace"
                     or cfg["serviceMonitorName"] != "dspace"
@@ -776,6 +821,11 @@ def validate_metric_labels(cfg, labels, derived_values=None):
         )
     ):
         fail("DSPACE build identity label mismatch (details redacted)", 1)
+    for kubernetes_label in cfg["serviceMonitor"]["targetLabels"]:
+        prometheus_label_name = re.sub(r"[^a-zA-Z0-9_]", "_", kubernetes_label)
+        expected_values = cfg["allowedApplicationLabels"].get(prometheus_label_name)
+        if expected_values is None or labels.get(prometheus_label_name) not in expected_values:
+            fail("transferred metric label missing or mismatched (details redacted)", 1)
     for label, value in labels.items():
         if (
             not isinstance(label, str)
@@ -896,6 +946,27 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                 # Prefer exact identity before normalizing conventional suffixes.
                 if series_name == metric or metric_family_from_series(series_name) == metric:
                     found.add(metric)
+        if metric not in found and metric in cfg["metadataOnlyMetricFamilies"]:
+            data = prom(
+                "/api/v1/metadata?metric=" + urllib.parse.quote(metric, safe="")
+            )
+            if not isinstance(data, dict) or set(data) != {metric}:
+                fail("Prometheus metric metadata family mismatch (details redacted)", 1)
+            entries = data[metric]
+            if (
+                not isinstance(entries, list)
+                or len(entries) != 1
+                or not isinstance(entries[0], dict)
+                or set(entries[0]) != {"type", "help", "unit"}
+                or not all(isinstance(value, str) for value in entries[0].values())
+                or entries[0].get("type") != cfg["metadataOnlyMetricFamilies"][metric]
+            ):
+                fail(
+                    "Prometheus metric metadata is absent, conflicting, or malformed "
+                    "(details redacted)",
+                    1,
+                )
+            found.add(metric)
     return found
 
 
@@ -962,6 +1033,8 @@ def verify(app, env):
         fail("ServiceMonitor endpoint/auth contract mismatch", 1)
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("ServiceMonitor selector mismatch", 1)
+    if spec.get("targetLabels", []) != cfg["serviceMonitor"]["targetLabels"]:
+        fail("ServiceMonitor targetLabels mismatch", 1)
     targets = []
     attempts = cfg["retries"]["attempts"]
     for i in range(attempts):
@@ -1125,6 +1198,8 @@ def validate_render(
         fail("rendered ServiceMonitor namespace selector mismatch")
     if selector.get("matchLabels") != cfg["serviceMonitor"]["selectorMatchLabels"]:
         fail("rendered ServiceMonitor selector mismatch")
+    if spec.get("targetLabels", []) != cfg["serviceMonitor"]["targetLabels"]:
+        fail("rendered ServiceMonitor targetLabels mismatch")
     endpoints = spec.get("endpoints")
     if not isinstance(endpoints, list) or len(endpoints) != 1:
         fail("rendered ServiceMonitor must have exactly one endpoint")

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -151,6 +151,14 @@ spec:
   namespaceSelector:
     matchNames:
       - dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -416,6 +416,14 @@ spec:
   namespaceSelector:
     matchNames:
       - dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   selector:
     matchLabels:
       app.kubernetes.io/instance: dspace
@@ -5867,6 +5875,14 @@ def test_observability_app_metrics_inventory_dspace_staging_and_prod_are_canonic
     }
     assert staging["requiredMetricFamilies"] == app_metrics.DSPACE_REQUIRED_METRIC_FAMILIES
     assert prod["requiredMetricFamilies"] == app_metrics.DSPACE_REQUIRED_METRIC_FAMILIES
+    assert staging["serviceMonitor"]["targetLabels"] == list(
+        app_metrics.DSPACE_STAGING_TRANSFERRED_LABELS
+    )
+    assert staging["metadataOnlyMetricFamilies"] == (
+        app_metrics.DSPACE_STAGING_METADATA_ONLY_FAMILIES
+    )
+    assert prod["serviceMonitor"]["targetLabels"] == []
+    assert prod["metadataOnlyMetricFamilies"] == {}
     for env, cluster in (("staging", "sugarkube-int"), ("prod", "sugarkube-prod")):
         cfg = environments[env]
         assert cfg["targetLabels"] == {
@@ -5885,6 +5901,16 @@ def test_observability_app_metrics_inventory_dspace_staging_and_prod_are_canonic
             "release": ["dspace"],
             "cluster": [cluster],
             **app_metrics.DSPACE_SOURCE_LABELS,
+            **(
+                {
+                    prometheus_label: [value]
+                    for prometheus_label, value in (
+                        app_metrics.DSPACE_STAGING_TRANSFERRED_LABELS.values()
+                    )
+                }
+                if env == "staging"
+                else {}
+            ),
         }
 
 
@@ -6116,6 +6142,52 @@ spec:
           targetLabel: cluster
           replacement: sugarkube-prod
 """
+
+
+def _dspace_311_staging_chart_like_service_monitor() -> str:
+    rendered = _dspace_303_chart_like_service_monitor("  namespace: dspace\n")
+    rendered = rendered.replace("dspace-prod-metrics-token", "dspace-staging-metrics-token")
+    rendered = rendered.replace("replacement: prod", "replacement: staging")
+    rendered = rendered.replace("replacement: sugarkube-prod", "replacement: sugarkube-int")
+    target_labels = """  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
+"""
+    return rendered.replace("  selector:\n", target_labels + "  selector:\n")
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda labels: labels,
+        lambda labels: [labels[1], labels[0], *labels[2:]],
+        lambda labels: labels[:-1],
+        lambda labels: [*labels, labels[-1]],
+        lambda labels: [*labels, "example.com/unexpected"],
+    ],
+    ids=["exact", "reordered", "missing", "duplicate", "extra"],
+)
+def test_observability_app_metrics_render_enforces_ordered_dspace_target_labels(
+    tmp_path: Path, mutator
+):
+    expected = list(app_metrics.DSPACE_STAGING_TRANSFERRED_LABELS)
+    actual = mutator(expected)
+    rendered_text = _dspace_311_staging_chart_like_service_monitor()
+    original = "".join(f"    - {label}\n" for label in expected)
+    replacement = "".join(f"    - {label}\n" for label in actual)
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(rendered_text.replace(original, replacement), encoding="utf-8")
+
+    if actual == expected:
+        app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
+    else:
+        with pytest.raises(app_metrics.Error, match="targetLabels mismatch"):
+            app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
 
 
 def test_observability_app_metrics_validate_render_accepts_dspace_303_omitted_namespace(
@@ -6385,6 +6457,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
     ]["environments"]["staging"]
     service_monitor = {
         "spec": {
+            "targetLabels": cfg["serviceMonitor"]["targetLabels"],
             "selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]},
             "endpoints": [
                 {
@@ -6419,7 +6492,15 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
         if metric not in cfg["requiredMetricFamilies"]:
             return {"resultType": "vector", "result": []}
         queried_families.add(metric)
-        labels = {"__name__": metric}
+        labels = {
+            "__name__": metric,
+            **{
+                prometheus_label: value
+                for prometheus_label, value in (
+                    app_metrics.DSPACE_STAGING_TRANSFERRED_LABELS.values()
+                )
+            },
+        }
         if metric == "dspace_build_info":
             labels.update(
                 version="3.1.1",
@@ -6778,6 +6859,137 @@ def test_observability_app_metrics_accepts_exact_bucket_family(monkeypatch):
     }
 
 
+def _dspace_transferred_prometheus_labels() -> dict[str, str]:
+    return {
+        prometheus_label: value
+        for prometheus_label, value in app_metrics.DSPACE_STAGING_TRANSFERRED_LABELS.values()
+    }
+
+
+@pytest.mark.parametrize("metric", list(app_metrics.DSPACE_STAGING_METADATA_ONLY_FAMILIES))
+def test_observability_app_metrics_accepts_opted_in_zero_series_metadata_counter(
+    monkeypatch, metric
+):
+    inventory = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))
+    app_metrics.validate_inventory(inventory)
+    cfg = inventory["applications"]["dspace"]["environments"]["staging"]
+    cfg = {
+        **cfg,
+        "requiredMetricFamilies": [metric],
+        "metadataOnlyMetricFamilies": {metric: "counter"},
+    }
+
+    def fake_prom(path):
+        if path.startswith("/api/v1/metadata?"):
+            return {metric: [{"type": "counter", "help": "bounded fixture", "unit": ""}]}
+        return {"resultType": "vector", "result": []}
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.query_required_families(cfg, {}) == {metric}
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        [],
+        {"dspace_dchat_requests_total": []},
+        {"dspace_dchat_requests_total": [{"type": "gauge"}]},
+        {"dspace_dchat_requests_total": [{"type": "counter"}, {"type": "counter"}]},
+        {"dspace_dependency_requests_total": [{"type": "counter"}]},
+        {"dspace_dchat_requests_total": ["counter"]},
+        {"dspace_dchat_requests_total": [{"type": "counter", "unexpected": "field"}]},
+    ],
+    ids=[
+        "absent",
+        "non-object",
+        "empty",
+        "wrong-type",
+        "conflicting",
+        "wrong-family",
+        "bad-entry",
+        "extra-field",
+    ],
+)
+def test_observability_app_metrics_metadata_fallback_fails_closed(monkeypatch, metadata):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+    metric = "dspace_dchat_requests_total"
+    cfg = {
+        **cfg,
+        "requiredMetricFamilies": [metric],
+        "metadataOnlyMetricFamilies": {metric: "counter"},
+    }
+    monkeypatch.setattr(
+        app_metrics,
+        "prom",
+        lambda path: metadata
+        if path.startswith("/api/v1/metadata?")
+        else {"resultType": "vector", "result": []},
+    )
+
+    with pytest.raises(app_metrics.Error):
+        app_metrics.query_required_families(cfg, {})
+
+
+def test_observability_app_metrics_missing_non_opted_in_family_still_fails(monkeypatch):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+    cfg = {
+        **cfg,
+        "requiredMetricFamilies": ["dspace_instrumentation_up"],
+        "metadataOnlyMetricFamilies": {},
+    }
+    monkeypatch.setattr(
+        app_metrics, "prom", lambda path: {"resultType": "vector", "result": []}
+    )
+    assert app_metrics.query_required_families(cfg, {}) == set()
+
+
+def test_observability_app_metrics_sample_bearing_opted_in_family_uses_full_label_validation(
+    monkeypatch,
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"][
+        "dspace"
+    ]["environments"]["staging"]
+    metric = "dspace_dchat_requests_total"
+    cfg = {
+        **cfg,
+        "requiredMetricFamilies": [metric],
+        "metadataOnlyMetricFamilies": {metric: "counter"},
+    }
+    metadata_queried = False
+
+    def fake_prom(path):
+        nonlocal metadata_queried
+        if path.startswith("/api/v1/metadata?"):
+            metadata_queried = True
+            return {}
+        return {
+            "resultType": "vector",
+            "result": [{"metric": {"__name__": metric, **_dspace_transferred_prometheus_labels()}}],
+        }
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.query_required_families(cfg, {}) == {metric}
+    assert not metadata_queried
+
+    bad_labels = _dspace_transferred_prometheus_labels()
+    bad_labels["dspace_dev_environment"] = "prod"
+    monkeypatch.setattr(
+        app_metrics,
+        "prom",
+        lambda path: {
+            "resultType": "vector",
+            "result": [{"metric": {"__name__": metric, **bad_labels}}],
+        },
+    )
+    with pytest.raises(app_metrics.Error, match="transferred metric label"):
+        app_metrics.query_required_families(cfg, {})
+
+
 @pytest.mark.parametrize(
     ("present", "result_type"),
     [
@@ -7041,6 +7253,7 @@ def test_observability_app_metrics_dspace_build_info_labels_are_bounded(env):
             "__name__": "dspace_build_info",
             "version": "3.1.1",
             "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+            **(_dspace_transferred_prometheus_labels() if env == "staging" else {}),
         },
     )
 


### PR DESCRIPTION
### Motivation

- The generic application-metrics verifier rejected a healthy immutable DSPACE 3.1.1 staging contract because it did not validate the exact ordered `ServiceMonitor.spec.targetLabels` transfers and did not allow two legitimate zero-series counters to be accepted by narrow metadata-only verification. 
- The change must be fail-closed: accept only the exact transferred label names and bounded values for staging, and accept only the two specific DSPACE counters without samples when Prometheus metadata explicitly declares the family and type. 
- Preserve all existing verifier behavior for production, token.place, relabelings, and sample-bearing series label validation.

### Description

- Add explicit DSPACE staging artifacts and narrow metadata-only rules: introduce `DSPACE_STAGING_TRANSFERRED_LABELS` and `DSPACE_STAGING_METADATA_ONLY_FAMILIES` and wire them into inventory validation. (changes in `scripts/observability_app_metrics.py` and `platform/observability/app-metrics.json`)
- Enforce `ServiceMonitor.spec.targetLabels` as an ordered array during both rendered manifest validation and live verification, rejecting reordered/missing/duplicated/extra entries. (validators and live checks updated in `scripts/observability_app_metrics.py` and hermetic fixtures updated in `scripts/test-helm-oci-install.sh`)
- Add a narrow, inventory-controlled Prometheus metadata fallback that queries `/api/v1/metadata?metric=...` to accept an opted-in required family only when the response is exactly one metadata entry with the expected `type` (used for the two DSPACE staging counters). (implementation in `scripts/observability_app_metrics.py`) 
- Expand focused regression coverage and update the hermetic chart fixture to include the exact ordered staging `targetLabels` and tests exercising: ordered-label success/failure, transferred-value enums, metadata-only zero-series success and failure modes, and unchanged production contract. (tests updated/added in `tests/test_generic_app_just_recipes.py`)

### Testing

- Verified Python compile and inventory validation: `python3 -m compileall scripts/observability_app_metrics.py` and `python3 scripts/observability_app_metrics.py validate` both succeeded. 
- Ran the full just-recipe test bundle: `python3 -m pytest -q tests/test_generic_app_just_recipes.py` — 501 tests passed. 
- Ran focused observability tests: `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k observability_app_metrics` — 227 passed (274 deselected); and `python3 -m pytest -q tests/test_dspace_observability_alerts.py tests/test_dspace_runtime_values.py tests/test_dspace_runtime_verifier.py tests/test_dspace_promotion_plan.py` — 406 passed. 
- Executed chart/fixture smoke: `./scripts/test-helm-oci-install.sh` — helper/fixture checks exercised and reported expected messages (no failures for the hermetic fixture). 
- Repo consistency checks: `git diff --check` and secret-scan `git diff --cached | ./scripts/scan-secrets.py` ran with no exposed secrets or diff-check errors for these changes; `linkchecker --no-warnings README.md docs/` ran and reported no link errors. 
- Not-run / environmental: `pre-commit run --all-files` reported `pre-commit` missing in the environment and was not executed; `pyspelling -c .spellcheck.yaml` could not run because `aspell` is not installed in this environment; `bash scripts/checks.sh` produced existing repository-wide pycodestyle warnings unrelated to this change.

If reviewers want, I can split the inventory additions (JSON) and the verifier logic into separate commits for easier review, but the current diff is intentionally minimal and focused on the DSPACE staging contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8257cfccf4832f88a13c4de44cc91b)