### PR TITLE
Add durable repository-owned DSPACE /chat synthetic producer, materializer, installer, units, tests and runbook

### DIFF
--- a/config/dspace-chat-synthetic/staging.json
+++ b/config/dspace-chat-synthetic/staging.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "environment": "staging",
+  "runnerRevision": "97ab09f13fb098de928a878bf1fe9b8d13032cb5",
+  "dspaceVersion": "3.1.1",
+  "dspaceSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "identityContract": "build-info-v1",
+  "providerConfigContract": "legacy-no-default-provider-v1",
+  "provider": "token-place",
+  "tokenPlaceOrigin": "https://staging.token.place",
+  "tokenPlaceModel": "qwen3-8b-instruct",
+  "timeoutSeconds": 240,
+  "serviceAccount": "pi",
+  "serviceGroup": "pi",
+  "runnerRoot": "/var/lib/sugarkube/dspace-chat-runners",
+  "resultRoot": "/run/sugarkube/dspace-chat-synthetic",
+  "metricPath": "/var/lib/node_exporter/textfile_collector/dspace_chat_synthetic.prom",
+  "lockPath": "/run/lock/sugarkube-dspace-chat-synthetic.lock",
+  "runnerCommand": "apps/web/node_modules/.bin/playwright",
+  "runnerSpec": "apps/web/tests/remote-chat-smoke.spec.ts"
+}

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -1,0 +1,107 @@
+# DSPACE chat synthetic producer
+
+This runbook describes repository-owned source and reviewed coordinates for the
+staging DSPACE `/chat` producer. It is **not** authorization to change a host.
+Live cutover remains a separate, reviewed, explicitly authorized operation.
+The private recovery wrapper and incident evidence are behavioral provenance,
+not build inputs. Consequently, the repository wrapper is expected to differ
+from the previously observed private-wrapper SHA-256
+`5a160f1e4c077c09cda5fec062733cd9b31ed8cbfbc5b7f0779403f4a829e70e`.
+
+## Trust and filesystem contract
+
+[`staging.json`](../config/dspace-chat-synthetic/staging.json) explicitly binds
+runner `97ab09f13fb098de928a878bf1fe9b8d13032cb5`, DSPACE `3.1.1` source
+`22f506e07e0b5abfd0cf756e9c5827c0458fb4b2`, `build-info-v1`, and
+`legacy-no-default-provider-v1`. The legacy provider contract is allowed only
+for that exact tuple; absence of a provider field never selects a contract.
+The record also binds the non-secret token.place provider origin/model, timeout,
+runner, result, lock, and node-exporter metric paths.
+
+The runner is a full, independent Git checkout. Complete Git metadata is needed
+to prove the commit and object closure later; a worktree export cannot do that.
+The root `node_modules/.pnpm` store and frontend links are needed because pnpm's
+workspace layout resolves packages through both, rather than through an
+untracked global mutable store. Critical inputs are recorded in the runner
+manifest. Construction rejects dirty state and alternates.
+
+On a future authorized host, the result root must be `root:pi` mode `0710`, each
+invocation directory `root:pi` mode `0770`, and the child-published result
+`pi:pi` mode `0600`. The browser publishes atomically by writing a temporary
+file in its invocation directory, setting mode `0600`, and renaming it to
+`result.json`. The wrapper removes only that invocation-owned directory.
+
+## 1. Construct and validate the runner
+
+Use an already present, trusted local DSPACE checkout; construction is offline
+and never changes that repository:
+
+```bash
+python scripts/materialize_dspace_chat_runner.py \
+  --source /absolute/path/to/local/dspace \
+  --revision 97ab09f13fb098de928a878bf1fe9b8d13032cb5 \
+  --destination /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5
+```
+
+The command uses the exact lockfile with `pnpm install --frozen-lockfile
+--offline`, then validates Git object closure, the root pnpm store, frontend
+links, the Playwright shim, Node resolution, and file hashes. Missing cached
+packages fail rather than contacting a registry.
+
+## 2. Validate and dry-run installation
+
+These default operations are read-only and can target a temporary filesystem:
+
+```bash
+python scripts/install_dspace_chat_synthetic.py validate --runner /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5
+python scripts/install_dspace_chat_synthetic.py status --root /temporary/root
+python scripts/install_dspace_chat_synthetic.py install --root /temporary/root --runner /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5
+```
+
+Only a separately reviewed command with `install --apply` replaces files. It
+stages and validates the complete revision first, uses atomic per-file replaces,
+retains prior files, and does not call `systemctl`. Review hashes reported by
+`status` and unit provenance before proceeding.
+
+## 3. Controlled execution and timer activation
+
+After separately authorized installation, an operator may invoke exactly one
+controlled service execution. Do not infer success from a passing Playwright
+summary: result publication, ownership, mode, schema, invocation ID, and time
+window validation can still fail. Review only bounded wrapper status and metric
+metadata; never copy raw browser output, results, credentials, Secrets, or raw
+journals into evidence.
+
+Timer activation is another explicit operator decision. The installed timer has
+`Persistent=true`, but neither installer nor wrapper enables or starts it. A
+future cutover authorization must specify the exact `systemctl enable` and
+`systemctl start` actions. Observe at least two scheduled intervals and verify
+the unit invocation IDs, timestamps, metric age, and alert state.
+
+## Failure classification and evidence
+
+Before any retry, use read-only `status`, `systemctl show` properties, file
+metadata, and SHA-256 values to classify: preflight/coordinate rejection,
+overlap, launch/timeout, absent publication, ownership/mode, malformed or stale
+result, or metric publication. Do not print raw results or journals. Record the
+repository commit, config and unit hashes, runner-manifest hash, exact
+`INVOCATION_ID`, UTC start/end summary, exit state, and prior/current metric
+hash. A missing, late, malformed, or otherwise invalid current bounded result
+preserves the prior metric byte-for-byte. There is no automatic retry, second
+invocation, restart, restore, or rollback.
+
+## Explicit rollback
+
+Rollback is never automatic. Select the exact 40-character revision retained by
+a previous validated install, first dry-run it, and only then use `--apply` under
+separate authorization:
+
+```bash
+python scripts/install_dspace_chat_synthetic.py rollback --revision <exact-sha>
+python scripts/install_dspace_chat_synthetic.py rollback --revision <exact-sha> --apply
+```
+
+Rollback changes files only. Service execution and timer activation remain
+separate operator actions. After merge, the remaining work is still the live
+host cutover: transfer the independently built runner, validate host ownership
+and paths, install, execute once, explicitly activate the timer, and observe it.

