### PR TITLE
Validate the immutable DSPACE staging metrics contract

### DIFF
--- a/platform/observability/app-metrics.json
+++ b/platform/observability/app-metrics.json
@@ -79,6 +79,7 @@
             "tokenplace_instrumentation_up",
             "tokenplace_build_info"
           ],
+          "metadataOnlyMetricFamilies": {},
           "allowedApplicationLabels": {
             "app": [
               "tokenplace"
@@ -149,6 +150,8 @@
               "capacity_loss"
             ]
           },
+          "serviceMonitorTargetLabels": [],
+          "transferredTargetLabels": {},
           "forbiddenApplicationLabels": [
             "authorization",
             "bearer",
@@ -265,6 +268,10 @@
             "dspace_instrumentation_up",
             "dspace_build_info"
           ],
+          "metadataOnlyMetricFamilies": {
+            "dspace_dchat_requests_total": "counter",
+            "dspace_dependency_requests_total": "counter"
+          },
           "allowedApplicationLabels": {
             "app": [
               "dspace"
@@ -343,6 +350,24 @@
               "fallback_unavailable",
               "unknown_error"
             ]
+          },
+          "serviceMonitorTargetLabels": [
+            "app.kubernetes.io/name",
+            "app.kubernetes.io/instance",
+            "app.kubernetes.io/managed-by",
+            "dspace.dev/app",
+            "dspace.dev/environment",
+            "dspace.dev/release",
+            "dspace.dev/cluster"
+          ],
+          "transferredTargetLabels": {
+            "app_kubernetes_io_name": "dspace",
+            "app_kubernetes_io_instance": "dspace",
+            "app_kubernetes_io_managed_by": "Helm",
+            "dspace_dev_app": "dspace",
+            "dspace_dev_environment": "staging",
+            "dspace_dev_release": "dspace",
+            "dspace_dev_cluster": "sugarkube-int"
           },
           "derivedApplicationLabels": {},
           "forbiddenApplicationLabels": [
@@ -437,6 +462,7 @@
             "dspace_instrumentation_up",
             "dspace_build_info"
           ],
+          "metadataOnlyMetricFamilies": {},
           "allowedApplicationLabels": {
             "app": [
               "dspace"
@@ -516,6 +542,8 @@
               "unknown_error"
             ]
           },
+          "serviceMonitorTargetLabels": [],
+          "transferredTargetLabels": {},
           "derivedApplicationLabels": {},
           "forbiddenApplicationLabels": [
             "authorization",

--- a/scripts/observability_app_metrics.py
+++ b/scripts/observability_app_metrics.py
@@ -123,6 +123,28 @@ DSPACE_ENVIRONMENT_COORDINATES = {
         "url": "https://democratized.space/metrics",
     },
 }
+DSPACE_STAGING_SERVICE_TARGET_LABELS = [
+    "app.kubernetes.io/name",
+    "app.kubernetes.io/instance",
+    "app.kubernetes.io/managed-by",
+    "dspace.dev/app",
+    "dspace.dev/environment",
+    "dspace.dev/release",
+    "dspace.dev/cluster",
+]
+DSPACE_STAGING_TRANSFERRED_LABELS = {
+    "app_kubernetes_io_name": "dspace",
+    "app_kubernetes_io_instance": "dspace",
+    "app_kubernetes_io_managed_by": "Helm",
+    "dspace_dev_app": "dspace",
+    "dspace_dev_environment": "staging",
+    "dspace_dev_release": "dspace",
+    "dspace_dev_cluster": "sugarkube-int",
+}
+DSPACE_STAGING_METADATA_ONLY_FAMILIES = {
+    "dspace_dchat_requests_total": "counter",
+    "dspace_dependency_requests_total": "counter",
+}
 
 
 class Error(SystemExit):
@@ -290,7 +312,10 @@ def validate_inventory(doc):
                     "publicMetrics",
                     "retries",
                     "requiredMetricFamilies",
+                    "metadataOnlyMetricFamilies",
                     "allowedApplicationLabels",
+                    "serviceMonitorTargetLabels",
+                    "transferredTargetLabels",
                     "derivedApplicationLabels",
                     "forbiddenApplicationLabels",
                 },
