### PR TITLE
Require DSPACE runtime pre/post verification and explicit production authorization (Closes #2328)

### DIFF
--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -410,7 +410,8 @@ just app-deploy app=dspace env=staging tag=main-REPLACE_SHORTSHA \
 
 Production promotion additionally requires finalized staging evidence. Before production render,
 reservation, or mutation, Sugarkube compares immutable coordinates, checks the recorded staging
-Helm revision remains live, and reruns complete staging verification:
+Helm revision remains live, reruns complete staging verification, and separately requires an exact
+authorization bound to the production candidate's full source revision:
 
 ```bash
 just app-promote-prod \
@@ -420,7 +421,8 @@ just app-promote-prod \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$PROD_KUBECONFIG" \
-  staging_kubeconfig="$STAGING_KUBECONFIG"
+  staging_kubeconfig="$STAGING_KUBECONFIG" \
+  confirm="dspace:prod:<40-character-application-SHA>"
 ```
 
 If staging used a nondefault app config, pass that distinct path as
@@ -621,7 +623,8 @@ just app-promote-prod app=dspace tag="$APP_TAG" \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
   kubeconfig="$PROD_KUBECONFIG" \
-  staging_kubeconfig="$STAGING_KUBECONFIG"
+  staging_kubeconfig="$STAGING_KUBECONFIG" \
+  confirm="dspace:prod:${TARGET_SHA}"
 EVIDENCE=$(python3 scripts/dspace_release_manifest.py evidence-path \
   --manifest deployment-candidates/dspace/prod.json)
 git add "$EVIDENCE"
@@ -744,7 +747,8 @@ just app-promote-prod app=dspace tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
-  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG"
+  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG" \
+  confirm="dspace:prod:${TARGET_SHA}"
 ```
 
 Compatibility shim:
@@ -754,7 +758,8 @@ just dspace-oci-promote-prod tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
   smoke_runner="$DSPACE_SMOKE_RUNNER" \
-  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG"
+  kubeconfig="$PROD_KUBECONFIG" staging_kubeconfig="$STAGING_KUBECONFIG" \
+  confirm="dspace:prod:${TARGET_SHA}"
 ```
 
 ## Verify production

--- a/docs/apps/dspace.md
+++ b/docs/apps/dspace.md
@@ -618,6 +618,7 @@ python3 scripts/dspace_release_manifest.py candidate \
   --output deployment-candidates/dspace/prod.json \
   --environment prod --provider token-place \
   --approved-at 2026-07-26T13:00:00Z --approved-by '<operator-or-review-record>'
+TARGET_SHA=$(jq -er '.sourceRevision' deployment-candidates/dspace/prod.json)
 just app-promote-prod app=dspace tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
@@ -743,6 +744,7 @@ For staging, the browser smoke must show DSPACE calling `https://staging.token.p
 This configuration change does not promote or mutate production. Promote only after staging sign-off. Prefer the generic command; it uses the prod values chain, resolves chart `3.0.3` from `docs/apps/dspace.prod.version`, and can read `docs/apps/dspace.prod.tag` (`main-1a31a56`) when `tag=` is omitted.
 
 ```bash
+TARGET_SHA=$(jq -er '.sourceRevision' deployment-candidates/dspace/prod.json)
 just app-promote-prod app=dspace tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \
@@ -754,6 +756,7 @@ just app-promote-prod app=dspace tag="$APP_TAG" \
 Compatibility shim:
 
 ```bash
+TARGET_SHA=$(jq -er '.sourceRevision' deployment-candidates/dspace/prod.json)
 just dspace-oci-promote-prod tag="$APP_TAG" \
   manifest=deployment-candidates/dspace/prod.json \
   staging_evidence=deployment-evidence/dspace/staging/<finalized-record>.json \

--- a/justfile
+++ b/justfile
@@ -1954,13 +1954,7 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       --kubeconfig "${kubeconfig_path}" )
     [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
     umask 077
-    runtime_proof="$(mktemp)"
-    trap 'rm -f "${capability_proof}" "${runtime_proof}"' EXIT
-    timeout 360 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
-      "${verifier_args[@]}" >"${runtime_proof}"
-    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" verifier-proof \
-      --input "${runtime_proof}" --manifest "${manifest_path}" \
-      --environment "${selected_env}" --release dspace --namespace dspace
+    capability_proof="$(mktemp)"
     runtime_proof="$(mktemp)"
     trap 'rm -f "${capability_proof}" "${runtime_proof}"' EXIT
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities \

--- a/justfile
+++ b/justfile
@@ -1953,17 +1953,24 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       --manifest "${manifest_path}" --smoke-runner "${smoke_path}" \
       --kubeconfig "${kubeconfig_path}" )
     [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
+    capability_proof="$(mktemp)"
+    trap 'rm -f "${capability_proof}"' EXIT
+    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities \
+      "${verifier_args[@]}" >"${capability_proof}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" verifier-capabilities \
+      --input "${capability_proof}" --environment "${selected_env}" \
+      --release dspace --namespace dspace
     [ -z "${expected_revision}" ] || verifier_args+=(--expected-helm-revision "${expected_revision}")
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify "${verifier_args[@]}"
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
-app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input production_confirmation)
+    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2011,6 +2018,8 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify \
           staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" \
           "${staging_kubeconfig_path}" "${staging_revision}"
+        python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" authorize-production \
+          --manifest "${release_manifest}" --confirm "${production_confirmation}"
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then
@@ -2074,13 +2083,13 @@ app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_ev
     fi
 
 # Generic upgrade-only app redeploy backed by app config files.
-app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(env) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    destinations=(app_input env_input tag_input config_input release_manifest evidence_output staging_record runtime_smoke kubeconfig_input staging_config_input staging_kubeconfig_input production_confirmation)
+    prefixes=(app env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2113,6 +2122,8 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
         if [ "${staging_kubeconfig_path}" = "${kubeconfig_input}" ]; then echo "ERROR: staging and production kubeconfigs must be distinct." >&2; exit 2; fi
         just --justfile "{{ justfile_directory() }}/justfile" assert-cluster-env staging "${staging_kubeconfig_path}" >/dev/null
         just --justfile "{{ justfile_directory() }}/justfile" dspace-release-verify staging "${staging_record}" "${runtime_smoke}" "${staging_config_input}" "${staging_kubeconfig_path}" "${staging_revision}"
+        python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" authorize-production \
+          --manifest "${release_manifest}" --confirm "${production_confirmation}"
       fi
       chart_version="${SUGARKUBE_VERSION:-}"
       if [ -z "${chart_version}" ]; then chart_version="$(sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${SUGARKUBE_VERSION_FILE}" | head -n1)"; fi
@@ -2166,13 +2177,13 @@ app-redeploy app env='staging' tag='' config='' manifest='' evidence='' staging_
     fi
 
 # Promote an app to prod with an explicit immutable tag, or the configured prod tag file.
-app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='':
+app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input)
-    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(app) }} {{ quote(tag) }} {{ quote(config) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    destinations=(app_input tag_input config_input manifest_input evidence_input staging_evidence_input smoke_runner_input kubeconfig_input staging_config_input staging_kubeconfig_input production_confirmation)
+    prefixes=(app tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for destination in "${destinations[@]}"; do printf -v "${destination}" '%s' ''; done
     for index in "${!inputs[@]}"; do
       argument=${inputs[index]}; named=false
@@ -2195,7 +2206,7 @@ app-promote-prod app tag='' config='' manifest='' evidence='' staging_evidence='
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy \
       "${SUGARKUBE_APP}" prod "${SUGARKUBE_TAG}" "${SUGARKUBE_CONFIG_PATH}" \
       "${manifest_input}" "${evidence_input}" "${staging_evidence_input}" "${smoke_runner_input}" \
-      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}"
+      "${kubeconfig_input}" "${staging_config_input}" "${staging_kubeconfig_input}" "${production_confirmation}"
 
 # Show the pinned chart version and whether a newer semver chart appears published.
 app-chart-status app env='staging' config='':
@@ -2320,13 +2331,13 @@ app-cors-verify app env='staging' config='' origin='https://cors-smoke.invalid' 
 #
 
 # Use this for steady-state release validation flows where explicit image pinning matters.
-dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':
+dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9)
-    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9 10)
+    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2335,15 +2346,15 @@ dspace-oci-deploy env='staging' tag='' manifest='' evidence='' staging_evidence=
       if [[ ${argument} == "${prefixes[prefix_index]}="* ]]; then values[${destinations[prefix_index]}]=${argument#*=}; break; fi
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace "${values[0]}" "${values[1]}" \
-      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}"
+      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}" "${values[10]}"
 
 # Use this for optional canary/smoke testing before or alongside apex promotion workflows.
-dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
+dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig)
+    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2353,17 +2364,17 @@ dspace-oci-deploy-prod-subdomain tag='' manifest='' evidence='' staging_evidence
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-deploy dspace prod "${values[0]}" \
       "{{ justfile_directory() }}/docs/examples/apps/dspace-prod-subdomain.env" "${values[1]}" "${values[2]}" \
-      "${values[3]}" "${values[4]}" "${values[5]}" '' "${values[6]}"
+      "${values[3]}" "${values[4]}" "${values[5]}" '' "${values[6]}" "${values[7]}"
 
 # Promote dspace to production apex (democratized.space) using immutable tags.
 
 # If tag is omitted, this reads the pinned value from docs/apps/dspace.prod.tag.
-dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='':
+dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig)
+    inputs=({{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(kubeconfig) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' ''); prefixes=(tag manifest evidence staging_evidence smoke_runner kubeconfig staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2379,16 +2390,16 @@ dspace-oci-promote-prod tag='' manifest='' evidence='' staging_evidence='' smoke
       --require-tag)"
     eval "${config_exports}"
     just --justfile "{{ justfile_directory() }}/justfile" dspace-oci-deploy prod "${SUGARKUBE_TAG}" \
-      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}"
+      "${values[1]}" "${values[2]}" "${values[3]}" "${values[4]}" '' "${values[5]}" '' "${values[6]}" "${values[7]}"
 
 # Fast redeploy of dspace from GHCR (emergency mutable-tag refresh).
-dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='':
+dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidence='' smoke_runner='' config='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':
     #!/usr/bin/env bash
     set -Eeuo pipefail
 
-    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }})
-    values=('' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9)
-    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig)
+    inputs=({{ quote(env) }} {{ quote(tag) }} {{ quote(manifest) }} {{ quote(evidence) }} {{ quote(staging_evidence) }} {{ quote(smoke_runner) }} {{ quote(config) }} {{ quote(kubeconfig) }} {{ quote(staging_config) }} {{ quote(staging_kubeconfig) }} {{ quote(confirm) }})
+    values=('' '' '' '' '' '' '' '' '' '' ''); destinations=(0 1 6 2 3 4 5 7 8 9 10)
+    prefixes=(env tag config manifest evidence staging_evidence smoke_runner kubeconfig staging_config staging_kubeconfig confirm)
     for index in "${!inputs[@]}"; do
       named=false; for prefix in "${prefixes[@]}"; do [[ ${inputs[index]} == "${prefix}="* ]] && named=true; done
       ${named} || values[index]=${inputs[index]}
@@ -2397,7 +2408,7 @@ dspace-oci-redeploy env='staging' tag='' manifest='' evidence='' staging_evidenc
       if [[ ${argument} == "${prefixes[prefix_index]}="* ]]; then values[${destinations[prefix_index]}]=${argument#*=}; break; fi
     done; done
     just --justfile "{{ justfile_directory() }}/justfile" app-redeploy dspace "${values[0]}" "${values[1]}" \
-      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}"
+      "${values[6]}" "${values[2]}" "${values[3]}" "${values[4]}" "${values[5]}" "${values[7]}" "${values[8]}" "${values[9]}" "${values[10]}"
 
 # Dump dspace and Traefik logs for debugging HTTP 500s.
 dspace-debug-logs namespace='dspace':

--- a/justfile
+++ b/justfile
@@ -1953,15 +1953,21 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       --manifest "${manifest_path}" --smoke-runner "${smoke_path}" \
       --kubeconfig "${kubeconfig_path}" )
     [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
+    umask 077
     capability_proof="$(mktemp)"
-    trap 'rm -f "${capability_proof}"' EXIT
+    runtime_proof="$(mktemp)"
+    trap 'rm -f "${capability_proof}" "${runtime_proof}"' EXIT
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities \
       "${verifier_args[@]}" >"${capability_proof}"
     python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" verifier-capabilities \
       --input "${capability_proof}" --environment "${selected_env}" \
       --release dspace --namespace dspace
     [ -z "${expected_revision}" ] || verifier_args+=(--expected-helm-revision "${expected_revision}")
-    "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify "${verifier_args[@]}"
+    timeout 360 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+      "${verifier_args[@]}" >"${runtime_proof}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" verifier-proof \
+      --input "${runtime_proof}" --manifest "${manifest_path}" \
+      --environment "${selected_env}" --release dspace --namespace dspace
 
 # Generic immutable-tag app deploy backed by docs/examples/apps/*.env or local app configs.
 app-deploy app env='staging' tag='' config='' manifest='' evidence='' staging_evidence='' smoke_runner='' kubeconfig='' staging_config='' staging_kubeconfig='' confirm='':

--- a/justfile
+++ b/justfile
@@ -1954,7 +1954,13 @@ dspace-release-verify env manifest smoke_runner config='' kubeconfig='' expected
       --kubeconfig "${kubeconfig_path}" )
     [ -z "${config_path}" ] || verifier_args+=(--config "${config_path}")
     umask 077
-    capability_proof="$(mktemp)"
+    runtime_proof="$(mktemp)"
+    trap 'rm -f "${capability_proof}" "${runtime_proof}"' EXIT
+    timeout 360 "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" verify \
+      "${verifier_args[@]}" >"${runtime_proof}"
+    python3 "{{ justfile_directory() }}/scripts/dspace_release_manifest.py" verifier-proof \
+      --input "${runtime_proof}" --manifest "${manifest_path}" \
+      --environment "${selected_env}" --release dspace --namespace dspace
     runtime_proof="$(mktemp)"
     trap 'rm -f "${capability_proof}" "${runtime_proof}"' EXIT
     "{{ justfile_directory() }}/scripts/dspace_runtime_verifier.py" capabilities \

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -55,13 +55,6 @@ VERIFIER_CAPABILITIES_V1 = (
     "defaultProvider",
     "publicJourneys",
 )
-VERIFIER_CAPABILITIES_V1 = (
-    "applicationVersion",
-    "runtimeSourceRevision",
-    "frontendSourceRevision",
-    "defaultProvider",
-    "publicJourneys",
-)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SEMVER_RE = re.compile(
@@ -230,51 +223,6 @@ def required_final_checks(value: dict[str, Any]) -> set[str]:
     return checks
 
 
-def validate_runtime_verification(
-    proof: object,
-    manifest: dict[str, Any],
-    environment: str,
-    release: str = "dspace",
-    namespace: str = "dspace",
-) -> dict[str, Any]:
-    """Validate and return a standalone verifier proof without trusting its output."""
-    if not isinstance(proof, dict) or set(proof) != set(RUNTIME_VERIFICATION_FIELDS):
-        raise ManifestError("runtimeVerification has an incompatible verifier schema")
-    if type(proof["schemaVersion"]) is not int or proof["schemaVersion"] != 1:
-        raise ManifestError("runtimeVerification schemaVersion must be integer 1")
-    expected = {
-        "environment": environment,
-        "release": release,
-        "namespace": namespace,
-        "applicationVersion": manifest["applicationVersion"],
-        "runtimeSourceRevision": manifest["sourceRevision"],
-        "frontendSourceRevision": manifest["sourceRevision"],
-        "defaultProvider": manifest["expectedDefaultChatProvider"],
-    }
-    if manifest.get("environment") != environment or any(
-        proof[field] != expected_value for field, expected_value in expected.items()
-    ):
-        raise ManifestError("runtimeVerification does not match approved release")
-    journeys = proof["journeys"]
-    if not isinstance(journeys, list) or not journeys:
-        raise ManifestError("runtimeVerification lacks successful bounded journeys")
-    journey_names: set[str] = set()
-    for item in journeys:
-        if (
-            not isinstance(item, dict)
-            or set(item) != {"name", "passed"}
-            or not isinstance(item["name"], str)
-            or not PUBLIC_PATH_RE.fullmatch(item["name"])
-            or item["name"] in journey_names
-            or item["passed"] is not True
-        ):
-            raise ManifestError("runtimeVerification lacks successful bounded journeys")
-        journey_names.add(item["name"])
-    if "/chat" not in journey_names:
-        raise ManifestError("runtimeVerification lacks successful bounded journeys")
-    return proof
-
-
 def _validate_upstream(value: dict[str, Any]) -> None:
     _upstream_fields(value)
     if value["app"] != "dspace":
@@ -330,7 +278,41 @@ def validate_runtime_verification(
     }
     if manifest.get("environment") != environment or any(
         proof[field] != expected_value for field, expected_value in expected.items()
-            validate_runtime_verification(value["runtimeVerification"], value, value["environment"])
+    ):
+        raise ManifestError("runtimeVerification does not match approved release")
+    journeys = proof["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    journey_names: set[str] = set()
+    for item in journeys:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"name", "passed"}
+            or not isinstance(item["name"], str)
+            or not PUBLIC_PATH_RE.fullmatch(item["name"])
+            or item["name"] in journey_names
+            or item["passed"] is not True
+        ):
+            raise ManifestError("runtimeVerification lacks successful bounded journeys")
+        journey_names.add(item["name"])
+    if "/chat" not in journey_names:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    return proof
+
+
+def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
+    record_type = value.get("recordType")
+    if finalized is None:
+        finalized = record_type == "final"
+    expected = _final_fields(value) if finalized else candidate_fields(value)
+    if finalized and "runtimeVerification" in value:
+        expected += OPTIONAL_FINAL_FIELDS
+    _exact_fields(value, expected)
+    _validate_upstream(value)
+    if record_type != ("final" if finalized else "candidate"):
+        raise ManifestError("recordType does not match the requested record kind")
+    if value["environment"] not in {"staging", "prod"}:
+        raise ManifestError("environment must be staging or prod")
     if value["expectedDefaultChatProvider"] not in PROVIDERS:
         raise ManifestError("expectedDefaultChatProvider must be token-place or openai")
     if not isinstance(value["approvedBy"], str) or not value["approvedBy"].strip():
@@ -1097,14 +1079,19 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         raise ManifestError("staging gate requires prod candidate and staging final evidence")
     coordinates = (
         "applicationVersion",
-    if capabilities != list(VERIFIER_CAPABILITIES_V1):
-        raise ManifestError("runtime verifier capabilities do not match the ordered v1 contract")
-    proof = sub.add_parser("verifier-proof")
-    proof.add_argument("--input", type=Path, required=True)
-    proof.add_argument("--manifest", type=Path, required=True)
-    proof.add_argument("--environment", required=True)
-    proof.add_argument("--release", required=True)
-    proof.add_argument("--namespace", required=True)
+        "sourceRevision",
+        "chartSourceRevision",
+        "imageTag",
+        "imageDigest",
+        "chartVersion",
+        "chartDigest",
+        "semanticTag",
+        "expectedDefaultChatProvider",
+    )
+    if any(
+        (
+            chart_source_revision(candidate_value)
+            if field == "chartSourceRevision"
             else candidate_value[field]
         )
         != (
@@ -1387,16 +1374,6 @@ def main(argv: list[str] | None = None) -> int:
                 source,
                 helm,
                 pods,
-        elif args.command == "verifier-proof":
-            selected_manifest = validate(_object(args.manifest))
-            validated_proof = validate_runtime_verification(
-                _object(args.input),
-                selected_manifest,
-                args.environment,
-                args.release,
-                args.namespace,
-            )
-            sys.stdout.write(_canonical(validated_proof))
                 workloads,
                 results,
                 environment=args.environment,

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -48,6 +48,13 @@ FINAL_SUFFIX = (
 CANDIDATE_FIELDS = UPSTREAM_FIELDS_V1 + CANDIDATE_SUFFIX
 FINAL_FIELDS = CANDIDATE_FIELDS + FINAL_SUFFIX
 OPTIONAL_FINAL_FIELDS = ("runtimeVerification",)
+VERIFIER_CAPABILITIES_V1 = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SEMVER_RE = re.compile(
@@ -248,6 +255,51 @@ def _validate_upstream(value: dict[str, Any]) -> None:
         raise ManifestError("semanticTag must equal v<applicationVersion>")
 
 
+def validate_runtime_verification(
+    proof: object,
+    manifest: dict[str, Any],
+    environment: str,
+    release: str = "dspace",
+    namespace: str = "dspace",
+) -> dict[str, Any]:
+    """Validate and return a standalone verifier proof without trusting its output."""
+    if not isinstance(proof, dict) or set(proof) != set(RUNTIME_VERIFICATION_FIELDS):
+        raise ManifestError("runtimeVerification has an incompatible verifier schema")
+    if type(proof["schemaVersion"]) is not int or proof["schemaVersion"] != 1:
+        raise ManifestError("runtimeVerification schemaVersion must be integer 1")
+    expected = {
+        "environment": environment,
+        "release": release,
+        "namespace": namespace,
+        "applicationVersion": manifest["applicationVersion"],
+        "runtimeSourceRevision": manifest["sourceRevision"],
+        "frontendSourceRevision": manifest["sourceRevision"],
+        "defaultProvider": manifest["expectedDefaultChatProvider"],
+    }
+    if manifest.get("environment") != environment or any(
+        proof[field] != expected_value for field, expected_value in expected.items()
+    ):
+        raise ManifestError("runtimeVerification does not match approved release")
+    journeys = proof["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    journey_names: set[str] = set()
+    for item in journeys:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"name", "passed"}
+            or not isinstance(item["name"], str)
+            or not PUBLIC_PATH_RE.fullmatch(item["name"])
+            or item["name"] in journey_names
+            or item["passed"] is not True
+        ):
+            raise ManifestError("runtimeVerification lacks successful bounded journeys")
+        journey_names.add(item["name"])
+    if "/chat" not in journey_names:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    return proof
+
+
 def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
     record_type = value.get("recordType")
     if finalized is None:
@@ -303,41 +355,7 @@ def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, 
         if value["runtimeSourceRevisionMethod"] != RUNTIME_METHOD:
             raise ManifestError(f"runtimeSourceRevisionMethod must be {RUNTIME_METHOD}")
         if "runtimeVerification" in value:
-            proof = value["runtimeVerification"]
-            if not isinstance(proof, dict) or set(proof) != set(RUNTIME_VERIFICATION_FIELDS):
-                raise ManifestError("runtimeVerification has an incompatible verifier schema")
-            if type(proof["schemaVersion"]) is not int or proof["schemaVersion"] != 1:
-                raise ManifestError("runtimeVerification schemaVersion must be integer 1")
-            if any(
-                proof[field] != expected_value
-                for field, expected_value in {
-                    "environment": value["environment"],
-                    "release": "dspace",
-                    "namespace": "dspace",
-                    "applicationVersion": value["applicationVersion"],
-                    "runtimeSourceRevision": value["sourceRevision"],
-                    "frontendSourceRevision": value["sourceRevision"],
-                    "defaultProvider": value["expectedDefaultChatProvider"],
-                }.items()
-            ):
-                raise ManifestError("runtimeVerification does not match approved release")
-            journeys = proof["journeys"]
-            if not isinstance(journeys, list) or not journeys:
-                raise ManifestError("runtimeVerification lacks successful bounded journeys")
-            journey_names: set[str] = set()
-            for item in journeys:
-                if (
-                    not isinstance(item, dict)
-                    or set(item) != {"name", "passed"}
-                    or not isinstance(item["name"], str)
-                    or not PUBLIC_PATH_RE.fullmatch(item["name"])
-                    or item["name"] in journey_names
-                    or item["passed"] is not True
-                ):
-                    raise ManifestError("runtimeVerification lacks successful bounded journeys")
-                journey_names.add(item["name"])
-            if "/chat" not in journey_names:
-                raise ManifestError("runtimeVerification lacks successful bounded journeys")
+            validate_runtime_verification(value["runtimeVerification"], value, value["environment"])
         results = value["verificationResults"]
         if not isinstance(results, list) or not results:
             raise ManifestError("verificationResults must be a non-empty list")
@@ -1104,13 +1122,6 @@ def validate_verifier_capabilities(
 ) -> None:
     """Fail closed unless the repository verifier advertises its complete v1 contract."""
     expected_fields = {"schemaVersion", "environment", "release", "namespace", "capabilities"}
-    required = {
-        "applicationVersion",
-        "runtimeSourceRevision",
-        "frontendSourceRevision",
-        "defaultProvider",
-        "publicJourneys",
-    }
     if not isinstance(value, dict) or set(value) != expected_fields:
         raise ManifestError("runtime verifier capabilities are malformed")
     capabilities = value.get("capabilities")
@@ -1126,12 +1137,8 @@ def validate_verifier_capabilities(
         isinstance(capability, str) for capability in capabilities
     ):
         raise ManifestError("runtime verifier capabilities must be a list of strings")
-    capability_set = set(capabilities)
-    if len(capabilities) != len(capability_set):
-        raise ManifestError("runtime verifier capabilities contain duplicate entries")
-    missing = sorted(required - capability_set)
-    if missing:
-        raise ManifestError("runtime verifier lacks mandatory capabilities: " + ", ".join(missing))
+    if capabilities != list(VERIFIER_CAPABILITIES_V1):
+        raise ManifestError("runtime verifier capabilities do not match the ordered v1 contract")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1181,6 +1188,12 @@ def main(argv: list[str] | None = None) -> int:
     capabilities.add_argument("--environment", required=True)
     capabilities.add_argument("--release", required=True)
     capabilities.add_argument("--namespace", required=True)
+    proof = sub.add_parser("verifier-proof")
+    proof.add_argument("--input", type=Path, required=True)
+    proof.add_argument("--manifest", type=Path, required=True)
+    proof.add_argument("--environment", required=True)
+    proof.add_argument("--release", required=True)
+    proof.add_argument("--namespace", required=True)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -1399,6 +1412,16 @@ def main(argv: list[str] | None = None) -> int:
             validate_verifier_capabilities(
                 _object(args.input), args.environment, args.release, args.namespace
             )
+        elif args.command == "verifier-proof":
+            selected_manifest = validate(_object(args.manifest))
+            validated_proof = validate_runtime_verification(
+                _object(args.input),
+                selected_manifest,
+                args.environment,
+                args.release,
+                args.namespace,
+            )
+            sys.stdout.write(_canonical(validated_proof))
         elif args.command == "check-output":
             if args.output.exists():
                 raise ManifestError(f"refusing to overwrite existing record: {args.output}")

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -55,6 +55,13 @@ VERIFIER_CAPABILITIES_V1 = (
     "defaultProvider",
     "publicJourneys",
 )
+VERIFIER_CAPABILITIES_V1 = (
+    "applicationVersion",
+    "runtimeSourceRevision",
+    "frontendSourceRevision",
+    "defaultProvider",
+    "publicJourneys",
+)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SEMVER_RE = re.compile(
@@ -223,6 +230,51 @@ def required_final_checks(value: dict[str, Any]) -> set[str]:
     return checks
 
 
+def validate_runtime_verification(
+    proof: object,
+    manifest: dict[str, Any],
+    environment: str,
+    release: str = "dspace",
+    namespace: str = "dspace",
+) -> dict[str, Any]:
+    """Validate and return a standalone verifier proof without trusting its output."""
+    if not isinstance(proof, dict) or set(proof) != set(RUNTIME_VERIFICATION_FIELDS):
+        raise ManifestError("runtimeVerification has an incompatible verifier schema")
+    if type(proof["schemaVersion"]) is not int or proof["schemaVersion"] != 1:
+        raise ManifestError("runtimeVerification schemaVersion must be integer 1")
+    expected = {
+        "environment": environment,
+        "release": release,
+        "namespace": namespace,
+        "applicationVersion": manifest["applicationVersion"],
+        "runtimeSourceRevision": manifest["sourceRevision"],
+        "frontendSourceRevision": manifest["sourceRevision"],
+        "defaultProvider": manifest["expectedDefaultChatProvider"],
+    }
+    if manifest.get("environment") != environment or any(
+        proof[field] != expected_value for field, expected_value in expected.items()
+    ):
+        raise ManifestError("runtimeVerification does not match approved release")
+    journeys = proof["journeys"]
+    if not isinstance(journeys, list) or not journeys:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    journey_names: set[str] = set()
+    for item in journeys:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"name", "passed"}
+            or not isinstance(item["name"], str)
+            or not PUBLIC_PATH_RE.fullmatch(item["name"])
+            or item["name"] in journey_names
+            or item["passed"] is not True
+        ):
+            raise ManifestError("runtimeVerification lacks successful bounded journeys")
+        journey_names.add(item["name"])
+    if "/chat" not in journey_names:
+        raise ManifestError("runtimeVerification lacks successful bounded journeys")
+    return proof
+
+
 def _validate_upstream(value: dict[str, Any]) -> None:
     _upstream_fields(value)
     if value["app"] != "dspace":
@@ -278,41 +330,7 @@ def validate_runtime_verification(
     }
     if manifest.get("environment") != environment or any(
         proof[field] != expected_value for field, expected_value in expected.items()
-    ):
-        raise ManifestError("runtimeVerification does not match approved release")
-    journeys = proof["journeys"]
-    if not isinstance(journeys, list) or not journeys:
-        raise ManifestError("runtimeVerification lacks successful bounded journeys")
-    journey_names: set[str] = set()
-    for item in journeys:
-        if (
-            not isinstance(item, dict)
-            or set(item) != {"name", "passed"}
-            or not isinstance(item["name"], str)
-            or not PUBLIC_PATH_RE.fullmatch(item["name"])
-            or item["name"] in journey_names
-            or item["passed"] is not True
-        ):
-            raise ManifestError("runtimeVerification lacks successful bounded journeys")
-        journey_names.add(item["name"])
-    if "/chat" not in journey_names:
-        raise ManifestError("runtimeVerification lacks successful bounded journeys")
-    return proof
-
-
-def validate(value: dict[str, Any], finalized: bool | None = None) -> dict[str, Any]:
-    record_type = value.get("recordType")
-    if finalized is None:
-        finalized = record_type == "final"
-    expected = _final_fields(value) if finalized else candidate_fields(value)
-    if finalized and "runtimeVerification" in value:
-        expected += OPTIONAL_FINAL_FIELDS
-    _exact_fields(value, expected)
-    _validate_upstream(value)
-    if record_type != ("final" if finalized else "candidate"):
-        raise ManifestError("recordType does not match the requested record kind")
-    if value["environment"] not in {"staging", "prod"}:
-        raise ManifestError("environment must be staging or prod")
+            validate_runtime_verification(value["runtimeVerification"], value, value["environment"])
     if value["expectedDefaultChatProvider"] not in PROVIDERS:
         raise ManifestError("expectedDefaultChatProvider must be token-place or openai")
     if not isinstance(value["approvedBy"], str) or not value["approvedBy"].strip():
@@ -1079,19 +1097,14 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
         raise ManifestError("staging gate requires prod candidate and staging final evidence")
     coordinates = (
         "applicationVersion",
-        "sourceRevision",
-        "chartSourceRevision",
-        "imageTag",
-        "imageDigest",
-        "chartVersion",
-        "chartDigest",
-        "semanticTag",
-        "expectedDefaultChatProvider",
-    )
-    if any(
-        (
-            chart_source_revision(candidate_value)
-            if field == "chartSourceRevision"
+    if capabilities != list(VERIFIER_CAPABILITIES_V1):
+        raise ManifestError("runtime verifier capabilities do not match the ordered v1 contract")
+    proof = sub.add_parser("verifier-proof")
+    proof.add_argument("--input", type=Path, required=True)
+    proof.add_argument("--manifest", type=Path, required=True)
+    proof.add_argument("--environment", required=True)
+    proof.add_argument("--release", required=True)
+    proof.add_argument("--namespace", required=True)
             else candidate_value[field]
         )
         != (
@@ -1374,6 +1387,16 @@ def main(argv: list[str] | None = None) -> int:
                 source,
                 helm,
                 pods,
+        elif args.command == "verifier-proof":
+            selected_manifest = validate(_object(args.manifest))
+            validated_proof = validate_runtime_verification(
+                _object(args.input),
+                selected_manifest,
+                args.environment,
+                args.release,
+                args.namespace,
+            )
+            sys.stdout.write(_canonical(validated_proof))
                 workloads,
                 results,
                 environment=args.environment,

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1089,6 +1089,44 @@ def staging_gate(candidate_value: dict[str, Any], evidence_value: dict[str, Any]
     return evidence_value["helmRevision"]
 
 
+def production_authorization(candidate_value: dict[str, Any], supplied: str) -> None:
+    """Require approval that is independent of, and bound more tightly than, staging proof."""
+    validate(candidate_value, False)
+    if candidate_value["environment"] != "prod":
+        raise ManifestError("production authorization requires a prod candidate")
+    expected = f"dspace:prod:{candidate_value['sourceRevision']}"
+    if supplied != expected:
+        raise ManifestError(f"production authorization must exactly equal {expected}")
+
+
+def validate_verifier_capabilities(
+    value: object, environment: str, release: str, namespace: str
+) -> None:
+    """Fail closed unless the repository verifier advertises its complete v1 contract."""
+    expected_fields = {"schemaVersion", "environment", "release", "namespace", "capabilities"}
+    required = {
+        "applicationVersion",
+        "runtimeSourceRevision",
+        "frontendSourceRevision",
+        "defaultProvider",
+        "publicJourneys",
+    }
+    if not isinstance(value, dict) or set(value) != expected_fields:
+        raise ManifestError("runtime verifier capabilities are malformed")
+    capabilities = value.get("capabilities")
+    if (
+        type(value.get("schemaVersion")) is not int
+        or value["schemaVersion"] != 1
+        or value.get("environment") != environment
+        or value.get("release") != release
+        or value.get("namespace") != namespace
+        or not isinstance(capabilities, list)
+        or len(capabilities) != len(set(capabilities))
+        or not required <= set(capabilities)
+    ):
+        raise ManifestError("runtime verifier lacks mandatory source-integrity or /chat capability")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1128,6 +1166,14 @@ def main(argv: list[str] | None = None) -> int:
     gate = sub.add_parser("staging-gate")
     gate.add_argument("--manifest", type=Path, required=True)
     gate.add_argument("--staging-evidence", type=Path, required=True)
+    authorize = sub.add_parser("authorize-production")
+    authorize.add_argument("--manifest", type=Path, required=True)
+    authorize.add_argument("--confirm", default="")
+    capabilities = sub.add_parser("verifier-capabilities")
+    capabilities.add_argument("--input", type=Path, required=True)
+    capabilities.add_argument("--environment", required=True)
+    capabilities.add_argument("--release", required=True)
+    capabilities.add_argument("--namespace", required=True)
     available = sub.add_parser("check-output")
     available.add_argument("--output", type=Path, required=True)
     destination = sub.add_parser("evidence-path")
@@ -1340,6 +1386,12 @@ def main(argv: list[str] | None = None) -> int:
             _sync_directory(args.output.expanduser().resolve(strict=False).parent)
         elif args.command == "staging-gate":
             print(staging_gate(_object(args.manifest), _object(args.staging_evidence)))
+        elif args.command == "authorize-production":
+            production_authorization(_object(args.manifest), args.confirm)
+        elif args.command == "verifier-capabilities":
+            validate_verifier_capabilities(
+                _object(args.input), args.environment, args.release, args.namespace
+            )
         elif args.command == "check-output":
             if args.output.exists():
                 raise ManifestError(f"refusing to overwrite existing record: {args.output}")

--- a/scripts/dspace_release_manifest.py
+++ b/scripts/dspace_release_manifest.py
@@ -1114,17 +1114,24 @@ def validate_verifier_capabilities(
     if not isinstance(value, dict) or set(value) != expected_fields:
         raise ManifestError("runtime verifier capabilities are malformed")
     capabilities = value.get("capabilities")
-    if (
-        type(value.get("schemaVersion")) is not int
-        or value["schemaVersion"] != 1
-        or value.get("environment") != environment
-        or value.get("release") != release
-        or value.get("namespace") != namespace
-        or not isinstance(capabilities, list)
-        or len(capabilities) != len(set(capabilities))
-        or not required <= set(capabilities)
+    if type(value.get("schemaVersion")) is not int or value["schemaVersion"] != 1:
+        raise ManifestError("runtime verifier capabilities require schemaVersion 1")
+    if value.get("environment") != environment:
+        raise ManifestError("runtime verifier capabilities environment mismatch")
+    if value.get("release") != release:
+        raise ManifestError("runtime verifier capabilities release mismatch")
+    if value.get("namespace") != namespace:
+        raise ManifestError("runtime verifier capabilities namespace mismatch")
+    if not isinstance(capabilities, list) or not all(
+        isinstance(capability, str) for capability in capabilities
     ):
-        raise ManifestError("runtime verifier lacks mandatory source-integrity or /chat capability")
+        raise ManifestError("runtime verifier capabilities must be a list of strings")
+    capability_set = set(capabilities)
+    if len(capabilities) != len(capability_set):
+        raise ManifestError("runtime verifier capabilities contain duplicate entries")
+    missing = sorted(required - capability_set)
+    if missing:
+        raise ManifestError("runtime verifier lacks mandatory capabilities: " + ", ".join(missing))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/dspace_runtime_verifier.py
+++ b/scripts/dspace_runtime_verifier.py
@@ -77,6 +77,18 @@ LEGACY_310_COORDINATES = {
     "semanticTag": "v3.1.0",
     "expectedDefaultChatProvider": "token-place",
 }
+LEGACY_PROVIDER_CONFIG_311_COORDINATES = {
+    "schemaVersion": 2,
+    "applicationVersion": "3.1.1",
+    "sourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+    "chartSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+    "imageTag": "main-22f506e",
+    "imageDigest": "sha256:467890df969cc7938cb760f965fd8f90a8912b1dcb1f8425bc808216b7e1512b",
+    "chartVersion": "3.1.2",
+    "chartDigest": "sha256:544a3e31ab827e6d2bf28754a19d8af17b0402b75159c2a40c1b3dfe5eb60161",
+    "semanticTag": "v3.1.1",
+    "expectedDefaultChatProvider": "token-place",
+}
 LEGACY_IDENTITY_COORDINATES = (
     LEGACY_302_COORDINATES,
     LEGACY_303_COORDINATES,
@@ -279,6 +291,15 @@ def identity_contract(manifest: dict[str, Any]) -> str:
     return MODERN_IDENTITY_CONTRACT
 
 
+def provider_config_contract(manifest: dict[str, Any]) -> str | None:
+    """Select a compatibility contract only for its finalized immutable coordinate fixture."""
+    if all(
+        manifest.get(key) == value for key, value in LEGACY_PROVIDER_CONFIG_311_COORDINATES.items()
+    ):
+        return "legacy-no-default-provider-v1"
+    return None
+
+
 def named_http_port(container: object, category: str) -> int:
     """Return the unique, valid named HTTP container port."""
     if not isinstance(container, dict) or not isinstance(container.get("ports"), list):
@@ -370,6 +391,7 @@ def load_manifest(path: Path) -> dict[str, Any]:
 def verify(args: argparse.Namespace) -> dict[str, Any]:
     manifest = load_manifest(args.manifest)
     contract = identity_contract(manifest)
+    provider_contract = provider_config_contract(manifest)
     identity_path = (
         "/build-meta.json" if contract == LEGACY_IDENTITY_CONTRACT else "/build-info.json"
     )
@@ -584,6 +606,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
         "--identity-contract",
         contract,
     ]
+    if provider_contract is not None:
+        smoke_argv += ["--provider-config-contract", provider_contract]
     if expected["provider"] == "token-place":
         assert token_values is not None
         token_origin, token_model = token_values

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -97,6 +97,49 @@ def test_provider_config_contract_is_bound_to_finalized_311_coordinates() -> Non
     assert verifier.provider_config_contract(approved) is None
 
 
+@pytest.mark.parametrize(
+    "drift_field",
+    [None, *verifier.LEGACY_PROVIDER_CONFIG_311_COORDINATES.keys(), "unrelated-release"],
+)
+def test_verify_selects_provider_config_contract_only_for_exact_311_tuple(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, drift_field: str | None
+) -> None:
+    coordinates = dict(verifier.LEGACY_PROVIDER_CONFIG_311_COORDINATES)
+    expected = drift_field is None
+    if drift_field == "unrelated-release":
+        coordinates = {
+            **coordinates,
+            "applicationVersion": "3.2.0",
+            "semanticTag": "v3.2.0",
+            "chartVersion": "3.2.0",
+        }
+    elif drift_field is not None:
+        coordinates[drift_field] = (
+            1 if drift_field == "schemaVersion" else "drift"
+        )
+        # Use valid scalar shapes; load validation is isolated below so every selector
+        # field, including fields coupled by the manifest schema, is drifted independently.
+        if drift_field in {"sourceRevision", "chartSourceRevision"}:
+            coordinates[drift_field] = "f" * 40
+        elif drift_field in {"imageDigest", "chartDigest"}:
+            coordinates[drift_field] = "sha256:" + "f" * 64
+        elif drift_field == "imageTag":
+            coordinates[drift_field] = "release-" + str(coordinates["sourceRevision"])[:7]
+        elif drift_field in {"applicationVersion", "chartVersion"}:
+            coordinates[drift_field] = "9.9.9"
+        elif drift_field == "semanticTag":
+            coordinates[drift_field] = "v9.9.9"
+        elif drift_field == "expectedDefaultChatProvider":
+            coordinates[drift_field] = "openai"
+    args, calls = _verify_setup(monkeypatch, tmp_path, coordinates=coordinates)
+    monkeypatch.setattr(verifier, "load_manifest", lambda path: coordinates)
+    verifier.verify(args)
+    option = "--provider-config-contract"
+    assert (option in calls[0]) is expected
+    if expected:
+        assert calls[0][calls[0].index(option) + 1] == "legacy-no-default-provider-v1"
+
+
 def test_values_expectations_use_ordered_overlay(tmp_path: Path) -> None:
     base = tmp_path / "base.yaml"
     overlay = tmp_path / "overlay.yaml"
@@ -121,6 +164,7 @@ def _verify_setup(
     overrides: dict[str, object] | None = None,
     legacy: bool = False,
     legacy_310: bool = False,
+    coordinates: dict[str, object] | None = None,
 ) -> tuple[Namespace, list[list[str]]]:
     """Install a complete, mutable fake cluster and return verifier arguments."""
     if legacy and legacy_310:
@@ -130,24 +174,25 @@ def _verify_setup(
     smoke = tmp_path / "smoke"
     smoke.write_text("#!/bin/sh\nexit 0\n")
     smoke.chmod(0o700)
-    coordinates = (
+    selected_coordinates = coordinates or (
         verifier.LEGACY_310_COORDINATES if legacy_310 else verifier.LEGACY_303_COORDINATES
     )
     is_legacy = legacy or legacy_310
-    revision = str(coordinates["sourceRevision"]) if is_legacy else SHA
-    digest = str(coordinates["imageDigest"]) if is_legacy else DIGEST
-    image_tag = str(coordinates["imageTag"]) if is_legacy else "main-abcdef0"
-    version = str(coordinates["applicationVersion"]) if is_legacy else "3.1.0"
-    chart_version = str(coordinates["chartVersion"]) if is_legacy else "3.1.0"
+    use_coordinates = is_legacy or coordinates is not None
+    revision = str(selected_coordinates["sourceRevision"]) if use_coordinates else SHA
+    digest = str(selected_coordinates["imageDigest"]) if use_coordinates else DIGEST
+    image_tag = str(selected_coordinates["imageTag"]) if use_coordinates else "main-abcdef0"
+    version = str(selected_coordinates["applicationVersion"]) if use_coordinates else "3.1.0"
+    chart_version = str(selected_coordinates["chartVersion"]) if use_coordinates else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
     declared = f"{canonical}@{digest}" if rollback else canonical
 
-    def build(image: str = canonical, revision: str = SHA) -> str:
+    def build(image: str = canonical, build_revision: str = revision) -> str:
         return json.dumps(
             {
                 "version": version,
-                "revision": revision,
-                "shortRevision": revision[:7],
+                "revision": build_revision,
+                "shortRevision": build_revision[:7],
                 "buildTimestamp": BUILD_TIMESTAMP,
                 "image": image,
             }
@@ -210,7 +255,7 @@ def _verify_setup(
     default_html = (
         "<!doctype html><html><head><title>DSPACE</title></head><body></body></html>"
         if is_legacy
-        else f'<meta name="dspace-build-revision" content="{SHA}">'
+        else f'<meta name="dspace-build-revision" content="{revision}">'
     )
     public_html = override.get("public_html", default_html)
     legacy_build = json.dumps(
@@ -329,6 +374,20 @@ def _verify_setup(
         manifest_path = legacy_310_manifest(tmp_path)
     elif legacy:
         manifest_path = recovery_manifest(tmp_path)
+    elif coordinates is not None:
+        manifest_path = tmp_path / "selected-coordinates.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    **coordinates,
+                    "app": "dspace",
+                    "recordType": "candidate",
+                    "environment": "staging",
+                    "approvedAt": "2026-07-30T00:00:00Z",
+                    "approvedBy": "release-test",
+                }
+            )
+        )
     else:
         manifest_path = manifest(tmp_path, provider)
 

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -90,6 +90,13 @@ def test_capabilities_schema_and_order(capsys: pytest.CaptureFixture[str]) -> No
     assert value["capabilities"] == verifier.CAPABILITIES
 
 
+def test_provider_config_contract_is_bound_to_finalized_311_coordinates() -> None:
+    approved = dict(verifier.LEGACY_PROVIDER_CONFIG_311_COORDINATES)
+    assert verifier.provider_config_contract(approved) == "legacy-no-default-provider-v1"
+    approved["imageDigest"] = DIGEST
+    assert verifier.provider_config_contract(approved) is None
+
+
 def test_values_expectations_use_ordered_overlay(tmp_path: Path) -> None:
     base = tmp_path / "base.yaml"
     overlay = tmp_path / "overlay.yaml"

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -140,51 +140,6 @@ def test_verify_selects_provider_config_contract_only_for_exact_311_tuple(
         assert calls[0][calls[0].index(option) + 1] == "legacy-no-default-provider-v1"
 
 
-    coordinates: dict[str, object] | None = None,
-    selected_coordinates = coordinates or (
-    use_coordinates = is_legacy or coordinates is not None
-    revision = str(selected_coordinates["sourceRevision"]) if use_coordinates else SHA
-    digest = str(selected_coordinates["imageDigest"]) if use_coordinates else DIGEST
-    image_tag = str(selected_coordinates["imageTag"]) if use_coordinates else "main-abcdef0"
-    version = str(selected_coordinates["applicationVersion"]) if use_coordinates else "3.1.0"
-    chart_version = str(selected_coordinates["chartVersion"]) if use_coordinates else "3.1.0"
-    def build(image: str = canonical, build_revision: str = revision) -> str:
-                "revision": build_revision,
-                "shortRevision": build_revision[:7],
-    if drift_field == "unrelated-release":
-        coordinates = {
-            **coordinates,
-            "applicationVersion": "3.2.0",
-            "semanticTag": "v3.2.0",
-            "chartVersion": "3.2.0",
-        }
-    elif drift_field is not None:
-        coordinates[drift_field] = (
-            1 if drift_field == "schemaVersion" else "drift"
-        )
-        # Use valid scalar shapes; load validation is isolated below so every selector
-        # field, including fields coupled by the manifest schema, is drifted independently.
-        if drift_field in {"sourceRevision", "chartSourceRevision"}:
-            coordinates[drift_field] = "f" * 40
-        elif drift_field in {"imageDigest", "chartDigest"}:
-            coordinates[drift_field] = "sha256:" + "f" * 64
-        elif drift_field == "imageTag":
-            coordinates[drift_field] = "release-" + str(coordinates["sourceRevision"])[:7]
-        elif drift_field in {"applicationVersion", "chartVersion"}:
-            coordinates[drift_field] = "9.9.9"
-        elif drift_field == "semanticTag":
-            coordinates[drift_field] = "v9.9.9"
-        elif drift_field == "expectedDefaultChatProvider":
-            coordinates[drift_field] = "openai"
-    args, calls = _verify_setup(monkeypatch, tmp_path, coordinates=coordinates)
-    monkeypatch.setattr(verifier, "load_manifest", lambda path: coordinates)
-    verifier.verify(args)
-    option = "--provider-config-contract"
-    assert (option in calls[0]) is expected
-    if expected:
-        assert calls[0][calls[0].index(option) + 1] == "legacy-no-default-provider-v1"
-
-
 def test_values_expectations_use_ordered_overlay(tmp_path: Path) -> None:
     base = tmp_path / "base.yaml"
     overlay = tmp_path / "overlay.yaml"
@@ -230,7 +185,7 @@ def _verify_setup(
     version = str(selected_coordinates["applicationVersion"]) if use_coordinates else "3.1.0"
     chart_version = str(selected_coordinates["chartVersion"]) if use_coordinates else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
-        else f'<meta name="dspace-build-revision" content="{revision}">'
+    declared = f"{canonical}@{digest}" if rollback else canonical
 
     def build(image: str = canonical, build_revision: str = revision) -> str:
         return json.dumps(
@@ -349,20 +304,6 @@ def _verify_setup(
                                                 "name": "DSPACE_TOKEN_PLACE_CHAT_MODEL",
                                                 "value": "model-a",
                                             },
-    elif coordinates is not None:
-        manifest_path = tmp_path / "selected-coordinates.json"
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    **coordinates,
-                    "app": "dspace",
-                    "recordType": "candidate",
-                    "environment": "staging",
-                    "approvedAt": "2026-07-30T00:00:00Z",
-                    "approvedBy": "release-test",
-                }
-            )
-        )
                                         ],
                                     }
                                 ]

--- a/tests/test_dspace_runtime_verifier.py
+++ b/tests/test_dspace_runtime_verifier.py
@@ -140,6 +140,51 @@ def test_verify_selects_provider_config_contract_only_for_exact_311_tuple(
         assert calls[0][calls[0].index(option) + 1] == "legacy-no-default-provider-v1"
 
 
+    coordinates: dict[str, object] | None = None,
+    selected_coordinates = coordinates or (
+    use_coordinates = is_legacy or coordinates is not None
+    revision = str(selected_coordinates["sourceRevision"]) if use_coordinates else SHA
+    digest = str(selected_coordinates["imageDigest"]) if use_coordinates else DIGEST
+    image_tag = str(selected_coordinates["imageTag"]) if use_coordinates else "main-abcdef0"
+    version = str(selected_coordinates["applicationVersion"]) if use_coordinates else "3.1.0"
+    chart_version = str(selected_coordinates["chartVersion"]) if use_coordinates else "3.1.0"
+    def build(image: str = canonical, build_revision: str = revision) -> str:
+                "revision": build_revision,
+                "shortRevision": build_revision[:7],
+    if drift_field == "unrelated-release":
+        coordinates = {
+            **coordinates,
+            "applicationVersion": "3.2.0",
+            "semanticTag": "v3.2.0",
+            "chartVersion": "3.2.0",
+        }
+    elif drift_field is not None:
+        coordinates[drift_field] = (
+            1 if drift_field == "schemaVersion" else "drift"
+        )
+        # Use valid scalar shapes; load validation is isolated below so every selector
+        # field, including fields coupled by the manifest schema, is drifted independently.
+        if drift_field in {"sourceRevision", "chartSourceRevision"}:
+            coordinates[drift_field] = "f" * 40
+        elif drift_field in {"imageDigest", "chartDigest"}:
+            coordinates[drift_field] = "sha256:" + "f" * 64
+        elif drift_field == "imageTag":
+            coordinates[drift_field] = "release-" + str(coordinates["sourceRevision"])[:7]
+        elif drift_field in {"applicationVersion", "chartVersion"}:
+            coordinates[drift_field] = "9.9.9"
+        elif drift_field == "semanticTag":
+            coordinates[drift_field] = "v9.9.9"
+        elif drift_field == "expectedDefaultChatProvider":
+            coordinates[drift_field] = "openai"
+    args, calls = _verify_setup(monkeypatch, tmp_path, coordinates=coordinates)
+    monkeypatch.setattr(verifier, "load_manifest", lambda path: coordinates)
+    verifier.verify(args)
+    option = "--provider-config-contract"
+    assert (option in calls[0]) is expected
+    if expected:
+        assert calls[0][calls[0].index(option) + 1] == "legacy-no-default-provider-v1"
+
+
 def test_values_expectations_use_ordered_overlay(tmp_path: Path) -> None:
     base = tmp_path / "base.yaml"
     overlay = tmp_path / "overlay.yaml"
@@ -185,7 +230,7 @@ def _verify_setup(
     version = str(selected_coordinates["applicationVersion"]) if use_coordinates else "3.1.0"
     chart_version = str(selected_coordinates["chartVersion"]) if use_coordinates else "3.1.0"
     canonical = f"ghcr.io/democratizedspace/dspace:{image_tag}"
-    declared = f"{canonical}@{digest}" if rollback else canonical
+        else f'<meta name="dspace-build-revision" content="{revision}">'
 
     def build(image: str = canonical, build_revision: str = revision) -> str:
         return json.dumps(
@@ -304,6 +349,20 @@ def _verify_setup(
                                                 "name": "DSPACE_TOKEN_PLACE_CHAT_MODEL",
                                                 "value": "model-a",
                                             },
+    elif coordinates is not None:
+        manifest_path = tmp_path / "selected-coordinates.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    **coordinates,
+                    "app": "dspace",
+                    "recordType": "candidate",
+                    "environment": "staging",
+                    "approvedAt": "2026-07-30T00:00:00Z",
+                    "approvedBy": "release-test",
+                }
+            )
+        )
                                         ],
                                     }
                                 ]

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -3391,8 +3391,9 @@ def test_dspace_release_verify_ignores_runtime_verifier_override(
     assert result.returncode == 0, result.stderr + result.stdout
     assert not marker.exists()
     invocations = Path(env["RUNTIME_VERIFIER_LOG"]).read_text(encoding="utf-8").splitlines()
-    assert len(invocations) == 1
-    assert invocations[0].startswith(
+    assert len(invocations) == 2
+    assert " capabilities " in f" {invocations[0]} "
+    assert invocations[1].startswith(
         f"{REPO_ROOT / 'scripts/dspace_runtime_verifier.py'} verify "
     )
 
@@ -3460,10 +3461,11 @@ def test_dspace_release_verify_normalizes_public_arguments(
     result = _run_just(["dspace-release-verify", *arguments], generic_app_stub_env)
 
     assert result.returncode == 0, result.stderr + result.stdout
-    invocation = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
+    invocations = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
         encoding="utf-8"
-    )
-    argv = invocation.split()
+    ).splitlines()
+    assert len(invocations) == 2
+    argv = invocations[1].split()
     required = {
         "--environment": values["env"],
         "--manifest": values["manifest"],
@@ -3619,9 +3621,9 @@ def test_dspace_staging_wrappers_route_sparse_named_arguments_once(
     verifier_lines = Path(generic_app_stub_env["RUNTIME_VERIFIER_LOG"]).read_text(
         encoding="utf-8"
     ).splitlines()
-    assert len(verifier_lines) == 1
-    assert verifier_lines[0].count(f"--manifest {manifest}") == 1
-    assert verifier_lines[0].count(
+    assert len(verifier_lines) == 2
+    assert verifier_lines[1].count(f"--manifest {manifest}") == 1
+    assert verifier_lines[1].count(
         f"--smoke-runner {generic_app_stub_env['DSPACE_SMOKE_RUNNER']}"
     ) == 1
 
@@ -3690,17 +3692,18 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
             f"evidence={prod_evidence}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
     verifier_lines = runtime_log.read_text(encoding="utf-8").splitlines()
-    assert len(verifier_lines) == 2
+    assert len(verifier_lines) == 4
     assert "--environment staging" in verifier_lines[0]
     assert f"--manifest {staging_evidence}" in verifier_lines[0]
-    assert "--environment prod" in verifier_lines[1]
-    assert f"--manifest {prod_manifest}" in verifier_lines[1]
+    assert "--environment prod" in verifier_lines[2]
+    assert f"--manifest {prod_manifest}" in verifier_lines[2]
     assert json.loads(prod_evidence.read_text(encoding="utf-8"))["recordType"] == "final"
     helm_lines = Path(env["HELM_LOG"]).read_text(encoding="utf-8").splitlines()
     assert sum(line.startswith("upgrade ") for line in helm_lines) == 1
@@ -3708,6 +3711,7 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
     ordered_events = [
         next(i for i, line in enumerate(commands) if line == "release-manifest staging-gate"),
         next(i for i, line in enumerate(commands) if line == "runtime-verifier staging"),
+        next(i for i, line in enumerate(commands) if line == "release-manifest authorize-production"),
         next(i for i, line in enumerate(commands) if line == "release-manifest preflight"),
         next(i for i, line in enumerate(commands) if line.startswith("helm template ")),
         next(i for i, line in enumerate(commands) if line == "release-manifest reserve"),
@@ -3718,6 +3722,25 @@ def test_dspace_promote_prod_routes_sparse_named_arguments_through_both_gates(
     assert ordered_events == sorted(ordered_events)
 
     Path(env["HELM_LOG"]).write_text("", encoding="utf-8")
+    unauthorized = _run_just(
+        [
+            "app-promote-prod",
+            "app=dspace",
+            "tag=main-abcdef0",
+            f"config={config}",
+            f"manifest={prod_manifest}",
+            f"staging_evidence={staging_evidence}",
+            f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
+            f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
+            f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            f"evidence={tmp_path / 'unauthorized-evidence.json'}",
+        ],
+        env,
+    )
+    assert unauthorized.returncode != 0
+    assert "production authorization must exactly equal" in unauthorized.stderr
+    assert "upgrade " not in Path(env["HELM_LOG"]).read_text(encoding="utf-8")
+
     identical = tmp_path / "same-kubeconfig"
     rejected = _run_just(
         [
@@ -3796,6 +3819,7 @@ def test_dspace_prod_staging_gate_failures_stop_before_production_work(
             f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )
@@ -3853,6 +3877,7 @@ def test_dspace_prod_verifier_failure_preserves_post_mutation_reservation(
             f"smoke_runner={env['DSPACE_SMOKE_RUNNER']}",
             f"kubeconfig={tmp_path / 'prod-kubeconfig'}",
             f"staging_kubeconfig={tmp_path / 'staging-kubeconfig'}",
+            "confirm=dspace:prod:abcdef0123456789abcdef0123456789abcdef01",
         ],
         env,
     )

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -2000,3 +2000,26 @@ def test_verifier_capabilities_requires_exact_ordered_v1_list(
     }
     with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
         manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        list(manifest.VERIFIER_CAPABILITIES_V1[:-1]),
+        list(reversed(manifest.VERIFIER_CAPABILITIES_V1)),
+        [*manifest.VERIFIER_CAPABILITIES_V1, "extra"],
+        [*manifest.VERIFIER_CAPABILITIES_V1, manifest.VERIFIER_CAPABILITIES_V1[-1]],
+    ],
+)
+def test_verifier_capabilities_requires_exact_ordered_v1_list(
+    capabilities: list[str],
+) -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": capabilities,
+    }
+    with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1918,7 +1918,7 @@ def test_production_authorization_is_explicit_and_source_bound() -> None:
             manifest.production_authorization(value, supplied)
 
 
-def test_verifier_capabilities_fail_closed_without_mandatory_proof() -> None:
+def test_verifier_capabilities_fail_closed_without_exact_contract() -> None:
     value = {
         "schemaVersion": 1,
         "environment": "staging",
@@ -1926,7 +1926,7 @@ def test_verifier_capabilities_fail_closed_without_mandatory_proof() -> None:
         "namespace": "dspace",
         "capabilities": ["applicationVersion", "publicJourneys"],
     }
-    with pytest.raises(manifest.ManifestError, match="mandatory capabilities: defaultProvider"):
+    with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
         manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
 
 
@@ -1975,5 +1975,28 @@ def test_verifier_capabilities_identifies_duplicate_entries() -> None:
         "namespace": "dspace",
         "capabilities": ["publicJourneys", "publicJourneys"],
     }
-    with pytest.raises(manifest.ManifestError, match="duplicate entries"):
+    with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        list(manifest.VERIFIER_CAPABILITIES_V1[:-1]),
+        list(reversed(manifest.VERIFIER_CAPABILITIES_V1)),
+        [*manifest.VERIFIER_CAPABILITIES_V1, "extra"],
+        [*manifest.VERIFIER_CAPABILITIES_V1, manifest.VERIFIER_CAPABILITIES_V1[-1]],
+    ],
+)
+def test_verifier_capabilities_requires_exact_ordered_v1_list(
+    capabilities: list[str],
+) -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": capabilities,
+    }
+    with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
         manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1926,5 +1926,54 @@ def test_verifier_capabilities_fail_closed_without_mandatory_proof() -> None:
         "namespace": "dspace",
         "capabilities": ["applicationVersion", "publicJourneys"],
     }
-    with pytest.raises(manifest.ManifestError, match="mandatory source-integrity or /chat"):
+    with pytest.raises(manifest.ManifestError, match="mandatory capabilities: defaultProvider"):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
+
+
+@pytest.mark.parametrize("capability", [{"name": "publicJourneys"}, ["publicJourneys"]])
+def test_verifier_capabilities_reject_non_string_entries(capability: object) -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": [capability],
+    }
+    with pytest.raises(manifest.ManifestError, match="list of strings"):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("schemaVersion", 2, "schemaVersion 1"),
+        ("environment", "prod", "environment mismatch"),
+        ("release", "other", "release mismatch"),
+        ("namespace", "other", "namespace mismatch"),
+    ],
+)
+def test_verifier_capabilities_identifies_metadata_mismatch(
+    field: str, replacement: object, message: str
+) -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": [],
+    }
+    value[field] = replacement
+    with pytest.raises(manifest.ManifestError, match=message):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
+
+
+def test_verifier_capabilities_identifies_duplicate_entries() -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": ["publicJourneys", "publicJourneys"],
+    }
+    with pytest.raises(manifest.ManifestError, match="duplicate entries"):
         manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -2000,26 +2000,3 @@ def test_verifier_capabilities_requires_exact_ordered_v1_list(
     }
     with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
         manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")
-
-
-@pytest.mark.parametrize(
-    "capabilities",
-    [
-        list(manifest.VERIFIER_CAPABILITIES_V1[:-1]),
-        list(reversed(manifest.VERIFIER_CAPABILITIES_V1)),
-        [*manifest.VERIFIER_CAPABILITIES_V1, "extra"],
-        [*manifest.VERIFIER_CAPABILITIES_V1, manifest.VERIFIER_CAPABILITIES_V1[-1]],
-    ],
-)
-def test_verifier_capabilities_requires_exact_ordered_v1_list(
-    capabilities: list[str],
-) -> None:
-    value = {
-        "schemaVersion": 1,
-        "environment": "staging",
-        "release": "dspace",
-        "namespace": "dspace",
-        "capabilities": capabilities,
-    }
-    with pytest.raises(manifest.ManifestError, match="ordered v1 contract"):
-        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1908,3 +1908,23 @@ def test_finalize_rejects_noncanonical_image_id() -> None:
     item["status"]["containerStatuses"][0]["imageID"] = "not-a-digest"
     with pytest.raises(manifest.ManifestError, match="non-canonical pod imageID"):
         finalize(pods_json={"items": [item]})
+
+
+def test_production_authorization_is_explicit_and_source_bound() -> None:
+    value = split_candidate("prod")
+    manifest.production_authorization(value, f"dspace:prod:{SHA}")
+    for supplied in ("", "dspace:prod:staging", f"dspace:prod:{CHART_SHA}"):
+        with pytest.raises(manifest.ManifestError, match="exactly equal"):
+            manifest.production_authorization(value, supplied)
+
+
+def test_verifier_capabilities_fail_closed_without_mandatory_proof() -> None:
+    value = {
+        "schemaVersion": 1,
+        "environment": "staging",
+        "release": "dspace",
+        "namespace": "dspace",
+        "capabilities": ["applicationVersion", "publicJourneys"],
+    }
+    with pytest.raises(manifest.ManifestError, match="mandatory source-integrity or /chat"):
+        manifest.validate_verifier_capabilities(value, "staging", "dspace", "dspace")


### PR DESCRIPTION
## Motivation

DSPACE production promotion must fail closed unless the approved release passes repository-owned source-integrity and bounded `/chat` verification before mutation and again after rollout. Staging proof must remain separate from explicit production authorization.

## Changes

- Require finalized schema-v2 staging evidence and rerun live staging verification before production preflight, evidence reservation, rendering, or Helm mutation.
- Require explicit production authorization bound to the production candidate’s full source revision.
- Thread authorization through the generic deploy/redeploy/promote recipes and DSPACE compatibility wrappers.
- Negotiate and validate the exact ordered runtime-verifier capability contract.
- Capture verifier output in permission-restricted temporary files, bound execution to 360 seconds, and validate the exact schema, environment, release coordinates, source revisions, provider, successful journeys, and `/chat` result before accepting it.
- Run the same repository-owned verifier against production after rollout and before evidence finalization.
- Preserve distinct staging and production kubeconfigs, coordinates, endpoints, evidence, and authorization.
- Preserve existing schema-v2 evidence and schema-v1 runtime-proof contracts.
- Select `legacy-no-default-provider-v1` only for the exact approved DSPACE 3.1.1 immutable coordinate tuple; unrelated or drifted releases cannot infer this compatibility contract.
- Preserve fail-closed post-rollout behavior: verification failure leaves the reservation for operator reconciliation and does not retry, roll back, restore, or perform another production mutation.
- Update production-promotion documentation with the required source-bound confirmation.

## Safety

- Tests use deterministic stubs and do not contact or mutate either cluster.
- Missing tools, malformed capabilities or proofs, coordinate mismatches, failed authorization, verifier failures, timeouts, and failed `/chat` verification stop the workflow.
- Private verifier artifacts use restrictive permissions and are removed on exit.
- Existing credential redaction and non-mutating dry-run/report-only behavior remain unchanged.

## Verification

- `python3 -m pytest -q tests/test_release_manifest.py tests/test_dspace_runtime_verifier.py` — 462 passed.
- `python3 -m pytest -q tests/test_generic_app_just_recipes.py -k 'dspace_release_verify or dspace_promote_prod or dspace_prod_verifier or dspace_prod_staging_gate or dspace_production_wrappers'` — passed.
- `just --unstable --fmt --check` — passed.
- `git diff --check` — passed.
- `git diff --cached --check` — passed.
- `git diff --cached | python3 scripts/scan-secrets.py` — passed.
- GitHub Actions runs the full test, CI, documentation, spellcheck, Justfile-formatting, and Pi-image checks against the latest head.

Closes #2328

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a857739a6dc832fb1d507999c42a43f)