### PR TITLE
dspace: require and validate modern buildTimestamp in build-info-v1 identity

### DIFF
--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -43,7 +43,7 @@ RESULT_FIELDS = (
     "defaultProvider",
     "journeys",
 )
-BUILD_FIELDS = {"version", "revision", "shortRevision", "image"}
+BUILD_FIELDS = {"version", "revision", "shortRevision", "buildTimestamp", "image"}
 LEGACY_BUILD_FIELDS = {"gitSha", "generatedAt", "source"}
 MODERN_IDENTITY_CONTRACT = "build-info-v1"
 LEGACY_IDENTITY_CONTRACT = "legacy-build-meta-v1"
@@ -87,6 +87,9 @@ META_RE = re.compile(
     re.IGNORECASE,
 )
 IMAGE_ID_RE = re.compile(r"sha256:[0-9a-f]{64}$")
+BUILD_TIMESTAMP_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{3})?Z$"
+)
 HTML_DOCUMENT_RE = re.compile(r"^\s*(?:<!doctype\s+html\b|<html\b)", re.IGNORECASE)
 PUBLIC_HTTP_USER_AGENT = "sugarkube-dspace-runtime-verifier/1.0"
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -218,14 +221,17 @@ def fetch(url: str, public_origin: tuple[str, str] | None = None) -> bytes:
 
 def identity(
     raw: bytes, version: str, revision: str, image: str, category: str
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     if len(raw) > 1024 * 1024:
         fail(category)
     try:
         value = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail(category)
-    if not isinstance(value, dict) or set(value) - BUILD_FIELDS:
+    if not isinstance(value, dict) or set(value) not in (
+        BUILD_FIELDS,
+        BUILD_FIELDS - {"image"},
+    ):
         fail(category)
     if (
         value.get("version") != version
@@ -236,7 +242,22 @@ def identity(
     runtime_image = value.get("image")
     if runtime_image is not None and runtime_image != image:
         fail(category)
-    return version, revision, runtime_image or image
+    build_timestamp = value.get("buildTimestamp")
+    if (
+        not isinstance(build_timestamp, str)
+        or not build_timestamp
+        or len(build_timestamp) > 40
+        or BUILD_TIMESTAMP_RE.fullmatch(build_timestamp) is None
+    ):
+        fail(category)
+    try:
+        timestamp_format = (
+            "%Y-%m-%dT%H:%M:%SZ" if "." not in build_timestamp else "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        datetime.strptime(build_timestamp, timestamp_format)
+    except ValueError:
+        fail(category)
+    return version, revision, runtime_image or image, build_timestamp
 
 
 def marker(raw: bytes, revision: str, category: str) -> None:
@@ -444,7 +465,7 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
 
     helm_before = helm_identity(args, expected["chart_version"])
 
-    replica_identity: tuple[str, str, str] | None = None
+    replica_identity: tuple[str, ...] | None = None
     for pod in pods:
         metadata, spec, status = pod.get("metadata", {}), pod.get("spec", {}), pod.get("status", {})
         if not all(isinstance(value, dict) for value in (metadata, spec, status)):

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -12,6 +12,7 @@ SHA = "abcdef0123456789abcdef0123456789abcdef01"
 DIGEST = "sha256:" + "1" * 64
 SENTINEL = "SENTINEL_SECRET"
 RECOVERY_SHA = "1a31a569aff2dbeb238e8c2688b9e85140d2077d"
+BUILD_TIMESTAMP = "2026-08-16T05:20:19.000Z"
 
 
 def manifest(tmp_path: Path, provider: str = "token-place") -> Path:
@@ -140,6 +141,7 @@ def _verify_setup(
                 "version": version,
                 "revision": revision,
                 "shortRevision": revision[:7],
+                "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
         )
@@ -1105,7 +1107,14 @@ def test_verify_fails_closed_for_any_bad_replica_or_image(
 def test_verify_rejects_mixed_replica_and_public_direct_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    mismatched = json.dumps({"version": "3.1.0", "revision": "f" * 40, "shortRevision": "fffffff"})
+    mismatched = json.dumps(
+        {
+            "version": "3.1.0",
+            "revision": "f" * 40,
+            "shortRevision": "fffffff",
+            "buildTimestamp": BUILD_TIMESTAMP,
+        }
+    )
     args, _ = _verify_setup(
         monkeypatch,
         tmp_path,
@@ -1121,7 +1130,7 @@ def test_verify_rejects_mixed_replica_and_public_direct_identity(
         raw: bytes, version: str, revision: str, image: str, category: str
     ):  # noqa: ANN202
         value = real_identity(raw, version, revision, image, category)
-        return (value[0], value[1], "different") if category == "public identity" else value
+        return (*value[:3], "different") if category == "public identity" else value
 
     monkeypatch.setattr(verifier, "identity", disagree)
     with pytest.raises(verifier.VerificationError, match="public identity"):
@@ -1527,6 +1536,133 @@ def test_build_identity_requires_canonical_coordinates(
             "ghcr.io/democratizedspace/dspace:main-abcdef0",
             category,
         )
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    ["2026-08-16T05:20:19Z", "2026-08-16T05:20:19.123Z"],
+    ids=("seconds", "milliseconds"),
+)
+def test_modern_identity_accepts_canonical_utc_build_timestamp(build_timestamp: str) -> None:
+    image = "ghcr.io/democratizedspace/dspace:main-22f506e"
+    revision = "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"
+    payload = {
+        "version": "3.1.1",
+        "revision": revision,
+        "shortRevision": "22f506e",
+        "buildTimestamp": build_timestamp,
+        "image": image,
+    }
+
+    assert verifier.identity(
+        json.dumps(payload).encode(), "3.1.1", revision, image, "direct identity"
+    ) == ("3.1.1", revision, image, build_timestamp)
+
+
+@pytest.mark.parametrize(
+    "build_timestamp",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("", id="empty"),
+        pytest.param(123, id="non-string"),
+        pytest.param("2" * 41, id="overlong"),
+        pytest.param("2026-08-16T05:20:19Z\n" + SENTINEL, id="control-character"),
+        pytest.param("2026-02-30T05:20:19Z", id="impossible-date"),
+        pytest.param("2026-08-16T05:20:19+00:00", id="offset-timezone"),
+        pytest.param("2026-08-16T05:20:19", id="non-utc"),
+        pytest.param("2026-08-16T05:20:19.12Z", id="noncanonical-fraction"),
+        pytest.param("2026-08-16T05:20:19Z" + SENTINEL, id="trailing-data"),
+    ],
+)
+def test_modern_identity_rejects_bad_build_timestamp_without_leaking(
+    build_timestamp: object,
+) -> None:
+    payload = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": build_timestamp,
+    }
+    if build_timestamp is None:
+        del payload["buildTimestamp"]
+
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "direct identity",
+        )
+
+    assert str(raised.value) == "direct identity"
+    assert SENTINEL not in str(raised.value)
+
+
+def test_modern_identity_still_rejects_unknown_fields_without_leaking() -> None:
+    payload = {
+        "version": "3.1.0",
+        "revision": SHA,
+        "shortRevision": SHA[:7],
+        "buildTimestamp": BUILD_TIMESTAMP,
+        "unexpected": SENTINEL,
+    }
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.identity(
+            json.dumps(payload).encode(),
+            "3.1.0",
+            SHA,
+            "ghcr.io/democratizedspace/dspace:main-abcdef0",
+            "public identity",
+        )
+    assert str(raised.value) == "public identity"
+    assert SENTINEL not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    "overrides,category",
+    [
+        (
+            {
+                "direct_builds": {
+                    "dspace-2": json.dumps(
+                        {
+                            "version": "3.1.0",
+                            "revision": SHA,
+                            "shortRevision": SHA[:7],
+                            "buildTimestamp": "2026-08-16T05:20:20Z",
+                        }
+                    )
+                }
+            },
+            "pod/replica identity",
+        ),
+        (
+            {
+                "public_build": json.dumps(
+                    {
+                        "version": "3.1.0",
+                        "revision": SHA,
+                        "shortRevision": SHA[:7],
+                        "buildTimestamp": "2026-08-16T05:20:20Z",
+                    }
+                )
+            },
+            "public identity",
+        ),
+    ],
+    ids=("replicas", "direct-public"),
+)
+def test_modern_build_timestamp_disagreement_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    overrides: dict[str, object],
+    category: str,
+) -> None:
+    args, _ = _verify_setup(monkeypatch, tmp_path, overrides=overrides)
+    with pytest.raises(verifier.VerificationError) as raised:
+        verifier.verify(args)
+    assert str(raised.value) == category
 
 
 def test_command_success_and_nonzero_failure_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation

- The runtime verifier rejected the live DSPACE modern identity because `build-info-v1` responses include `buildTimestamp` but the verifier did not recognize it, causing valid staging `3.1.1` responses to be classified as direct-identity failures. 
- Staging is already running DSPACE application `3.1.1`, chart `3.1.2`, Helm revision 29 with exactly two Ready pods at image `ghcr.io/democratizedspace/dspace:main-22f506e` and digest `sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b` (live pods use `image.pullPolicy=Always`).
- The change must be minimal and verification-only so the existing revision-29 reservation can be verified and later finalized without any Helm/cluster mutation or evidence changes.

### Description

- Update `scripts/dspace_runtime_verifier.py` to recognize `buildTimestamp` in the modern `build-info-v1` identity and require it as part of the modern identity tuple while keeping `image` optional.  The verifier still rejects missing fields, unknown fields, malformed coordinates, mismatched revisions, and mismatched images. 
- Add strict validation for `buildTimestamp`: it must be a JSON string, non-empty and at most 40 characters, contain no control characters, match the canonical ASCII UTC shape exactly, and parse as a real calendar timestamp in exactly `YYYY-MM-DDTHH:MM:SSZ` or `YYYY-MM-DDTHH:MM:SS.sssZ` form (no offsets, non-UTC forms, arbitrary fractional precision, trailing data, or extra fields).  The implementation uses a precise regex and `datetime.strptime` checks. 
- Include the normalized timestamp in the verifier’s internal direct-replica / public identity comparison so any timestamp disagreement between replicas or between direct and public responses fails closed, but do not add `buildTimestamp` to emitted public result schema or change `CAPABILITIES`, `RESULT_FIELDS`, journey names, or sanitized output. 
- Preserve legacy `/build-meta.json` behavior and immutable legacy-coordinate selection unchanged. 
- Add focused regression tests in `tests/test_dspace_runtime_verifier.py` covering: the canonical DSPACE 3.1.1 modern payload with `buildTimestamp`, accepted second- and millisecond-precision forms, a broad set of invalid/malformed/failure cases (missing/empty/non-string/overlong/control-character/impossible-date/offset-timezone/non-UTC/non-canonical-fraction/trailing-data), continued rejection of unknown fields, replica vs public timestamp disagreement, and redaction on failure paths.  Only two files were changed: `scripts/dspace_runtime_verifier.py` and the verifier unit test file.