@@ -398,6 +423,31 @@ def validate_inventory(doc):
                     fail("retry settings must be bounded integers")
             metrics = cfg["requiredMetricFamilies"]
             unique_string_list(metrics, "requiredMetricFamilies", prometheus_metric)
+            metadata_only = cfg["metadataOnlyMetricFamilies"]
+            if not isinstance(metadata_only, dict):
+                fail("metadataOnlyMetricFamilies must be an object")
+            for metric, metric_type in metadata_only.items():
+                prometheus_metric(metric, "metadata-only metric family")
+                if metric not in metrics or metric_type not in {
+                    "counter",
+                    "gauge",
+                    "histogram",
+                    "summary",
+                }:
+                    fail("metadataOnlyMetricFamilies must name required families with exact types")
+            service_target_labels = cfg["serviceMonitorTargetLabels"]
+            if not isinstance(service_target_labels, list):
+                fail("serviceMonitorTargetLabels must be an ordered unique array")
+            if service_target_labels:
+                unique_string_list(
+                    service_target_labels, "serviceMonitorTargetLabels", k8s_label_key
+                )
+            transferred = cfg["transferredTargetLabels"]
+            if not isinstance(transferred, dict):
+                fail("transferredTargetLabels must be an object")
+            for label, value in transferred.items():
+                prometheus_label(label, "transferred target label name")
+                k8s_label_value(value, "transferred target label value")
             allowed = cfg["allowedApplicationLabels"]
             if not isinstance(allowed, dict):
                 fail("allowedApplicationLabels must be an object")
@@ -432,6 +482,19 @@ def validate_inventory(doc):
                     fail("DSPACE required metric families must match the immutable source contract")
                 if allowed != expected_allowed:
                     fail("DSPACE application labels must match the immutable source contract")
+                expected_service_labels = (
+                    DSPACE_STAGING_SERVICE_TARGET_LABELS if env == "staging" else []
+                )
+                expected_transferred = DSPACE_STAGING_TRANSFERRED_LABELS if env == "staging" else {}
+                expected_metadata_only = (
+                    DSPACE_STAGING_METADATA_ONLY_FAMILIES if env == "staging" else {}
+                )
+                if (
+                    service_target_labels != expected_service_labels
+                    or transferred != expected_transferred
+                    or metadata_only != expected_metadata_only
+                ):
+                    fail("DSPACE transferred-label and metadata-only contracts must be exact")
                 if (
                     cfg["namespace"] != "dspace"
                     or cfg["serviceMonitorName"] != "dspace"
@@ -776,6 +839,9 @@ def validate_metric_labels(cfg, labels, derived_values=None):
         )
     ):
         fail("DSPACE build identity label mismatch (details redacted)", 1)