--- a/scripts/dspace_chat_synthetic
+++ b/scripts/dspace_chat_synthetic
@@ -1,0 +1,7 @@
+#!/bin/bash
+set +x
+set -Eeuo pipefail
+umask 077
+export PYTHONDONTWRITEBYTECODE=1
+
+exec /usr/bin/python3 /usr/local/libexec/sugarkube-dspace-chat-synthetic.py "$@"

--- a/scripts/dspace_chat_synthetic.py
+++ b/scripts/dspace_chat_synthetic.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Fail-closed, invocation-bound DSPACE /chat synthetic producer."""
+
+import argparse
+import datetime as dt
+import fcntl
+import grp
+import hashlib
+import json
+import os
+import pwd
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+SHA = re.compile(r"[0-9a-f]{40}")
+INVOCATION = re.compile(r"[0-9a-f]{32}")
+APPROVED = ("3.1.1", "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2", "legacy-no-default-provider-v1")
+CONFIG_KEYS = {
+    "schemaVersion",
+    "environment",
+    "runnerRevision",
+    "dspaceVersion",
+    "dspaceSourceRevision",
+    "identityContract",
+    "providerConfigContract",
+    "provider",
+    "tokenPlaceOrigin",
+    "tokenPlaceModel",
+    "timeoutSeconds",
+    "serviceAccount",
+    "serviceGroup",
+    "runnerRoot",
+    "resultRoot",
+    "metricPath",
+    "lockPath",
+    "runnerCommand",
+    "runnerSpec",
+}
+RESULT_KEYS = {
+    "schemaVersion",
+    "journey",
+    "passed",
+    "executedAt",
+    "completedAt",
+    "invocationId",
+    "runnerRevision",
+    "transport",
+    "mutationEnabled",
+}
+
+
+class SyntheticError(RuntimeError):
+    pass
+
+
+def utc(epoch: int) -> str:
+    return dt.datetime.fromtimestamp(epoch, dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_config(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or set(value) != CONFIG_KEYS:
+        raise SyntheticError("configuration does not match the exact schema")
+    if value["schemaVersion"] != 1 or value["environment"] != "staging":
+        raise SyntheticError("only staging schema v1 is supported")
+    for key in ("runnerRevision", "dspaceSourceRevision"):
+        if not isinstance(value[key], str) or not SHA.fullmatch(value[key]):
+            raise SyntheticError(f"invalid {key}")
+    if value["identityContract"] != "build-info-v1":
+        raise SyntheticError("identity contract must be selected explicitly")
+    coordinates = (
+        value["dspaceVersion"],
+        value["dspaceSourceRevision"],
+        value["providerConfigContract"],
+    )
+    if coordinates != APPROVED:
+        raise SyntheticError("provider-config contract is not approved for these exact coordinates")
+    if (
+        value["provider"] != "token-place"
+        or value["tokenPlaceOrigin"] != "https://staging.token.place"
+        or value["tokenPlaceModel"] != "qwen3-8b-instruct"
+    ):
+        raise SyntheticError("provider coordinates mismatch")
+    if type(value["timeoutSeconds"]) is not int or not 30 <= value["timeoutSeconds"] <= 300:
+        raise SyntheticError("timeout must be bounded from 30 through 300 seconds")
+    for key in ("runnerRoot", "resultRoot", "metricPath", "lockPath"):
+        if not Path(value[key]).is_absolute() or "$" in value[key]:
+            raise SyntheticError(f"{key} must be an exact absolute path")
+    return value
+
+
+def check_mode(path: Path, uid: int, gid: int, mode: int, label: str) -> None:
+    info = path.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(info.st_mode) or (info.st_uid, info.st_gid, stat.S_IMODE(info.st_mode)) != (
+        uid,
+        gid,
+        mode,
+    ):
+        raise SyntheticError(f"{label} ownership or mode mismatch")
+
+
+def verify_runner(config: dict) -> Path:
+    runner = Path(config["runnerRoot"]) / config["runnerRevision"]
+    manifest_path = runner / "sugarkube-runner-manifest.json"
+    if not runner.is_dir() or not (runner / ".git").is_dir() or not manifest_path.is_file():
+        raise SyntheticError("runner or complete Git metadata missing")
+
+    def git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(runner), *args], text=True, capture_output=True, check=False
+        )
+
+    head = git("rev-parse", "HEAD")
+    if head.returncode or head.stdout.strip() != config["runnerRevision"]:
+        raise SyntheticError("runner commit mismatch")
+    if git("status", "--porcelain=v1", "--untracked-files=no").stdout:
+        raise SyntheticError("runner tracked/index state is dirty")
+    if git("fsck", "--full", "--no-dangling").returncode:
+        raise SyntheticError("runner Git objects are incomplete")
+    alternates = runner / ".git/objects/info/alternates"
+    if (
+        alternates.exists()
+        or git("config", "--get", "extensions.worktreeConfig").stdout.strip() == "true"
+    ):
+        raise SyntheticError("runner depends on an external Git object store")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("runnerRevision") != config["runnerRevision"] or not isinstance(
+        manifest.get("files"), dict
+    ):
+        raise SyntheticError("runner manifest coordinates mismatch")
+    for relative, expected in manifest["files"].items():
+        target = runner / relative
+        if (
+            not target.is_file()
+            or target.is_symlink()
+            or hashlib.sha256(target.read_bytes()).hexdigest() != expected
+        ):
+            raise SyntheticError("critical runner file hash mismatch")
+    store = runner / "node_modules/.pnpm"
+    frontend = runner / "apps/web/node_modules"
+    command = runner / config["runnerCommand"]
+    spec = runner / config["runnerSpec"]
+    if not store.is_dir() or not any(store.iterdir()):
+        raise SyntheticError("root pnpm store missing")
+    if not frontend.is_dir() or any(
+        link.is_symlink() and not link.exists() for link in frontend.rglob("*")
+    ):
+        raise SyntheticError("frontend dependency link is broken")
+    if not command.is_file() or not os.access(command, os.X_OK) or not spec.is_file():
+        raise SyntheticError("Playwright CLI/shim or smoke spec missing")
+    probe = subprocess.run(
+        [str(command), "--version"],
+        cwd=runner,
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+        check=False,
+    )
+    if probe.returncode:
+        raise SyntheticError("Playwright CLI/shim resolution failed")
+    return runner
+
+
+def valid_result(
+    path: Path, config: dict, invocation: str, started: int, ended: int, uid: int, gid: int
+) -> bool:
+    try:
+        info = path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(info.st_mode) or (
+            info.st_uid,
+            info.st_gid,
+            stat.S_IMODE(info.st_mode),
+        ) != (uid, gid, 0o600):
+            return False
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return (
+            isinstance(value, dict)
+            and set(value) == RESULT_KEYS
+            and value["schemaVersion"] == 1
+            and value["journey"] == "/chat"
+            and type(value["passed"]) is bool
+            and value["runnerRevision"] == config["runnerRevision"]
+            and value["invocationId"] == invocation
+            and value["transport"] == "intercepted"
+            and value["mutationEnabled"] is False
+            and type(value["executedAt"]) is int
+            and type(value["completedAt"]) is int
+            and started <= value["executedAt"] <= value["completedAt"] <= ended
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError):
+        return False
+
+
+def publish_metric(path: Path, passed: bool, timestamp: int) -> None:
+    labels = 'application="dspace",environment="staging",cluster="sugarkube-int"'
+    content = (
+        "# HELP dspace_chat_synthetic_success Last executed isolated /chat result.\n"
+        "# TYPE dspace_chat_synthetic_success gauge\n"
+        f"dspace_chat_synthetic_success{{{labels}}} {int(passed)}\n"
+        "# HELP dspace_chat_synthetic_timestamp_seconds Unix time of the last execution.\n"
+        "# TYPE dspace_chat_synthetic_timestamp_seconds gauge\n"
+        f"dspace_chat_synthetic_timestamp_seconds{{{labels}}} {timestamp}\n"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            os.fchmod(stream.fileno(), 0o644)
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def execute(config: dict) -> int:
+    invocation = os.environ.get("INVOCATION_ID", "")
+    if not INVOCATION.fullmatch(invocation):
+        raise SyntheticError("a valid systemd INVOCATION_ID is required")
+    account, group = pwd.getpwnam(config["serviceAccount"]), grp.getgrnam(config["serviceGroup"])
+    if account.pw_gid != group.gr_gid:
+        raise SyntheticError("service account/group mismatch")
+    runner = verify_runner(config)
+    root = Path(config["resultRoot"])
+    check_mode(root, 0, group.gr_gid, 0o710, "result root")
+    lock_path = Path(config["lockPath"])
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock = lock_path.open("w")
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        raise SyntheticError("overlapping execution rejected")
+    result_dir = root / f"{account.pw_name}-{invocation}"
+    if result_dir.exists():
+        raise SyntheticError("pre-existing invocation path rejected")
+    result_dir.mkdir(mode=0o770)
+    os.chown(result_dir, 0, group.gr_gid)
+    check_mode(result_dir, 0, group.gr_gid, 0o770, "invocation directory")
+    result = result_dir / "result.json"
+    started = int(time.time())
+    argv = [
+        str(runner / config["runnerCommand"]),
+        "test",
+        config["runnerSpec"],
+        "--",
+        "--result",
+        str(result),
+        "--invocation-id",
+        invocation,
+        "--started-at",
+        utc(started),
+        "--identity-contract",
+        config["identityContract"],
+        "--provider-config-contract",
+        config["providerConfigContract"],
+        "--provider",
+        config["provider"],
+        "--expected-version",
+        config["dspaceVersion"],
+        "--expected-revision",
+        config["dspaceSourceRevision"],
+        "--expected-token-place-origin",
+        config["tokenPlaceOrigin"],
+        "--expected-token-place-model",
+        config["tokenPlaceModel"],
+    ]
+    command = (
+        argv
+        if os.environ.get("SUGARKUBE_SYNTHETIC_TEST_DIRECT") == "1"
+        else ["runuser", "--user", account.pw_name, "--", *argv]
+    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=runner,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=config["timeoutSeconds"],
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        completed = None
+    ended = int(time.time())
+    usable = completed is not None and valid_result(
+        result, config, invocation, started, ended, account.pw_uid, group.gr_gid
+    )
+    if usable:
+        publish_metric(Path(config["metricPath"]), json.loads(result.read_text())["passed"], ended)
+    shutil.rmtree(result_dir)  # exact invocation-owned path only
+    print(
+        "dspace-chat-synthetic "
+        f"invocation={invocation} start={utc(started)} end={utc(ended)} "
+        f"result={'published' if usable else 'preserved'}"
+    )
+    return 0 if usable else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config", type=Path, default=Path("/etc/sugarkube/dspace-chat-synthetic.json")
+    )
+    args = parser.parse_args()
+    try:
+        return execute(load_config(args.config))
+    except (
+        SyntheticError,
+        OSError,
+        KeyError,
+        json.JSONDecodeError,
+        subprocess.SubprocessError,
+    ) as error:
+        print(f"dspace-chat-synthetic: rejected: {error}", file=os.sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Stage, inspect, install, or explicitly roll back the synthetic producer."""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.dspace_chat_synthetic import load_config, verify_runner  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSETS = {
+    "wrapper": ROOT / "scripts/dspace_chat_synthetic",
+    "producer": ROOT / "scripts/dspace_chat_synthetic.py",
+    "config": ROOT / "config/dspace-chat-synthetic/staging.json",
+    "service": ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.service",
+    "timer": ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.timer",
+}
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def targets(root: Path) -> dict[str, Path]:
+    return {
+        "wrapper": root / "usr/local/libexec/sugarkube-dspace-chat-synthetic",
+        "producer": root / "usr/local/libexec/sugarkube-dspace-chat-synthetic.py",
+        "config": root / "etc/sugarkube/dspace-chat-synthetic.json",
+        "service": root / "etc/systemd/system/sugarkube-dspace-chat-synthetic.service",
+        "timer": root / "etc/systemd/system/sugarkube-dspace-chat-synthetic.timer",
+    }
+
+
+def validate_assets() -> dict:
+    config = load_config(ASSETS["config"])
+    for asset in ASSETS.values():
+        if not asset.is_file() or asset.is_symlink():
+            raise ValueError("repository asset missing or linked")
+    if "Persistent=true" not in ASSETS["timer"].read_text() or any(
+        word in ASSETS["service"].read_text() + ASSETS["timer"].read_text()
+        for word in ("systemctl start", "systemctl enable")
+    ):
+        raise ValueError("unit activation contract invalid")
+    return config
+
+
+def status(root: Path) -> None:
+    config = validate_assets()
+    installed = targets(root)
+    print(
+        f"runnerRevision={config['runnerRevision']} "
+        f"dspaceVersion={config['dspaceVersion']} "
+        f"sourceRevision={config['dspaceSourceRevision']}"
+    )
+    for name, source in ASSETS.items():
+        target = installed[name]
+        print(
+            f"{name} repositorySha256={digest(source)} "
+            f"installedSha256={digest(target) if target.is_file() else 'missing'}"
+        )
+    wants = root / "etc/systemd/system/timers.target.wants/sugarkube-dspace-chat-synthetic.timer"
+    print(f"timerActivation={'present' if wants.exists() else 'absent'}")
+
+
+def install(root: Path, runner: Path, apply: bool) -> None:
+    config = validate_assets()
+    if runner.resolve() != (
+        Path(config["runnerRoot"]) / config["runnerRevision"]
+    ).resolve() and root == Path("/"):
+        raise ValueError("runner target coordinate mismatch")
+    # Validate before touching an installed target. Test roots may use rendered configuration.
+    if root == Path("/"):
+        verify_runner(config)
+    stage = Path(tempfile.mkdtemp(prefix="dspace-synthetic-stage."))
+    try:
+        for name, source in ASSETS.items():
+            shutil.copy2(source, stage / name)
+        if not apply:
+            print("validated dry-run; no files or units changed")
+            return
+        installed = targets(root)
+        retention = (
+            root / "var/lib/sugarkube/dspace-chat-synthetic/retained" / config["runnerRevision"]
+        )
+        retention.mkdir(parents=True, exist_ok=True)
+        for name, target in installed.items():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                shutil.copy2(target, retention / name)
+            temporary = target.with_name(f".{target.name}.new")
+            shutil.copy2(stage / name, temporary)
+            os.chmod(temporary, 0o755 if name in {"wrapper", "producer"} else 0o644)
+            os.replace(temporary, target)
+        print("installed files only; no service or timer activation performed")
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+
+def rollback(root: Path, revision: str, apply: bool) -> None:
+    if not revision or any(c not in "0123456789abcdef" for c in revision) or len(revision) != 40:
+        raise ValueError("rollback requires an exact revision")
+    retained = root / "var/lib/sugarkube/dspace-chat-synthetic/retained" / revision
+    installed = targets(root)
+    if not retained.is_dir() or any(not (retained / name).is_file() for name in installed):
+        raise ValueError("exact validated retained revision is unavailable")
+    load_config(retained / "config")
+    if not apply:
+        print("validated rollback dry-run; no files or units changed")
+        return
+    for name, target in installed.items():
+        temporary = target.with_name(f".{target.name}.rollback")
+        shutil.copy2(retained / name, temporary)
+        os.replace(temporary, target)
+    print("rolled back files only; no service or timer activation performed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "action",
+        choices=("validate", "install", "status", "rollback"),
+        default="validate",
+        nargs="?",
+    )
+    parser.add_argument("--root", type=Path, default=Path("/"))
+    parser.add_argument("--runner", type=Path)
+    parser.add_argument("--revision")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.action == "status":
+            status(args.root)
+        elif args.action == "rollback":
+            rollback(args.root, args.revision or "", args.apply)
+        else:
+            install(
+                args.root,
+                args.runner or Path("/nonexistent"),
+                args.apply if args.action == "install" else False,
+            )
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/materialize_dspace_chat_runner.py
+++ b/scripts/materialize_dspace_chat_runner.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Build an independent, immutable DSPACE smoke-runner snapshot from local source."""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+class MaterializeError(RuntimeError):
+    pass
+
+
+def run(argv: list[str], *, cwd: Path | None = None) -> str:
+    completed = subprocess.run(argv, cwd=cwd, text=True, capture_output=True, check=False)
+    if completed.returncode:
+        raise MaterializeError("runner construction command failed")
+    return completed.stdout.strip()
+
+
+def materialize(
+    source: Path, revision: str, destination: Path, expected_origin: str, pnpm: str
+) -> Path:
+    source = source.resolve()
+    if not (source / ".git").exists() or run(
+        ["git", "-C", str(source), "rev-parse", "--show-toplevel"]
+    ) != str(source):
+        raise MaterializeError("source must be an explicitly identified repository root")
+    origin = run(["git", "-C", str(source), "remote", "get-url", "origin"])
+    if origin.rstrip("/").removesuffix(".git") != expected_origin.rstrip("/").removesuffix(".git"):
+        raise MaterializeError("source repository identity mismatch")
+    if run(["git", "-C", str(source), "rev-parse", "HEAD"]) != revision:
+        raise MaterializeError("source HEAD is not the exact requested commit")
+    run(["git", "-C", str(source), "cat-file", "-e", f"{revision}^{{commit}}"])
+    if run(["git", "-C", str(source), "status", "--porcelain=v1", "--untracked-files=no"]):
+        raise MaterializeError("source tracked/index state is dirty")
+    if (source / ".git/objects/info/alternates").exists():
+        raise MaterializeError("source depends on an external object store")
+    if not (source / "pnpm-lock.yaml").is_file() or not (source / "pnpm-workspace.yaml").is_file():
+        raise MaterializeError("exact pnpm workspace inputs are missing")
+    if destination.exists():
+        raise MaterializeError("destination already exists")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{revision}.", dir=destination.parent))
+    try:
+        # A local clone with --no-local copies every reachable object and creates no alternates.
+        run(
+            [
+                "git",
+                "clone",
+                "--no-local",
+                "--no-hardlinks",
+                "--no-checkout",
+                str(source),
+                str(staging),
+            ]
+        )
+        run(["git", "-C", str(staging), "checkout", "--detach", revision])
+        run(["git", "-C", str(staging), "reflog", "expire", "--expire=now", "--all"])
+        run(["git", "-C", str(staging), "gc", "--prune=now"])
+        if (staging / ".git/objects/info/alternates").exists():
+            raise MaterializeError("snapshot unexpectedly contains alternates")
+        run(["git", "-C", str(staging), "fsck", "--full", "--no-dangling"])
+        env = os.environ.copy()
+        env["CI"] = "1"
+        completed = subprocess.run(
+            [pnpm, "install", "--frozen-lockfile", "--offline"],
+            cwd=staging,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if completed.returncode:
+            raise MaterializeError("offline frozen pnpm installation failed")
+        critical = [
+            "pnpm-lock.yaml",
+            "pnpm-workspace.yaml",
+            "package.json",
+            "apps/web/package.json",
+            "apps/web/tests/remote-chat-smoke.spec.ts",
+        ]
+        for relative in critical:
+            if not (staging / relative).is_file():
+                raise MaterializeError(f"critical runner file missing: {relative}")
+        store, cli = (
+            staging / "node_modules/.pnpm",
+            staging / "apps/web/node_modules/.bin/playwright",
+        )
+        if not store.is_dir() or not any(store.iterdir()):
+            raise MaterializeError("root pnpm store missing")
+        if any(
+            path.is_symlink() and not path.exists()
+            for path in (staging / "apps/web/node_modules").rglob("*")
+        ):
+            raise MaterializeError("broken frontend dependency link")
+        if not cli.is_file() or not os.access(cli, os.X_OK):
+            raise MaterializeError("Playwright CLI/shim missing")
+        run([str(cli), "--version"], cwd=staging)
+        run(["node", "-e", "require.resolve('@playwright/test')"], cwd=staging / "apps/web")
+        files = {
+            relative: hashlib.sha256((staging / relative).read_bytes()).hexdigest()
+            for relative in critical
+        }
+        (staging / "sugarkube-runner-manifest.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "runnerRevision": revision,
+                    "sourceOrigin": expected_origin,
+                    "files": files,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        os.replace(staging, destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return destination
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--destination", required=True, type=Path)
+    parser.add_argument("--expected-origin", default="https://github.com/democratizedspace/dspace")
+    parser.add_argument("--pnpm", default="pnpm")
+    args = parser.parse_args()
+    try:
+        materialize(args.source, args.revision, args.destination, args.expected_origin, args.pnpm)
+    except (MaterializeError, OSError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/systemd/sugarkube-dspace-chat-synthetic.service
+++ b/scripts/systemd/sugarkube-dspace-chat-synthetic.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Sugarkube DSPACE staging chat synthetic producer
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/dspace-chat-synthetic-producer.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/timeout --signal=TERM --kill-after=15s 300s /usr/local/libexec/sugarkube-dspace-chat-synthetic
+RuntimeDirectory=sugarkube/dspace-chat-synthetic
+RuntimeDirectoryMode=0710
+UMask=0077
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadOnlyPaths=/var/lib/sugarkube/dspace-chat-runners
+ReadWritePaths=/run/sugarkube/dspace-chat-synthetic /run/lock /var/lib/node_exporter/textfile_collector
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+TimeoutStartSec=330s

--- a/scripts/systemd/sugarkube-dspace-chat-synthetic.timer
+++ b/scripts/systemd/sugarkube-dspace-chat-synthetic.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Schedule the Sugarkube DSPACE staging chat synthetic producer
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+AccuracySec=30s
+RandomizedDelaySec=30s
+Persistent=true
+Unit=sugarkube-dspace-chat-synthetic.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -1,0 +1,147 @@
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import dspace_chat_synthetic as producer
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "config/dspace-chat-synthetic/staging.json"
+INSTALLER = ROOT / "scripts/install_dspace_chat_synthetic.py"
+
+
+def test_config_explicitly_binds_approved_coordinates():
+    value = producer.load_config(CONFIG)
+    assert value["identityContract"] == "build-info-v1"
+    assert value["providerConfigContract"] == "legacy-no-default-provider-v1"
+    assert value["runnerRevision"] == "97ab09f13fb098de928a878bf1fe9b8d13032cb5"
+    assert value["dspaceSourceRevision"] == "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2"
+
+
+def test_contract_is_not_inferred_from_absence(tmp_path):
+    value = json.loads(CONFIG.read_text())
+    del value["providerConfigContract"]
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(value))
+    with pytest.raises(producer.SyntheticError, match="exact schema"):
+        producer.load_config(path)
+
+
+def test_legacy_contract_rejected_for_coordinate_drift(tmp_path):
+    value = json.loads(CONFIG.read_text())
+    value["dspaceVersion"] = "3.1.2"
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(value))
+    with pytest.raises(producer.SyntheticError, match="not approved"):
+        producer.load_config(path)
+
+
+def test_valid_result_binds_invocation_window_owner_and_mode(tmp_path):
+    config = json.loads(CONFIG.read_text())
+    invocation = "a" * 32
+    path = tmp_path / "result.json"
+    value = {
+        "schemaVersion": 1,
+        "journey": "/chat",
+        "passed": True,
+        "executedAt": 100,
+        "completedAt": 101,
+        "invocationId": invocation,
+        "runnerRevision": config["runnerRevision"],
+        "transport": "intercepted",
+        "mutationEnabled": False,
+    }
+    path.write_text(json.dumps(value))
+    path.chmod(0o600)
+    assert producer.valid_result(path, config, invocation, 99, 102, os.getuid(), os.getgid())
+    for field, replacement in (
+        ("invocationId", "b" * 32),
+        ("executedAt", 98),
+        ("completedAt", 103),
+        ("passed", "true"),
+    ):
+        changed = dict(value)
+        changed[field] = replacement
+        path.write_text(json.dumps(changed))
+        path.chmod(0o600)
+        assert not producer.valid_result(
+            path, config, invocation, 99, 102, os.getuid(), os.getgid()
+        )
+    path.write_text(json.dumps(value))
+    path.chmod(0o644)
+    assert not producer.valid_result(path, config, invocation, 99, 102, os.getuid(), os.getgid())
+
+
+def test_metric_publication_is_atomic_and_preservation_is_callers_default(tmp_path, monkeypatch):
+    output = tmp_path / "metric.prom"
+    output.write_bytes(b"previous\n")
+    before = output.read_bytes()
+    assert before == b"previous\n"
+    replaced = []
+    original = producer.os.replace
+    monkeypatch.setattr(
+        producer.os,
+        "replace",
+        lambda source, target: (replaced.append((source, target)), original(source, target))[1],
+    )
+    producer.publish_metric(output, True, 123)
+    assert replaced and output.read_text().endswith(" 123\n")
+    assert "dspace_chat_synthetic_success" in output.read_text()
+
+
+def test_wrapper_safety_provider_argv_and_units():
+    wrapper = (ROOT / "scripts/dspace_chat_synthetic").read_text()
+    assert wrapper.splitlines()[1:5] == [
+        "set +x",
+        "set -Eeuo pipefail",
+        "umask 077",
+        "export PYTHONDONTWRITEBYTECODE=1",
+    ]
+    source = (ROOT / "scripts/dspace_chat_synthetic.py").read_text()
+    assert '"--provider"' in source and 'config["provider"]' in source
+    assert "shutil.rmtree(result_dir)" in source
+    assert "glob-based cleanup" not in source
+    service = (ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.service").read_text()
+    timer = (ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.timer").read_text()
+    assert "Type=oneshot" in service and "TimeoutStartSec=330s" in service
+    assert "Persistent=true" in timer
+    assert "systemctl" not in service + timer
+
+
+def test_installer_dry_run_and_status_are_non_mutating(tmp_path):
+    before = hashlib.sha256(str(sorted(tmp_path.rglob("*"))).encode()).hexdigest()
+    result = subprocess.run(
+        [str(INSTALLER), "install", "--root", str(tmp_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "no files or units changed" in result.stdout
+    assert not list(tmp_path.rglob("*"))
+    status = subprocess.run(
+        [str(INSTALLER), "status", "--root", str(tmp_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert status.returncode == 0 and "timerActivation=absent" in status.stdout
+    assert before == hashlib.sha256(str(sorted(tmp_path.rglob("*"))).encode()).hexdigest()
+
+
+@pytest.mark.parametrize("revision", ["", "abc", "g" * 40, "1" * 39])
+def test_rollback_requires_exact_retained_revision(tmp_path, revision):
+    result = subprocess.run(
+        [str(INSTALLER), "rollback", "--root", str(tmp_path), "--revision", revision],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert not list(tmp_path.rglob("*"))


### PR DESCRIPTION
### Motivation

- Replace the prior private/manual DSPACE staging synthetic-producer with a reviewed, reproducible, repository-owned implementation that can be staged, validated, and later cut over under separate authorization.
- Provide deterministic runner construction, strict preflight validation, fail-closed execution, safe installer/rollback, and observability metric publication that preserves prior metrics on failure.

### Description

- Add a declarative staging coordinate record binding runner revision, DSPACE coordinates, identity/provider contracts, token.place origin/model, bounded timeout, service account, and exact runtime/metric/lock/result paths (`config/dspace-chat-synthetic/staging.json`).
- Add a minimal wrapper and a fail-closed Python producer that validates config and runner metadata, enforces exact contracts and coordinates, requires `INVOCATION_ID`, prevents overlaps, runs the unprivileged child, validates invocation-owned result ownership/mode/schema/window, atomically publishes node-exporter textfile metrics, and cleans only the current invocation directory (`scripts/dspace_chat_synthetic`, `scripts/dspace_chat_synthetic.py`).
- Add a deterministic materializer that snapshots a local DSPACE repository into an independent runner (full Git metadata, no alternates), performs offline frozen `pnpm` installation checks, validates Playwright/Node resolution, and emits a hashed runner manifest (`scripts/materialize_dspace_chat_runner.py`).
- Add a dry-run-first installer/updater with staging, per-file atomic replacement, retained prior revisions, explicit exact-revision rollback, non-mutating `status`/`validate` modes, and unit/timer assets (no automatic `systemctl` activation) plus systemd unit and timer templates that follow the repository hardening conventions (`scripts/install_dspace_chat_synthetic.py`, `scripts/systemd/*`).
- Add a runbook documenting the trust model, construction/validation/install/execute/timer/rollback separation, ownership and mode requirements, stale-metric preservation behavior, and required operator cutover steps (`docs/dspace-chat-synthetic-producer.md`).
- Add deterministic tests that exercise coordinate/contract selection, config schema rejection, result ownership/mode/window validation, atomic metric publication, wrapper safety assertions, non-mutating installer dry-run/status, and exact rollback validation (`tests/test_dspace_chat_synthetic_producer.py`).

### Testing

- Ran focused and relevant test suites: `pytest` on the new tests plus related verifier and observability tests returned all expected results; focused run reported the added tests passing and the trio of related test modules succeeded (test run: 241 passed for the selected suites).
- Performed static checks and formatting: `python -m py_compile` on new Python scripts, `bash -n` for the wrapper, `black` formatting, `flake8` checks for the new files, `git diff --cached --check`, and the repo secret scanner on the staged diff — these passed for the changes introduced here.
- Performed docs/link checks: `linkchecker --no-warnings README.md docs/` completed with no broken links; `pyspelling` could not complete in this environment because the `aspell` binary is not available (not a regression in the change set).
- Notes and limits: `pre-commit run --all-files` flagged unrelated, pre-existing repository-wide checks (outside the scope of this PR) and therefore did not fully complete globally in this environment; pushing/creating a remote PR was not performed because GitHub authentication is not available from this environment.

No live installation, systemd mutation, timer activation, cluster access, Helm operations, runner execution on a real host, or production/staging changes were performed as part of this work; the change provides the repository artifacts and deterministic tests required for a separately authorized host cutover.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8599b49834832f97a2498de41e2c3e)