### PR TITLE
Require explicit DSPACE production authorization (Closes #2328)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1957,13 +1957,13 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify "${verifier_args[@]}"
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input production_confirmation)
+    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2004,6 +2004,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
         fi
         staging_revision="$(python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" staging-gate \
           --manifest "${release_manifest}" --staging-evidence "${staging_record}")"
+        python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" authorize-production \
+          --manifest "${release_manifest}" --confirm "${production_confirmation}"
         staging_kubeconfig_path=${staging_kubeconfig_input}
         if [ -z "${staging_kubeconfig_path}" ]; then echo "ERROR: staging_kubeconfig=<path> is required for DSPACE prod." >&2; exit 2; fi
         if [ "${staging_kubeconfig_path}" = "${kubeconfig_input}" ]; then echo "ERROR: staging and production kubeconfigs must be distinct." >&2; exit 2; fi
@@ -2166,13 +2168,13 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input production_confirmation)
+    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2195,7 +2197,7 @@ app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       "${SUGARKUBE_APP}" prod "${SUGARKUBE_TAG}" "${SUGARKUBE_CONFIG_PATH}" \
       "${manifest_input}" "${evidence_input}" "${staging_evidence_input}" "${smoke_runner_input}" \
-      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}"
+      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}" "${production_confirmation}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
 app-chart-status app env='staging' config='':