### Testing

- Ran focused verifier unit tests: `python -m pytest -q tests/test_dspace_runtime_verifier.py` — 194 passed (all new and existing verifier tests passed).
- Ran broader affected suites: `python -m pytest -q tests/test_dspace_runtime_verifier.py tests/test_release_manifest.py tests/test_manifest_rollback.py tests/test_generic_app_just_recipes.py` — 1,055 passed, 1 pre-existing SyntaxWarning; no failures introduced by this change.
- Verified `capabilities` exact output and ordering with: `python scripts/dspace_runtime_verifier.py capabilities --environment staging --release dspace --namespace dspace` and asserted the JSON matches the exact existing schema and capability order (passed).
- Ran repository checks: `git diff --check`, `git diff | ./scripts/scan-secrets.py`, and `git diff --cached | ./scripts/scan-secrets.py` (no new secrets or diff errors from this change).
- Ran `pre-commit` on the modified files (formatters/hooks for those files were applied); a repository-wide `pre-commit run --all-files` produced failures that are pre-existing lint/style issues in unrelated files and were not introduced by this change.
- Link-checker run on README/docs completed with no link errors; `pyspelling` could not run in this environment due to missing `aspell` binary, but no docs were modified by this PR.

Notes and scope assurances: this PR only adjusts the modern identity parser and adds tests to cover the requested cases; it does not change emitted verifier schemas, evidence handling, Helm or Kubernetes resources, or any automation that would authorize redeploy, finalization, or production changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81f46b8168832f89ef1e8fe2adf94c)