### PR TITLE
Make DSPACE runtime verifier mandatory pre/post production promotion (fail-closed)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1940,6 +1940,13 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       just --justfile "{{ justfile_directory() }}/justfile" kubeconfig-env "${selected_env}"
       kubeconfig_path="${KUBECONFIG}"
     fi
+    verifier_args=( \
+      --environment "${selected_env}" --release dspace --namespace dspace \
+      --manifest "${manifest_path}" --smoke-runner "${smoke_path}" \
+      --kubeconfig "${kubeconfig_path}" )
+    [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
+    capabilities="$("{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities "${verifier_args[@]}")"
+    python3 -c 'import json,sys; expected={"schemaVersion":1,"environment":sys.argv[1],"release":"dspace","namespace":"dspace","capabilities":["applicationVersion","runtimeSourceRevision","frontendSourceRevision","defaultProvider","publicJourneys"]}; value=json.loads(sys.stdin.read()); value == expected or sys.exit("ERROR: DSPACE verification failed (runtime verifier capabilities)")' "${selected_env}" <<<"${capabilities}"
     just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env "${selected_env}" "${kubeconfig_path}" >/dev/null
     if [ -n "${expected_revision}" ]; then
       live_revision="$(helm --kubeconfig "${kubeconfig_path}" status dspace --namespace dspace -o json | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
@@ -1948,22 +1955,17 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
         exit 2
       fi
     fi
-    verifier_args=( \
-      --environment "${selected_env}" --release dspace --namespace dspace \
-      --manifest "${manifest_path}" --smoke-runner "${smoke_path}" \
-      --kubeconfig "${kubeconfig_path}" )
-    [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
     [ -z "${expected_revision}" ] || verifier_args+=(--expected-helm-revision "${expected_revision}")
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify "${verifier_args[@]}"
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input production_authorization)
+    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig authorization)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2011,6 +2013,12 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify \
           staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" \
           "${staging_kubeconfig_path}" "${staging_revision}"
+        staging_source_revision="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sourceRevision"])' "${staging_record}")"
+        expected_authorization="dspace:prod:${staging_source_revision}"
+        if [ "${production_authorization}" != "${expected_authorization}" ]; then
+          echo "ERROR: production authorization must exactly equal ${expected_authorization}." >&2
+          exit 2
+        fi
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
@@ -2074,13 +2082,13 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input production_authorization)
+    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig authorization)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2113,6 +2121,12 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
         if [ "${staging_kubeconfig_path}" = "${kubeconfig_input}" ]; then echo "ERROR: staging and production kubeconfigs must be distinct." >&2; exit 2; fi
         just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env staging "${staging_kubeconfig_path}" >/dev/null
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" "${staging_kubeconfig_path}" "${staging_revision}"
+        staging_source_revision="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sourceRevision"])' "${staging_record}")"
+        expected_authorization="dspace:prod:${staging_source_revision}"
+        if [ "${production_authorization}" != "${expected_authorization}" ]; then
+          echo "ERROR: production authorization must exactly equal ${expected_authorization}." >&2
+          exit 2
+        fi
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
@@ -2166,13 +2180,13 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input authorization_input)
+    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig authorization)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2195,7 +2209,7 @@ app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       "${SUGARKUBE_APP}" prod "${SUGARKUBE_TAG}" "${SUGARKUBE_CONFIG_PATH}" \
       "${manifest_input}" "${evidence_input}" "${staging_evidence_input}" "${smoke_runner_input}" \
-      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}"
+      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}" "${authorization_input}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
 app-chart-status app env='staging' config='':
@@ -2320,13 +2334,13 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9)
-    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    values=('' '' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9 10)
+    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig authorization)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2335,15 +2349,15 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence=
       if [[ ${argument} == "${prefixes[prefix_index]}="* ]]; then values[${destinations[prefix_index]}]=${argument#*=}; break; fi
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace "${values[0]}" "${values[1]}" \
-      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}"
+      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}" "${values[10]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig)
+    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    values=('' '' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig authorization)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2353,17 +2367,17 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace prod "${values[0]}" \
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env" "${values[1]}" "${values[2]}" \
-      "${values[3]}" "${values[4]}" "${values[5]}" '' "${values[6]}"
+      "${values[3]}" "${values[4]}" "${values[5]}" '' "${values[6]}" "${values[7]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig)
+    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    values=('' '' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig authorization)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2379,16 +2393,16 @@ dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke
       --require-tag)"
     eval "${config_exports}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy prod "${SUGARKUBE_TAG}" \
-      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}"
+      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}" "${values[7]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='' authorization='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9)
-    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(authorization) }})
+    values=('' '' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9 10)
+    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig authorization)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2397,7 +2411,7 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidenc
       if [[ ${argument} == "${prefixes[prefix_index]}="* ]]; then values[${destinations[prefix_index]}]=${argument#*=}; break; fi
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-redeploy dspace "${values[0]}" "${values[1]}" \
-      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}"
+      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}" "${values[10]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3391,8 +3391,11 @@ def test_dspace_release_verify_ignores_runtime_verifier_override(
     assert result.returncode == 0, result.stderr + result.stdout
     assert not marker.exists()
     invocations = Path(env["RUNTIME_VERIFIER_LOG"]).read_text(encoding="utf-8").splitlines()
-    assert len(invocations) == 1
+    assert len(invocations) == 2
     assert invocations[0].startswith(
+        f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} capabilities "
+    )
+    assert invocations[1].startswith(
         f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} verify "
     )
 
