### PR TITLE
Require DSPACE runtime verification gate before & after production promotion

### DIFF
--- a/justfile
+++ b/justfile
@@ -1954,7 +1954,22 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       --kubeconfig "${kubeconfig_path}" )
     [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
     [ -z "${expected_revision}" ] || verifier_args+=(--expected-helm-revision "${expected_revision}")
-    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify "${verifier_args[@]}"
+    capability_args=( \
+      --environment "${selected_env}" --release dspace --namespace dspace \
+      --manifest "${manifest_path}" --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" )
+    [ -z "${config_path}" ] || capability_args+=(--config "${config_path}")
+    capabilities_proof="$(mktemp)"
+    runtime_proof="$(mktemp)"
+    trap 'rm -f "${capabilities_proof}" "${runtime_proof}"' EXIT
+    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities \
+      "${capability_args[@]}" >"${capabilities_proof}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-capabilities \
+      --input "${capabilities_proof}" --environment "${selected_env}"
+    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+      "${verifier_args[@]}" >"${runtime_proof}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" runtime-gate \
+      --manifest "${manifest_path}" --proof "${runtime_proof}" --environment "${selected_env}"
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
@@ -2011,6 +2026,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify \
           staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" \
           "${staging_kubeconfig_path}" "${staging_revision}"
+        python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" production-authorization \
+          --manifest "${release_manifest}" --confirm "${SUGARKUBE_DSPACE_PROD_AUTHORIZATION:-}"
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
@@ -2113,6 +2130,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
         if [ "${staging_kubeconfig_path}" = "${kubeconfig_input}" ]; then echo "ERROR: staging and production kubeconfigs must be distinct." >&2; exit 2; fi
         just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env staging "${staging_kubeconfig_path}" >/dev/null
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" "${staging_kubeconfig_path}" "${staging_revision}"
+        python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" production-authorization \
+          --manifest "${release_manifest}" --confirm "${SUGARKUBE_DSPACE_PROD_AUTHORIZATION:-}"
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -95,6 +95,13 @@ RUNTIME_VERIFICATION_CHECKS = {
     "defaultProvider",
     "remoteChatSmoke",
 }
+RUNTIME_VERIFIER_CAPABILITIES = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
 PUBLIC_PATH_RE = re.compile(r"/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*")
 PLATFORM_CHECK_RE = re.compile(r"^imagePlatformSourceRevision\[(0|[1-9][0-9]*)\]$")
 POD_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -103,6 +110,83 @@ POD_SETTLE_INTERVAL_SECONDS = 2.0
 
 class ManifestError(ValueError):
     """A release record is missing or inconsistent."""
+
+
+def validate_runtime_capabilities(
+    value: object, environment: str, release: str = "dspace", namespace: str = "dspace"
+) -> dict[str, Any]:
+    """Require the repository verifier's complete, versioned capability contract."""
+    if not isinstance(value, dict) or set(value) != {
+        "schemaVersion",
+        "environment",
+        "release",
+        "namespace",
+        "capabilities",
+    }:
+        raise ManifestError("runtime verifier capabilities are malformed")
+    if (
+        type(value["schemaVersion"]) is not int
+        or value["schemaVersion"] != 1
+        or value["environment"] != environment
+        or value["release"] != release
+        or value["namespace"] != namespace
+        or value["capabilities"] != list(RUNTIME_VERIFIER_CAPABILITIES)
+    ):
+        raise ManifestError("mandatory runtime verifier capabilities are unavailable")
+    return value
+
+
+def validate_runtime_proof(
+    candidate_value: dict[str, Any], proof: object, environment: str
+) -> dict[str, Any]:
+    """Validate a verifier result before it may authorize a deployment phase."""
+    candidate_value = validate(candidate_value)
+    if candidate_value["environment"] != environment:
+        raise ManifestError("runtime verification target environment mismatch")
+    if not isinstance(proof, dict) or set(proof) != set(RUNTIME_VERIFICATION_FIELDS):
+        raise ManifestError("runtime verification result is malformed")
+    expected = {
+        "schemaVersion": 1,
+        "environment": environment,
+        "release": "dspace",
+        "namespace": "dspace",
+        "applicationVersion": candidate_value["applicationVersion"],
+        "runtimeSourceRevision": candidate_value["sourceRevision"],
+        "frontendSourceRevision": candidate_value["sourceRevision"],
+        "defaultProvider": candidate_value["expectedDefaultChatProvider"],
+    }
+    if type(proof["schemaVersion"]) is not int or any(
+        proof.get(field) != wanted for field, wanted in expected.items()
+    ):
+        raise ManifestError("runtime verification does not match approved release")
+    journeys = proof["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise ManifestError("runtime verification lacks successful bounded journeys")
+    names: set[str] = set()
+    for journey in journeys:
+        if (
+            not isinstance(journey, dict)
+            or set(journey) != {"name", "passed"}
+            or not isinstance(journey["name"], str)
+            or not PUBLIC_PATH_RE.fullmatch(journey["name"])
+            or journey["name"] in names
+            or journey["passed"] is not True
+        ):
+            raise ManifestError("runtime verification lacks successful bounded journeys")
+        names.add(journey["name"])
+    if "/chat" not in names:
+        raise ManifestError("runtime verification lacks successful bounded /chat")
+    return proof
+
+
+def production_authorization(value: dict[str, Any], confirmation: str) -> None:
+    """Require authorization independently bound to the production candidate."""
+    value = validate(value, finalized=False)
+    if value["environment"] != "prod":
+        raise ManifestError("production authorization requires a production candidate")
+    expected = f"dspace:prod:{value['sourceRevision']}"
+    if not confirmation or not secrets.compare_digest(confirmation, expected):
+        raise ManifestError(f"production authorization must exactly equal {expected}")
 
 
 def helm_status_needs_history(status: object) -> bool:
@@ -1128,6 +1212,16 @@ def main(argv: list[str] | None = None) -> int:
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
     gate.add_argument("--staging-evidence", type=Path, required=True)
+    capabilities = sub.add_parser("runtime-capabilities")
+    capabilities.add_argument("--input", type=Path, required=True)
+    capabilities.add_argument("--environment", required=True)
+    runtime_gate = sub.add_parser("runtime-gate")
+    runtime_gate.add_argument("--manifest", type=Path, required=True)
+    runtime_gate.add_argument("--proof", type=Path, required=True)
+    runtime_gate.add_argument("--environment", required=True)
+    authorization = sub.add_parser("production-authorization")
+    authorization.add_argument("--manifest", type=Path, required=True)
+    authorization.add_argument("--confirm", required=True)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -1340,6 +1434,15 @@ def main(argv: list[str] | None = None) -> int:
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "staging-gate":
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
+        elif args.command == "runtime-capabilities":
+            validate_runtime_capabilities(_object(args.input), args.environment)
+        elif args.command == "runtime-gate":
+            validate_runtime_proof(
+                _object(args.manifest), _object(args.proof), args.environment
+            )
+            sys.stdout.write(_canonical(_object(args.proof)))
+        elif args.command == "production-authorization":
+            production_authorization(_object(args.manifest), args.confirm)
         elif args.command == "check-output":
             if args.output.exists():
                 raise ManifestError(f"refusing to overwrite existing record: {args.output}")

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -77,6 +77,18 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
+LEGACY_NO_DEFAULT_PROVIDER_V1_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.1",
+    "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+    "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+    "imageTag": "main-22f506e",
+    "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+    "chartVersion": "3.1.2",
+    "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+    "semanticTag": "v3.1.1",
+    "expectedDefaultChatProvider": "openai",
+}
 LEGACY_IDENTITY_COORDINATES = (
     LEGACY_302_COORDINATES,
     LEGACY_303_COORDINATES,
@@ -277,6 +289,16 @@ def identity_contract(manifest: dict[str, Any]) -> str:
     ):
         return LEGACY_IDENTITY_CONTRACT
     return MODERN_IDENTITY_CONTRACT
+
+
+def provider_config_contract(manifest: dict[str, Any]) -> str | None:
+    """Select a compatibility contract only for its reviewed immutable release tuple."""
+    if all(
+        manifest.get(key) == value
+        for key, value in LEGACY_NO_DEFAULT_PROVIDER_V1_COORDINATES.items()
+    ):
+        return "legacy-no-default-provider-v1"
+    return None
 
 
 def named_http_port(container: object, category: str) -> int:
@@ -584,6 +606,9 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "--identity-contract",
         contract,
     ]
+    provider_contract = provider_config_contract(manifest)
+    if provider_contract is not None:
+        smoke_argv += ["--provider-config-contract", provider_contract]
     if expected["provider"] == "token-place":
         assert token_values is not None
         token_origin, token_model = token_values

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -748,6 +748,21 @@ def test_any_310_coordinate_drift_prevents_legacy_selection(field: str) -> None:
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT
 
 
+def test_provider_config_contract_is_bound_to_exact_finalized_311_coordinates() -> None:
+    selected = dict(verifier.LEGACY_NO_DEFAULT_PROVIDER_V1_COORDINATES)
+    assert verifier.provider_config_contract(selected) == "legacy-no-default-provider-v1"
+    for field in selected:
+        drifted = dict(selected)
+        drifted[field] = 3 if field == "schemaVersion" else "unexpected"
+        assert verifier.provider_config_contract(drifted) is None
+
+
+def test_provider_config_contract_is_not_inferred_from_an_absent_runtime_field() -> None:
+    selected = dict(verifier.LEGACY_NO_DEFAULT_PROVIDER_V1_COORDINATES)
+    selected.pop("expectedDefaultChatProvider")
+    assert verifier.provider_config_contract(selected) is None
+
+
 def test_unrelated_modern_manifest_uses_modern_contract(tmp_path: Path) -> None:
     candidate = json.loads(manifest(tmp_path).read_text())
     assert verifier.identity_contract(candidate) == verifier.MODERN_IDENTITY_CONTRACT

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -75,15 +75,16 @@ else:
         bin_dir / "python3",
         f"""#!/bin/sh
 if [ "${{1:-}}" = {str(REPO_ROOT / 'scripts/dspace_runtime_verifier.py')!r} ]; then
-  printf '%s\\n' "$*" >> {str(runtime_verifier_log)!r}
   environment=""
   previous=""
   for argument in "$@"; do
     [ "$previous" != --environment ] || environment="$argument"
     previous="$argument"
   done
-  printf 'runtime-verifier %s\\n' "$environment" >> {str(tmp_path / 'commands.log')!r}
-  if [ "$environment" = prod ] && [ "${{SUGARKUBE_STUB_PROD_VERIFIER_FAIL:-}}" = 1 ]; then
+  phase="${{2:-unknown}}"
+  printf 'runtime-%s %s\\n' "$phase" "$environment" >> {str(tmp_path / 'commands.log')!r}
+  if [ "$phase" = verify ]; then printf '%s\\n' "$*" >> {str(runtime_verifier_log)!r}; fi
+  if [ "$phase" = verify ] && [ "$environment" = prod ] && [ "${{SUGARKUBE_STUB_PROD_VERIFIER_FAIL:-}}" = 1 ]; then
     exit 1
   fi
   shift
@@ -644,6 +645,9 @@ print(json.dumps(value))
     env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
     env["SUGARKUBE_HELM_ROLLOUT_TIMEOUT"] = "1s"
     env["DSPACE_SMOKE_RUNNER"] = str(smoke)
+    env["SUGARKUBE_DSPACE_PROD_AUTHORIZATION"] = (
+        "dspace:prod:abcdef0123456789abcdef0123456789abcdef01"
+    )
     env["HELM_LOG"] = str(log_path)
     env["RUNTIME_VERIFIER_LOG"] = str(runtime_verifier_log)
     env["KUBECTL_LOG"] = str(tmp_path / "kubectl.log")
@@ -3707,15 +3711,40 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
     commands = (tmp_path / "commands.log").read_text(encoding="utf-8").splitlines()
     ordered_events = [
         next(i for i, line in enumerate(commands) if line == "release-manifest staging-gate"),
-        next(i for i, line in enumerate(commands) if line == "runtime-verifier staging"),
+        next(i for i, line in enumerate(commands) if line == "runtime-capabilities staging"),
+        next(i for i, line in enumerate(commands) if line == "runtime-verify staging"),
+        next(i for i, line in enumerate(commands) if line == "release-manifest production-authorization"),
         next(i for i, line in enumerate(commands) if line == "release-manifest preflight"),
         next(i for i, line in enumerate(commands) if line.startswith("helm template ")),
         next(i for i, line in enumerate(commands) if line == "release-manifest reserve"),
         next(i for i, line in enumerate(commands) if line.startswith("helm upgrade ")),
-        next(i for i, line in enumerate(commands) if line == "runtime-verifier prod"),
+        next(i for i, line in enumerate(commands) if line == "runtime-capabilities prod"),
+        next(i for i, line in enumerate(commands) if line == "runtime-verify prod"),
         next(i for i, line in enumerate(commands) if line == "release-manifest finalize"),
     ]
     assert ordered_events == sorted(ordered_events)
+
+    Path(env["HELM_LOG"]).write_text("", encoding="utf-8")
+    unauthorized_env = env.copy()
+    unauthorized_env.pop("SUGARKUBE_DSPACE_PROD_AUTHORIZATION")
+    unauthorized = _run_just(
+        [
+            "app-promote-prod",
+            "app=dspace",
+            "tag=main-abcdef0",
+            f"config={config}",
+            f"manifest={prod_manifest}",
+            f"staging_evidence={staging_evidence}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+            f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
+            f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            f"evidence={tmp_path / 'unauthorized-evidence.json'}",
+        ],
+        unauthorized_env,
+    )
+    assert unauthorized.returncode != 0
+    assert "production authorization" in unauthorized.stderr
+    assert "upgrade " not in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
 
     Path(env["HELM_LOG"]).write_text("", encoding="utf-8")
     identical = tmp_path / "same-kubeconfig"
@@ -3862,7 +3891,7 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
     assert sum(line.startswith("helm upgrade ") for line in commands) == 1, (
         result.stderr + result.stdout + "\n" + "\n".join(commands)
     )
-    assert "runtime-verifier prod" in commands
+    assert "runtime-verify prod" in commands
     assert "release-manifest finalize" not in commands
     assert not prod_evidence.exists()
     assert Path(str(prod_evidence.resolve()) + ".reservation").exists()

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -589,6 +589,52 @@ def prod_candidate() -> dict[str, object]:
     return value
 
 
+def test_runtime_gate_requires_exact_source_integrity_and_chat_contract() -> None:
+    selected = candidate()
+    assert (
+        manifest.validate_runtime_proof(selected, runtime_proof(), "staging")
+        == runtime_proof()
+    )
+    for change in (
+        {"runtimeSourceRevision": "0" * 40},
+        {"frontendSourceRevision": "0" * 40},
+        {"journeys": [{"name": "/chat", "passed": False}]},
+        {"journeys": [{"name": "/", "passed": True}]},
+        {"journeys": "skipped"},
+    ):
+        with pytest.raises(manifest.ManifestError):
+            manifest.validate_runtime_proof(selected, runtime_proof(**change), "staging")
+
+
+def test_runtime_capabilities_are_exact_and_fail_closed() -> None:
+    report = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": list(manifest.RUNTIME_VERIFIER_CAPABILITIES),
+    }
+    assert manifest.validate_runtime_capabilities(report, "staging") == report
+    for capabilities in (
+        [],
+        list(manifest.RUNTIME_VERIFIER_CAPABILITIES[:-1]),
+        [*manifest.RUNTIME_VERIFIER_CAPABILITIES, "optionalSkip"],
+        "disabled",
+    ):
+        rejected = dict(report, capabilities=capabilities)
+        with pytest.raises(manifest.ManifestError, match="capabilities"):
+            manifest.validate_runtime_capabilities(rejected, "staging")
+
+
+def test_production_authorization_is_explicit_and_revision_bound() -> None:
+    selected = prod_candidate()
+    expected = f"dspace:prod:{selected['sourceRevision']}"
+    manifest.production_authorization(selected, expected)
+    for confirmation in ("", "dspace:prod:" + "0" * 40, "staging-proof"):
+        with pytest.raises(manifest.ManifestError, match="authorization"):
+            manifest.production_authorization(selected, confirmation)
+
+
 def test_staging_gate_returns_revision_despite_approval_metadata_difference() -> None:
     production = prod_candidate()
     production.update(approvedAt="2026-07-27T12:00:00Z", approvedBy="production-approver")


### PR DESCRIPTION
### Motivation

- Make the repository-owned DSPACE runtime verifier a mandatory, fail-closed gate that runs both before any production-mutating command and again after a production rollout, enforcing finalized staging evidence, source-integrity, and a bounded `/chat` smoke.
- Preserve existing schema-v2 semantics, the finalized-evidence contract, and the verifier output contracts while preventing staging evidence or successful staging verification from implying production authorization.
- Keep secrets and private verifier artifacts redacted and follow existing timeout/cancellation and dry-run/report-only conventions.

### Description

- Add strict runtime verifier validation helpers to `scripts/dspace_release_manifest.py` including `validate_runtime_capabilities`, `validate_runtime_proof`, and `production_authorization`, and expose CLI subcommands `runtime-capabilities`, `runtime-gate`, and `production-authorization` to enforce the gates server-side.
- Update the dspace release verification flow in the `justfile` to: first request verifier capabilities, validate them, run the repository verifier to produce a runtime proof, validate that runtime proof against the approved manifest, and require explicit production authorization before any production preflight/mutation steps.
- Extend `scripts/dspace_runtime_verifier.py` to select a provider-config compatibility contract only for an exact reviewed immutable coordinate tuple (`legacy-no-default-provider-v1`) and thread that contract into the smoke runner invocation when present, preventing inference from absent fields.
- Add and adapt deterministic tests: new checks in `tests/test_release_manifest.py` and updates to `tests/test_generic_app_just_recipes.py` and `tests/test_dspace_runtime_verifier.py` to assert fail-closed behavior for missing/malformed capabilities, missing/failed source-integrity, missing/failed bounded `/chat`, pre/post gate ordering, distinct staging vs prod coordinates, explicit production authorization, and no automatic rollback/retry on post-rollout verification failures.
- Test-only harness adjustments: the test stub for the runtime verifier now supports a `capabilities` command and the test environment provides `SUGARKUBE_DSPACE_PROD_AUTHORIZATION` to exercise the authorization path.

### Testing

- Focused unit/runbook checks (selected tests): `python3 -m pytest -q tests/test_release_manifest.py::test_runtime_gate_requires_exact_source_integrity_and_chat_contract tests/test_release_manifest.py::test_runtime_capabilities_are_exact_and_fail_closed tests/test_release_manifest.py::test_production_authorization_is_explicit_and_revision_bound tests/test_dspace_runtime_verifier.py::test_provider_config_contract_is_bound_to_exact_finalized_311_coordinates tests/test_dspace_runtime_verifier.py::test_provider_config_contract_is_not_inferred_from_an_absent_runtime_field tests/test_generic_app_just_recipes.py::test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates tests/test_generic_app_just_recipes.py::test_dspace_prod_verifier_failure_preserves_post_mutation_reservation` — all passed (7 passed).
- Larger targeted test run: `python3 -m pytest -q tests/test_release_manifest.py tests/test_dspace_runtime_verifier.py tests/test_generic_app_just_recipes.py -k 'dspace_promote_prod_routes_sparse_named_arguments_through_both_gates or dspace_prod_staging_gate_failures_stop_before_production_work or dspace_prod_verifier_failure_preserves_post_mutation_reservation or dspace_production_wrappers_share_staging_evidence_guard or runtime or provider_config or production_authorization or staging_gate'` — passed for the exercised cases.
- Repo checks: `linkchecker --no-warnings README.md docs/` — succeeded (211 links checked, 0 errors); `pre-commit run --all-files` initially unavailable then run and failed on unrelated, pre-existing YAML/flake8 issues (these are repository-wide style/format findings and were not introduced by this change); `pyspelling -c .spellcheck.yaml` could not complete due to missing `aspell` in the environment.
- Dry-run and no-cluster assurances: tests use deterministic stubs/fixtures and the harness never contacts or mutates a real cluster during verification runs.

Commands and outcomes observed (representative):
- `python3 -m pytest -q <focused tests>` — returned `7 passed` for the focused set.
- `python3 -m pytest -q tests/test_release_manifest.py tests/test_dspace_runtime_verifier.py tests/test_generic_app_just_recipes.py -k '<selectors>'` — targeted tests passed.
- `linkchecker --no-warnings README.md docs/` — success (0 errors).
- `pre-commit run --all-files` — failed due to existing repository-wide YAML and flake8 issues unrelated to this change.
- Attempts to push/create a remote PR in this environment failed due to missing GitHub credentials / SSH/network restrictions.

Residual notes and follow-ups

- The change set is narrowly scoped to the DSPACE promotion gate and tests covering the required behavior; it intentionally preserves existing verification schemas and redaction behavior.
- CI/pre-commit in this environment surfaced pre-existing repository-wide linter/format issues; those are unrelated and were not introduced by this PR.
- I could not open a draft PR on GitHub from this environment due to credential/SSH/network limits; the branch created locally is `codex/dspace-runtime-promotion-gate` and is ready to push from a credentialed machine. The branch codifies the mandatory pre/post runtime verifier gate and explicit production authorization required by issue #2328.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85774b9378832f9ccc0c96a0d9134c)