@@ -2320,13 +2322,13 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9)
-    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9 10)
+    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2335,7 +2337,7 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence=
       if [[ ${argument} == "${prefixes[prefix_index]}="* ]]; then values[${destinations[prefix_index]}]=${argument#*=}; break; fi
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace "${values[0]}" "${values[1]}" \
-      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}"
+      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}" "${values[10]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
 dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
@@ -2358,12 +2360,12 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig)
+    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2379,7 +2381,7 @@ dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke
       --require-tag)"
     eval "${config_exports}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy prod "${SUGARKUBE_TAG}" \
-      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}"
+      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}" "${values[7]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
 dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1089,6 +1089,19 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
     return evidence_value["helmRevision"]
 
 
+def authorize_production(candidate_value: dict[str, Any], confirmation: str) -> None:
+    """Require an explicit, release-bound authorization for production mutation."""
+    validate(candidate_value, False)
+    if candidate_value["environment"] != "prod":
+        raise ManifestError("production authorization requires a prod candidate")
+    expected = f"dspace:prod:{candidate_value['sourceRevision']}"
+    if confirmation != expected:
+        raise ManifestError(
+            "explicit production mutation authorization is required; "
+            "pass confirm=dspace:prod:<approved-source-revision>"
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1128,6 +1141,9 @@ def main(argv: list[str] | None = None) -> int:
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
     gate.add_argument("--staging-evidence", type=Path, required=True)
+    authorize = sub.add_parser("authorize-production")
+    authorize.add_argument("--manifest", type=Path, required=True)
+    authorize.add_argument("--confirm", required=True)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -1340,6 +1356,8 @@ def main(argv: list[str] | None = None) -> int:
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "staging-gate":
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
+        elif args.command == "authorize-production":
+            authorize_production(_object(args.manifest), args.confirm)
         elif args.command == "check-output":
             if args.output.exists():
                 raise ManifestError(f"refusing to overwrite existing record: {args.output}")

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3690,6 +3690,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
             f"evidence={prod_evidence}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
@@ -3731,11 +3732,62 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
             f"kubeconfig={identical}",
             f"staging_kubeconfig={identical}",
             f"evidence={tmp_path / 'rejected-evidence.json'}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
     assert rejected.returncode != 0
     assert "kubeconfigs must be distinct" in rejected.stderr
+    assert "upgrade " not in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_dspace_staging_proof_does_not_authorize_production_mutation(
+    tmp_path: Path, generic_app_stub_env: dict[str, str]
+) -> None:
+    staging_manifest = tmp_path / "staging.json"
+    staging_evidence = tmp_path / "staging-evidence.json"
+    production_manifest = tmp_path / "production.json"
+    _write_dspace_candidate(staging_manifest, "staging")
+    staged = _run_just(
+        [
+            "app-deploy",
+            "dspace",
+            "staging",
+            "main-abcdef0",
+            "",
+            str(staging_manifest),
+            str(staging_evidence),
+        ],
+        generic_app_stub_env,
+    )
+    assert staged.returncode == 0, staged.stderr + staged.stdout
+    _write_dspace_candidate(production_manifest, "prod")
+    record = json.loads(production_manifest.read_text(encoding="utf-8"))
+    record["chartVersion"] = "3.1.2"
+    production_manifest.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    env = generic_app_stub_env.copy()
+    env["SUGARKUBE_STUB_NODE_ENV"] = "prod"
+    env["SUGARKUBE_STUB_CHART_VERSION"] = "3.1.2"
+    Path(env["HELM_LOG"]).write_text("", encoding="utf-8")
+
+    result = _run_just(
+        [
+            "app-promote-prod",
+            "app=dspace",
+            "tag=main-abcdef0",
+            f"manifest={production_manifest}",
+            f"staging_evidence={staging_evidence}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+            f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
+            f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            f"evidence={tmp_path / 'production-evidence.json'}",
+        ],
+        env,
+    )
+
+    assert result.returncode != 0
+    assert "explicit production mutation authorization is required" in result.stderr
     assert "upgrade " not in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
 
 
@@ -3796,6 +3848,7 @@ def test_dspace_prod_staging_gate_failures_stop_before_production_work(
             f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
@@ -3853,6 +3906,7 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
             f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -595,6 +595,17 @@ def test_staging_gate_returns_revision_despite_approval_metadata_difference() ->
     assert manifest.staging_gate(production, runtime_final()) == 17
 
 
+def test_production_authorization_is_explicit_and_release_bound() -> None:
+    production = prod_candidate()
+    manifest.authorize_production(
+        production, f"dspace:prod:{production['sourceRevision']}"
+    )
+    with pytest.raises(manifest.ManifestError, match="explicit production mutation authorization"):
+        manifest.authorize_production(production, "")
+    with pytest.raises(manifest.ManifestError, match="explicit production mutation authorization"):
+        manifest.authorize_production(production, "dspace:prod:" + "0" * 40)
+
+
 def test_schema_v2_finalization_and_staging_gate_preserve_chart_provenance() -> None:
     staging = split_candidate()
     final = finalize(


### PR DESCRIPTION
### Motivation

- Ensure production promotion remains fail-closed by requiring an explicit, repository-bound production authorization before any production-mutating command runs. 
- Preserve the existing finalized staging evidence, schema-v2 semantics, mandatory source-integrity checks, and bounded `/chat` smoke behavior while making pre/post runtime verification gates mandatory. 
- Keep staging proof and production authorization distinct so valid staging evidence never implies production mutation rights. 

### Description

- Add `authorize_production()` to `scripts/dspace_release_manifest.py` which validates an exact `confirm=dspace:prod:<sourceRevision>` token tied to the production candidate and expose it via a new `authorize-production` subcommand. 
- Thread an explicit `confirm` parameter through the DSPACE promotion/deploy wrappers in `justfile` (`app-deploy`, `app-promote-prod`, `dspace-oci-deploy`, `dspace-oci-promote-prod`) and invoke the new repository-owned authorization check after the finalized staging-gate but before any production preflight, evidence reservation, rendering, or Helm mutation. 
- Preserve the existing runtime verifier flow (staging and prod runs remain distinct, pre- and post-rollout verification kept) and keep verifier/evidence schemas unchanged. 
- Add deterministic test coverage: unit tests for the authorization function and integration-style tests to assert that staging evidence alone does not authorize production mutation and that the pre/post verifier ordering and reservation semantics remain enforced. 

### Testing

- Ran targeted pytest suites validating the change: `python3 -m pytest -q tests/test_release_manifest.py tests/test_dspace_runtime_verifier.py tests/test_generic_app_just_recipes.py` and focused collections; the relevant test runs passed (targeted run produced 443 passed, 1 warning). 
- Exercised per-test invocations used by the CI harness for the changed recipes (examples): `python3 -m pytest -q tests/test_generic_app_just_recipes.py::test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates` which passed. 
- Documentation and link checks: `linkchecker --no-warnings README.md docs/` completed with 0 errors. 
- Repo checks: `pre-commit run --all-files` reported unrelated, pre-existing repository-wide linter/YAML issues in this environment and is not attributable to the narrow changes in this PR; `pyspelling -c .spellcheck.yaml` could not complete due to `aspell` being unavailable in the test environment. 

Notes and follow-ups

- The diff is intentionally narrow and focused only on the explicit production-authorization gate and the tests that prove its behavior; verifier contracts and evidence schema handling remain unchanged. 
- I prepared a changes branch with these edits and validated the tests locally, but pushing/creating a remote draft PR could not be completed from this environment due to missing GitHub credentials; please push the branch and open the PR (include `Closes #2328`) if you want me to propose the remote PR text or help finalize CI details.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8577487b74832f96e1cd69977cd499)