@@ -3460,10 +3463,12 @@ def test_dspace_release_verify_normalizes_public_arguments(
     result = _run_just(["dspace-release-verify", *arguments], generic_app_stub_env)
 
     assert result.returncode == 0, result.stderr + result.stdout
-    invocation = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
+    invocations = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
         encoding="utf-8"
-    )
-    argv = invocation.split()
+    ).splitlines()
+    assert len(invocations) == 2
+    assert " capabilities " in f" {invocations[0]} "
+    argv = invocations[1].split()
     required = {
         "--environment": values["env"],
         "--manifest": values["manifest"],
@@ -3619,9 +3624,10 @@ def test_dspace_staging_wrappers_route_sparse_named_arguments_once(
     verifier_lines = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
         encoding="utf-8"
     ).splitlines()
-    assert len(verifier_lines) == 1
-    assert verifier_lines[0].count(f"--manifest {manifest}") == 1
-    assert verifier_lines[0].count(
+    assert len(verifier_lines) == 2
+    assert " capabilities " in f" {verifier_lines[0]} "
+    assert verifier_lines[1].count(f"--manifest {manifest}") == 1
+    assert verifier_lines[1].count(
         f"--smoke-runner {generic_app_stub_env['DSPACE_SMOKE_RUNNER']}"
     ) == 1
 
@@ -3690,17 +3696,20 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
             f"evidence={prod_evidence}",
+            "authorization=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
     verifier_lines = runtime_log.read_text(encoding="utf-8").splitlines()
-    assert len(verifier_lines) == 2
-    assert "--environment staging" in verifier_lines[0]
-    assert f"--manifest {staging_evidence}" in verifier_lines[0]
-    assert "--environment prod" in verifier_lines[1]
-    assert f"--manifest {prod_manifest}" in verifier_lines[1]
+    assert len(verifier_lines) == 4
+    assert " capabilities " in f" {verifier_lines[0]} "
+    assert "--environment staging" in verifier_lines[1]
+    assert f"--manifest {staging_evidence}" in verifier_lines[1]
+    assert " capabilities " in f" {verifier_lines[2]} "
+    assert "--environment prod" in verifier_lines[3]
+    assert f"--manifest {prod_manifest}" in verifier_lines[3]
     assert json.loads(prod_evidence.read_text(encoding="utf-8"))["recordType"] == "final"
     helm_lines = Path(env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
     assert sum(line.startswith("upgrade ") for line in helm_lines) == 1
@@ -3718,6 +3727,25 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
     assert ordered_events == sorted(ordered_events)
 
     Path(env["HELM_LOG"]).write_text("", encoding="utf-8")
+    unauthorized = _run_just(
+        [
+            "app-promote-prod",
+            "app=dspace",
+            "tag=main-abcdef0",
+            f"config={config}",
+            f"manifest={prod_manifest}",
+            f"staging_evidence={staging_evidence}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+            f"kubeconfig={tmp_path / 'unauthorized-prod-kubeconfig'}",
+            f"staging_kubeconfig={tmp_path / 'unauthorized-staging-kubeconfig'}",
+            f"evidence={tmp_path / 'unauthorized-evidence.json'}",
+        ],
+        env,
+    )
+    assert unauthorized.returncode != 0
+    assert "production authorization must exactly equal" in unauthorized.stderr
+    assert "upgrade " not in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+
     identical = tmp_path / "same-kubeconfig"
     rejected = _run_just(
         [
@@ -3853,6 +3881,7 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
             f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            "authorization=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )


### PR DESCRIPTION
### Motivation

- Ensure production promotion for DSPACE cannot proceed without repository-owned, finalized runtime evidence and a bounded `/chat` smoke, and ensure staging proof never impersonates production authorization.
- Preserve existing evidence schema-v2 semantics, verifier capability/output contracts, and the post-rollout finalization flow while enforcing a fail-closed gate around any production mutation.

### Description

- Call the repository verifier's `capabilities` command and assert its expected contract before running any cluster-bound `verify` step, making capability negotiation fail-closed when absent or malformed and preserving the `verify` invocation and its JSON output contract. 
- Extend DSPACE deploy/promote wrappers to accept an explicit `authorization` input, derive the expected production authorization from the validated staging evidence `sourceRevision`, and reject any production mutation if the supplied `authorization` does not exactly match that derived token. 
- Thread the new `authorization` through `app-deploy` -> `app-promote-prod` -> DSPACE-specific wrappers (deploy/redeploy/promote) so production authorization is required and distinct from staging proof; keep staging and production verifier coordinates and invocations separate. 
- Update deterministic unit/integration tests to assert capability negotiation, enforce pre-mutation verifier execution, validate post-rollout verifier execution against production coordinates, and check fail-closed authorization and non-retry-on-post-verifier-failure behavior.

### Testing

- Ran the DSPACE verifier unit suite with `python3 -m pytest -q tests/test_dspace_runtime_verifier.py`, which completed successfully (`200 passed`).
- Ran focused promotion tests with `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k "dspace_release_verify or dspace_promote_prod_routes or dspace_prod_staging_gate or dspace_prod_verifier_failure or dspace_production_wrappers_share_staging_evidence_guard or dspace_staging_wrappers_route_sparse"`, which exercised the new pre/post verifier phases and authorization checks and passed in the final run. 
- Executed `pre-commit run --all-files` and `pyspelling -c .spellcheck.yaml` as repo checks; `pre-commit` surfaced pre-existing unrelated YAML and lint warnings (check-yaml / flake8 entries) and `pyspelling` failed due to missing `aspell` in the environment, so those repository-wide hooks were not fully green here (these are unrelated to the changes in scope). 
- All added/modified deterministic tests that exercise the new gating logic passed in this environment; no live cluster access was used and all runtime verifier behavior was exercised using the repository fixtures and deterministic stubs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85774365dc832fac474bdbf5799107)