+    for label, value in cfg.get("transferredTargetLabels", {}).items():
+        if labels.get(label) != value:
+            fail("transferred target metric label mismatch (details redacted)", 1)
     for label, value in labels.items():
         if (
             not isinstance(label, str)
@@ -788,6 +854,7 @@ def validate_metric_labels(cfg, labels, derived_values=None):
         if (
             not is_standard
             and label not in cfg["allowedApplicationLabels"]
+            and label not in cfg.get("transferredTargetLabels", {})
             and label not in cfg.get("derivedApplicationLabels", {})
         ):
             fail("unbounded application metric label observed (details redacted)", 1)
@@ -896,6 +963,19 @@ def query_required_families(cfg: dict[str, Any], derived_values: dict[str, str])
                 # Prefer exact identity before normalizing conventional suffixes.
                 if series_name == metric or metric_family_from_series(series_name) == metric:
                     found.add(metric)
+        if metric not in found and metric in cfg.get("metadataOnlyMetricFamilies", {}):
+            data = prom("/api/v1/metadata?metric=" + urllib.parse.quote(metric))
+            if set(data) != {metric} or not isinstance(data.get(metric), list):
+                fail("Prometheus metadata response is structurally invalid (details redacted)", 1)
+            entries = data[metric]
+            expected_type = cfg["metadataOnlyMetricFamilies"][metric]
+            if (
+                len(entries) != 1
+                or not isinstance(entries[0], dict)
+                or entries[0].get("type") != expected_type
+            ):
+                fail("Prometheus metadata type contract mismatch (details redacted)", 1)
+            found.add(metric)
     return found
 
 
@@ -921,6 +1001,8 @@ def verify(app, env):
     spec = sm.get("spec")
     if not isinstance(spec, dict):
         fail("ServiceMonitor response is structurally invalid", 1)
+    if spec.get("targetLabels", []) != cfg["serviceMonitorTargetLabels"]:
+        fail("ServiceMonitor targetLabels contract mismatch", 1)
     metadata = sm.get("metadata")
     labels = metadata.get("labels") if isinstance(metadata, dict) else None
     if env == "prod":
@@ -1117,6 +1199,8 @@ def validate_render(
     spec = sm.get("spec", {})
     if not isinstance(spec, dict):
         fail("rendered ServiceMonitor spec is structurally invalid")
+    if spec.get("targetLabels", []) != cfg["serviceMonitorTargetLabels"]:
+        fail("rendered ServiceMonitor targetLabels contract mismatch")
     namespace_selector = spec.get("namespaceSelector")
     selector = spec.get("selector")
     if not isinstance(namespace_selector, dict) or not isinstance(selector, dict):

--- a/scripts/test-helm-oci-install.sh
+++ b/scripts/test-helm-oci-install.sh
@@ -155,6 +155,14 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: dspace
       app.kubernetes.io/name: dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   endpoints:
     - port: http
       path: /metrics

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -420,6 +420,14 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: dspace
       app.kubernetes.io/name: dspace
+  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
   endpoints:
     - port: http
       path: /metrics
@@ -6385,6 +6393,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
     ]["environments"]["staging"]
     service_monitor = {
         "spec": {
+            "targetLabels": cfg["serviceMonitorTargetLabels"],
             "selector": {"matchLabels": cfg["serviceMonitor"]["selectorMatchLabels"]},
             "endpoints": [
                 {
@@ -6419,7 +6428,7 @@ def test_observability_app_metrics_verify_dspace_staging_contract(monkeypatch, c
         if metric not in cfg["requiredMetricFamilies"]:
             return {"resultType": "vector", "result": []}
         queried_families.add(metric)
-        labels = {"__name__": metric}
+        labels = {"__name__": metric, **cfg["transferredTargetLabels"]}
         if metric == "dspace_build_info":
             labels.update(
                 version="3.1.1",
@@ -7041,6 +7050,7 @@ def test_observability_app_metrics_dspace_build_info_labels_are_bounded(env):
             "__name__": "dspace_build_info",
             "version": "3.1.1",
             "revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+            **cfg["transferredTargetLabels"],
         },
     )
 
@@ -8111,3 +8121,185 @@ def test_observability_app_metrics_strict_inventory_boundaries_are_controlled(
     with pytest.raises(app_metrics.Error) as excinfo:
         app_metrics.validate_inventory(doc)
     assert message in str(excinfo.value)
+def _dspace_311_staging_chart_like_service_monitor() -> str:
+    rendered = _dspace_303_chart_like_service_monitor("  namespace: dspace\n")
+    rendered = rendered.replace("dspace-prod-metrics-token", "dspace-staging-metrics-token")
+    rendered = rendered.replace("replacement: prod", "replacement: staging")
+    rendered = rendered.replace("replacement: sugarkube-prod", "replacement: sugarkube-int")
+    target_labels = """  targetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/managed-by
+    - dspace.dev/app
+    - dspace.dev/environment
+    - dspace.dev/release
+    - dspace.dev/cluster
+"""
+    return rendered.replace("  endpoints:\n", target_labels + "  endpoints:\n")
+
+
+
+def test_observability_app_metrics_dspace_staging_render_accepts_exact_target_labels(
+    tmp_path: Path,
+):
+    rendered = tmp_path / "rendered.yaml"
+    rendered.write_text(_dspace_311_staging_chart_like_service_monitor(), encoding="utf-8")
+
+    app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
+
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda labels: [labels[1], labels[0], *labels[2:]],
+        lambda labels: labels[:-1],
+        lambda labels: [*labels, labels[-1]],
+        lambda labels: [*labels, "example.com/extra"],
+    ],
+    ids=["reordered", "missing", "duplicate", "extra"],
+)
+def test_observability_app_metrics_dspace_staging_render_rejects_target_label_drift(
+    tmp_path: Path, mutator
+):
+    rendered = tmp_path / "rendered.yaml"
+    text = _dspace_311_staging_chart_like_service_monitor()
+    expected = app_metrics.DSPACE_STAGING_SERVICE_TARGET_LABELS
+    original = "".join(f"    - {label}\n" for label in expected)
+    changed = "".join(f"    - {label}\n" for label in mutator(expected))
+    rendered.write_text(text.replace(original, changed), encoding="utf-8")
+
+    with pytest.raises(app_metrics.Error, match="targetLabels contract mismatch"):
+        app_metrics.validate_render("dspace", "staging", str(rendered), "dspace")
+
+
+
+def test_observability_app_metrics_dspace_transferred_labels_are_exact_and_required():
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"][
+        "environments"
+    ]["staging"]
+    labels = {
+        "__name__": "dspace_http_requests_total",
+        **cfg["transferredTargetLabels"],
+    }
+    app_metrics.validate_metric_labels(cfg, labels)
+
+    for label in cfg["transferredTargetLabels"]:
+        missing = dict(labels)
+        missing.pop(label)
+        with pytest.raises(app_metrics.Error, match="transferred target metric label mismatch"):
+            app_metrics.validate_metric_labels(cfg, missing)
+
+    wrong = dict(labels)
+    wrong["dspace_dev_environment"] = "prod"
+    with pytest.raises(app_metrics.Error, match="transferred target metric label mismatch"):
+        app_metrics.validate_metric_labels(cfg, wrong)
+    with pytest.raises(app_metrics.Error, match="unbounded application metric label"):
+        app_metrics.validate_metric_labels(cfg, labels | {"dspace_dev_unlisted": "value"})
+    with pytest.raises(app_metrics.Error, match="label enum mismatch"):
+        app_metrics.validate_metric_labels(cfg, labels | {"route": "/not-declared"})
+    with pytest.raises(app_metrics.Error, match="unbounded application metric label"):
+        app_metrics.validate_metric_labels(cfg, labels | {"customer_email": "redacted"})
+
+
+
+@pytest.mark.parametrize(
+    "metric",
+    ["dspace_dchat_requests_total", "dspace_dependency_requests_total"],
+)
+def test_observability_app_metrics_metadata_declared_zero_series_succeeds(monkeypatch, metric):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"][
+        "environments"
+    ]["staging"]
+    cfg = {**cfg, "requiredMetricFamilies": [metric]}
+
+    def fake_prom(path):
+        if path.startswith("/api/v1/metadata?"):
+            return {metric: [{"type": "counter", "help": "declared", "unit": ""}]}
+        return {"resultType": "vector", "result": []}
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.query_required_families(cfg, {}) == {metric}
+
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        [],
+        {"dspace_dchat_requests_total": "malformed"},
+        {"dspace_dchat_requests_total": [{"type": "gauge"}]},
+        {"dspace_dchat_requests_total": [{"type": "counter"}, {"type": "counter"}]},
+        {"other_family": [{"type": "counter"}]},
+    ],
+    ids=[
+        "absent",
+        "malformed-root",
+        "malformed-entry-list",
+        "wrong-type",
+        "conflicting",
+        "wrong-family",
+    ],
+)
+def test_observability_app_metrics_metadata_fallback_fails_closed(monkeypatch, metadata):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"][
+        "environments"
+    ]["staging"]
+    cfg = {**cfg, "requiredMetricFamilies": ["dspace_dchat_requests_total"]}
+    monkeypatch.setattr(
+        app_metrics,
+        "prom",
+        lambda path: (
+            metadata
+            if path.startswith("/api/v1/metadata?")
+            else {"resultType": "vector", "result": []}
+        ),
+    )
+    with pytest.raises(app_metrics.Error, match="metadata"):
+        app_metrics.query_required_families(cfg, {})
+
+
+
+def test_observability_app_metrics_non_opted_in_missing_family_still_fails(monkeypatch):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"][
+        "environments"
+    ]["staging"]
+    cfg = {
+        **cfg,
+        "requiredMetricFamilies": ["dspace_http_requests_total"],
+        "metadataOnlyMetricFamilies": {},
+    }
+    paths = []
+    monkeypatch.setattr(
+        app_metrics,
+        "prom",
+        lambda path: paths.append(path) or {"resultType": "vector", "result": []},
+    )
+    assert app_metrics.query_required_families(cfg, {}) == set()
+    assert not any(path.startswith("/api/v1/metadata?") for path in paths)
+
+
+
+def test_observability_app_metrics_sample_bearing_metadata_opt_in_uses_normal_validation(
+    monkeypatch,
+):
+    cfg = json.loads(APP_METRICS_CONFIG.read_text(encoding="utf-8"))["applications"]["dspace"][
+        "environments"
+    ]["staging"]
+    cfg = {**cfg, "requiredMetricFamilies": ["dspace_dchat_requests_total"]}
+    paths = []
+
+    def fake_prom(path):
+        paths.append(path)
+        metric = app_metrics.urllib.parse.unquote(path).split("query=", 1)[-1].split("{", 1)[0]
+        if metric == "dspace_dchat_requests_total":
+            return {
+                "resultType": "vector",
+                "result": [{"metric": {"__name__": metric, **cfg["transferredTargetLabels"]}}],
+            }
+        return {"resultType": "vector", "result": []}
+
+    monkeypatch.setattr(app_metrics, "prom", fake_prom)
+    assert app_metrics.query_required_families(cfg, {}) == {"dspace_dchat_requests_total"}
+    assert not any(path.startswith("/api/v1/metadata?") for path in paths)


### PR DESCRIPTION
### Motivation

- The DSPACE 3.1.1 staging chart transfers a specific ordered set of seven ServiceMonitor `targetLabels` and projects them into Prometheus with bounded values, and the verifier must treat those as chart-transferred labels (not arbitrary app labels) and validate them exactly. 
- Two DSPACE staging counters legitimately have no series until traffic occurs and must be accepted only when Prometheus metadata explicitly declares the family and type. 
- The generic application-metrics verifier must fail-closed for reordered/missing/extra `targetLabels`, wrong transferred-label values, unlisted projected labels, malformed metadata, and any non-opted-in missing family.

### Description

- Add DSPACE staging constants and a narrow inventory opt-in surface: `metadataOnlyMetricFamilies`, `serviceMonitorTargetLabels`, and `transferredTargetLabels`, and update the DSPACE staging entry in `platform/observability/app-metrics.json`. 
- Enforce exact ordered `ServiceMonitor.spec.targetLabels` in both rendered validation (`validate_render`) and live verification (`verify`) and require the configured `serviceMonitorTargetLabels` list to match exactly. 
- Require every sampled DSPACE staging series to include the seven transferred Prometheus labels with their exact bounded values and continue rejecting forbidden, unlisted, malformed, or out-of-enum application labels. 
- Implement a fail-closed Prometheus metadata fallback in `query_required_families` that only accepts explicitly opted-in `metadataOnlyMetricFamilies` and verifies the metadata contains exactly one entry with the expected `type` before treating the family as present. 
- Update the hermetic staging fixtures used by `scripts/test-helm-oci-install.sh` and add focused regression tests in `tests/test_generic_app_just_recipes.py` covering target-label order/duplicates/missing/extra, transferred-label enforcement and value mismatches, metadata-declared zero-series success for the two counters, and metadata fallback failures for malformed/wrong/conflicting responses.

### Testing

- `python3 -m compileall scripts/observability_app_metrics.py` completed successfully. 
- `python3 scripts/observability_app_metrics.py validate` completed successfully and reported the inventory valid. 
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py` ran and passed (500 passed; 1 pre-existing SyntaxWarning reported). 
- Focused DSPACE tests `python3 -m pytest -q tests/test_dspace_observability_alerts.py tests/test_dspace_promotion_plan.py tests/test_dspace_runtime_values.py` ran and passed (209 passed). 
- `./scripts/test-helm-oci-install.sh` executed the hermetic chart fixture successfully. 
- `pre-commit run --all-files` was not executed because `pre-commit` is not installed in this environment. 
- Creating the remote pull request could not be completed from this environment due to missing GitHub authentication; the local branch contains the change and is ready for a remote PR from an authenticated environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8257d25678832f9b8760cf63158626)