### PR TITLE
Add durable repository-owned DSPACE chat synthetic producer

### DIFF
--- a/config/dspace-chat-synthetic.json
+++ b/config/dspace-chat-synthetic.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "runner_revision": "97ab09f13fb098de928a878bf1fe9b8d13032cb5",
+  "dspace_repository": "https://github.com/democratizedspace/dspace.git",
+  "dspace_version": "3.1.1",
+  "dspace_source_revision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "identity_contract": "build-info-v1",
+  "provider_config_contract": "legacy-no-default-provider-v1",
+  "provider": "token-place",
+  "origin": "https://staging.token.place",
+  "model": "qwen3-8b-instruct",
+  "timeout_seconds": 180,
+  "service_user": "pi",
+  "service_group": "pi",
+  "runner_root": "/var/lib/sugarkube/dspace-chat-runners",
+  "result_root": "/run/sugarkube/dspace-chat-results",
+  "metric_path": "/var/lib/node_exporter/textfile_collector/dspace-chat.prom",
+  "wrapper_path": "/usr/local/libexec/sugarkube-dspace-chat-synthetic"
+}

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -1,0 +1,81 @@
+# Repository-owned DSPACE chat synthetic producer
+
+This package replaces behavioral provenance from the former private/manual staging recovery with
+reviewable source. The old wrapper hash
+`5a160f1e4c077c09cda5fec062733cd9b31ed8cbfbc5b7f0779403f4a829e70e` is recorded only as a
+baseline: it is not a source input, and the repository wrapper legitimately has another hash. Live
+cutover is **not** part of repository construction or installation and requires a separate reviewed,
+explicitly authorized operation.
+
+## Trust and filesystem model
+
+The checked-in JSON explicitly selects the release, source and runner commits, `build-info-v1`, and
+`legacy-no-default-provider-v1`; absence never selects a contract. The legacy provider contract is
+accepted only for DSPACE 3.1.1 at source `22f506e07e0b5abfd0cf756e9c5827c0458fb4b2`.
+The runner is a complete detached Git checkout, including its object database, exact lockfile and
+root `node_modules/.pnpm` store. Complete Git metadata proves the commit and cleanliness without the
+source checkout; the root store is required because pnpm workspace links resolve through it.
+
+The result root is `root:pi` mode `0710`; each invocation directory is `root:pi` mode `0770`; and
+the unprivileged `pi` child atomically renames its same-directory temporary result to a `pi:pi`, mode
+`0600` final file. The wrapper accepts only its exact `INVOCATION_ID`, time window, owner, mode,
+schema and coordinates, then removes only that invocation directory. Normal cleanup is not evidence
+loss. Invalid, missing, late, or timed-out results leave the prior metric byte-for-byte unchanged.
+A passing Playwright summary does not prove that the bounded result was published.
+
+## 1. Construct and validate a runner
+
+From an explicitly identified local, clean DSPACE checkout at the exact commit (never from a live
+host), run:
+
+```bash
+python3 scripts/materialize_dspace_chat_runner.py \
+  --source /absolute/path/to/local/dspace \
+  --repository https://github.com/democratizedspace/dspace.git \
+  --revision 97ab09f13fb098de928a878bf1fe9b8d13032cb5 \
+  --output /safe/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5
+```
+
+Construction uses frozen lockfile resolution, validates Playwright and module resolution, rejects
+alternates and broken frontend links, and writes hashes to `sugarkube-runner-manifest.json`.
+
+## 2. Render and inspect without mutation
+
+```bash
+python3 scripts/install_dspace_chat_synthetic.py dry-run
+python3 scripts/install_dspace_chat_synthetic.py status --root /temporary/root
+```
+
+Dry-run is the default. Tests should always use `--root` with a temporary directory. Review rendered
+hashes, coordinates, unit provenance and the persistent timer before authorizing any later operation.
+
+## 3. Install, execute, and activate separately
+
+Only after separate host authorization, `apply` stages and validates all assets before atomic
+replacement. It does not call systemctl. A controlled execution and timer activation are distinct
+operator decisions: first use `systemctl start dspace-chat-synthetic.service`, inspect its bounded
+summary and metric freshness, then separately use `systemctl enable --now
+dspace-chat-synthetic.timer`. The timer has `Persistent=true`; installation never enables, starts,
+stops, restarts, or disables it.
+
+## 4. Read-only failure classification
+
+Before considering a retry, use `status`, `systemctl show` for activation state and unit hashes, and
+read only metric metadata and bounded wrapper summaries. Classify preflight, overlap, launch,
+timeout, absent result, result validation, or metric publication failure. Do not print raw results,
+journals, credentials, Secret values, browser output, or private artifacts. Do not retry until a new
+reviewed operator decision; the producer never retries, restarts, rolls back, or invokes a second run.
+
+## 5. Explicit recovery and evidence
+
+An applied update retains the preceding validated asset set. Recovery requires its exact revision:
+
+```bash
+python3 scripts/install_dspace_chat_synthetic.py rollback --revision EXACT_RETAINED_REVISION
+```
+
+Rollback validates every retained hash and does not manipulate systemd. Collect only configuration,
+runner-manifest and unit hashes, coordinates, activation states, invocation-bound summaries, and
+metric timestamp/value. Never collect payloads or sensitive artifacts. After merge, the remaining
+work is a separately reviewed host cutover: materialize/copy the runner, prepare exact ownership and
+modes, apply assets, perform one controlled run, and explicitly activate and observe the schedule.

--- a/scripts/dspace-chat-synthetic
+++ b/scripts/dspace-chat-synthetic
@@ -1,0 +1,7 @@
+#!/bin/bash
+set +x
+set -Eeuo pipefail
+umask 077
+export PYTHONDONTWRITEBYTECODE=1
+
+exec /usr/bin/python3 /usr/local/libexec/sugarkube-dspace-chat-synthetic.py "$@"

--- a/scripts/dspace_chat_synthetic.py
+++ b/scripts/dspace_chat_synthetic.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Fail-closed, invocation-bound DSPACE synthetic producer."""
+
+import argparse
+import fcntl
+import json
+import os
+import pwd
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+SHA = re.compile(r"[0-9a-f]{40}")
+INVOCATION = re.compile(r"[0-9a-f]{32}")
+APPROVED_LEGACY = ("3.1.1", "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2")
+REQUIRED = {
+    "runner_revision",
+    "dspace_version",
+    "dspace_source_revision",
+    "identity_contract",
+    "provider_config_contract",
+    "provider",
+    "origin",
+    "model",
+    "timeout_seconds",
+    "service_user",
+    "service_group",
+    "runner_root",
+    "result_root",
+    "metric_path",
+    "wrapper_path",
+}
+
+
+def utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_config(path: Path) -> dict:
+    value = json.loads(path.read_text())
+    missing = REQUIRED - value.keys()
+    if missing:
+        raise ValueError("configuration lacks explicit required fields")
+    if not SHA.fullmatch(value["runner_revision"]) or not SHA.fullmatch(
+        value["dspace_source_revision"]
+    ):
+        raise ValueError("coordinates require full commit hashes")
+    if value["identity_contract"] != "build-info-v1":
+        raise ValueError("unsupported explicit identity contract")
+    if value["provider_config_contract"] != "legacy-no-default-provider-v1":
+        raise ValueError("unsupported explicit provider configuration contract")
+    if (value["dspace_version"], value["dspace_source_revision"]) != APPROVED_LEGACY:
+        raise ValueError("legacy provider contract is restricted to approved DSPACE coordinates")
+    if not 1 <= int(value["timeout_seconds"]) <= 300:
+        raise ValueError("timeout is outside the bounded range")
+    for key in ("runner_root", "result_root", "metric_path", "wrapper_path"):
+        if not Path(value[key]).is_absolute() or "$" in value[key]:
+            raise ValueError(f"{key} must be an absolute resolved path")
+    return value
+
+
+def check_dir(path: Path, uid: int, gid: int, mode: int) -> None:
+    info = path.stat()
+    if not stat.S_ISDIR(info.st_mode) or (info.st_uid, info.st_gid, stat.S_IMODE(info.st_mode)) != (
+        uid,
+        gid,
+        mode,
+    ):
+        raise ValueError(f"unsafe ownership or mode for {path}")
+
+
+def validate_runner(config: dict) -> Path:
+    runner = Path(config["runner_root"]) / config["runner_revision"]
+    manifest = json.loads((runner / "sugarkube-runner-manifest.json").read_text())
+    if manifest.get("revision") != config["runner_revision"]:
+        raise ValueError("wrapper/config/runner coordinate mismatch")
+    if (
+        subprocess.check_output(["git", "-C", str(runner), "rev-parse", "HEAD"], text=True).strip()
+        != config["runner_revision"]
+    ):
+        raise ValueError("runner HEAD mismatch")
+    if subprocess.run(
+        ["git", "-C", str(runner), "status", "--porcelain", "--untracked-files=no"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout:
+        raise ValueError("runner tracked/index state is dirty")
+    if (runner / ".git/objects/info/alternates").exists() or not (
+        runner / "node_modules/.pnpm"
+    ).is_dir():
+        raise ValueError("runner is incomplete or externally dependent")
+    for relative, expected in manifest.get("files", {}).items():
+        import hashlib
+
+        actual = hashlib.sha256((runner / relative).read_bytes()).hexdigest()
+        if actual != expected:
+            raise ValueError("critical runner file hash mismatch")
+    cli = runner / "node_modules/.bin/playwright"
+    if (
+        not cli.exists()
+        or not os.access(cli, os.X_OK)
+        or (cli.is_symlink() and not cli.resolve().exists())
+    ):
+        raise ValueError("Playwright CLI/shim is invalid")
+    subprocess.run(
+        ["node", "-e", "require.resolve('@playwright/test')"],
+        cwd=runner,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return runner
+
+
+def metric(config: dict, passed: bool, timestamp: int) -> bytes:
+    labels = 'application="dspace",environment="staging",cluster="sugarkube-int"'
+    return (
+        "# HELP dspace_chat_synthetic_success Last executed isolated /chat result.\n"
+        "# TYPE dspace_chat_synthetic_success gauge\n"
+        f"dspace_chat_synthetic_success{{{labels}}} {int(passed)}\n"
+        "# HELP dspace_chat_synthetic_timestamp_seconds Unix time of the last execution.\n"
+        "# TYPE dspace_chat_synthetic_timestamp_seconds gauge\n"
+        f"dspace_chat_synthetic_timestamp_seconds{{{labels}}} {timestamp}\n"
+    ).encode()
+
+
+def publish(path: Path, content: bytes) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=".dspace-chat.", dir=path.parent)
+    try:
+        os.write(fd, content)
+        os.fsync(fd)
+        os.fchmod(fd, 0o644)
+        os.close(fd)
+        fd = -1
+        os.replace(temporary, path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config", type=Path, default=Path("/etc/sugarkube/dspace-chat-synthetic.json")
+    )
+    args = parser.parse_args()
+    invocation = os.environ.get("INVOCATION_ID", "")
+    if not INVOCATION.fullmatch(invocation):
+        parser.error("a valid systemd INVOCATION_ID is required")
+    started, start_epoch = utc(), int(time.time())
+    config = load_config(args.config)
+    account = pwd.getpwnam(config["service_user"])
+    result_root = Path(config["result_root"])
+    metric_path = Path(config["metric_path"])
+    lock = os.open(result_root.parent / "dspace-chat-synthetic.lock", os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        print(f"invocation={invocation} outcome=overlap-rejected start={started}")
+        return 75
+    invocation_dir = result_root / f"{config['service_user']}-{invocation}"
+    result = invocation_dir / "result.json"
+    try:
+        check_dir(result_root, 0, account.pw_gid, 0o710)
+        if invocation_dir.exists():
+            raise ValueError("invocation result path already exists")
+        runner = validate_runner(config)
+        invocation_dir.mkdir(mode=0o770)
+        os.chown(invocation_dir, 0, account.pw_gid)
+        argv = [
+            str(runner / "node_modules/.bin/playwright"),
+            "test",
+            "tests/remote-chat-smoke.spec.ts",
+            "--",
+            "--provider",
+            config["provider"],
+            "--origin",
+            config["origin"],
+            "--model",
+            config["model"],
+            "--identity-contract",
+            config["identity_contract"],
+            "--provider-config-contract",
+            config["provider_config_contract"],
+            "--result",
+            str(result),
+            "--runner-revision",
+            config["runner_revision"],
+            "--invocation-id",
+            invocation,
+        ]
+
+        def demote():
+            os.setgid(account.pw_gid)
+            os.setuid(account.pw_uid)
+
+        try:
+            subprocess.run(
+                argv,
+                cwd=runner,
+                timeout=config["timeout_seconds"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                preexec_fn=demote,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            print(
+                f"invocation={invocation} outcome=no-consumable-result start={started} end={utc()}"
+            )
+            return 1
+        info = result.stat()
+        if (info.st_uid, info.st_gid, stat.S_IMODE(info.st_mode)) != (
+            account.pw_uid,
+            account.pw_gid,
+            0o600,
+        ):
+            raise ValueError("unsafe result ownership or mode")
+        value = json.loads(result.read_text())
+        end_epoch = int(time.time())
+        if set(value) != {
+            "schemaVersion",
+            "passed",
+            "runnerRevision",
+            "invocationId",
+            "startedAt",
+            "endedAt",
+        }:
+            raise ValueError("malformed bounded result")
+        if (
+            value["schemaVersion"] != 1
+            or type(value["passed"]) is not bool
+            or value["runnerRevision"] != config["runner_revision"]
+            or value["invocationId"] != invocation
+        ):
+            raise ValueError("result binding mismatch")
+        if not start_epoch <= value["startedAt"] <= value["endedAt"] <= end_epoch:
+            raise ValueError("result is outside invocation window")
+        publish(metric_path, metric(config, value["passed"], end_epoch))
+        passed_summary = str(value["passed"]).lower()
+        print(
+            f"invocation={invocation} outcome=published "
+            f"passed={passed_summary} start={started} end={utc()}"
+        )
+        return 0 if value["passed"] else 1
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError):
+        print(f"invocation={invocation} outcome=no-consumable-result start={started} end={utc()}")
+        return 1
+    finally:
+        if invocation_dir.exists():
+            shutil.rmtree(invocation_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Stage, inspect, install, or explicitly recover the DSPACE producer."""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+ASSETS = {
+    "usr/local/libexec/sugarkube-dspace-chat-synthetic": "scripts/dspace-chat-synthetic",
+    "usr/local/libexec/sugarkube-dspace-chat-synthetic.py": "scripts/dspace_chat_synthetic.py",
+    "etc/sugarkube/dspace-chat-synthetic.json": "config/dspace-chat-synthetic.json",
+    "etc/systemd/system/dspace-chat-synthetic.service": (
+        "scripts/systemd/dspace-chat-synthetic.service"
+    ),
+    "etc/systemd/system/dspace-chat-synthetic.timer": "scripts/systemd/dspace-chat-synthetic.timer",
+}
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def stage(repo: Path, root: Path) -> dict:
+    hashes = {}
+    for target, source in ASSETS.items():
+        src = repo / source
+        if not src.is_file():
+            raise ValueError(f"missing repository asset: {source}")
+        dst = root / target
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        os.chmod(dst, 0o755 if target.startswith("usr/") else 0o644)
+        hashes[target] = digest(dst)
+    config = json.loads((root / "etc/sugarkube/dspace-chat-synthetic.json").read_text())
+    if config["wrapper_path"] != "/usr/local/libexec/sugarkube-dspace-chat-synthetic":
+        raise ValueError("wrapper target mismatch")
+    if (
+        "Persistent=true"
+        not in (root / "etc/systemd/system/dspace-chat-synthetic.timer").read_text()
+    ):
+        raise ValueError("timer is not persistent")
+    return {"schema_version": 1, "revision": config["runner_revision"], "files": hashes}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "command", nargs="?", choices=("dry-run", "apply", "status", "rollback"), default="dry-run"
+    )
+    p.add_argument("--root", type=Path, default=Path("/"))
+    p.add_argument("--repo", type=Path, default=REPO)
+    p.add_argument("--revision")
+    a = p.parse_args()
+    installed = a.root / "var/lib/sugarkube/dspace-chat-installer"
+    current = installed / "current.json"
+    retained = installed / "retained"
+    if a.command == "status":
+        value = json.loads(current.read_text()) if current.exists() else {"installed": False}
+        value["timer_enabled"] = (
+            subprocess.run(
+                ["systemctl", "is-enabled", "dspace-chat-synthetic.timer"], capture_output=True
+            ).returncode
+            == 0
+            if a.root == Path("/")
+            else None
+        )
+        print(json.dumps(value, sort_keys=True))
+        return 0
+    if a.command == "rollback":
+        if not a.revision or not (retained / f"{a.revision}.json").is_file():
+            p.error("rollback requires an exact validated retained revision")
+        manifest = json.loads((retained / f"{a.revision}.json").read_text())
+        for target, expected in manifest["files"].items():
+            candidate = retained / a.revision / target
+            if not candidate.is_file() or digest(candidate) != expected:
+                p.error("retained revision validation failed")
+            dst = a.root / target
+            tmp = dst.with_name(f".{dst.name}.rollback")
+            shutil.copy2(candidate, tmp)
+            os.replace(tmp, dst)
+        current.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        return 0
+    with tempfile.TemporaryDirectory() as temporary:
+        staged = Path(temporary)
+        manifest = stage(a.repo, staged)
+        print(json.dumps(manifest, sort_keys=True))
+        if a.command == "dry-run":
+            return 0
+        installed.mkdir(parents=True, exist_ok=True)
+        retained.mkdir(exist_ok=True)
+        if current.exists():
+            old = json.loads(current.read_text())
+            oldrev = old["revision"]
+            oldroot = retained / oldrev
+            if not oldroot.exists():
+                for target in old["files"]:
+                    dst = oldroot / target
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(a.root / target, dst)
+                (retained / f"{oldrev}.json").write_text(json.dumps(old, sort_keys=True) + "\n")
+        for target in ASSETS:
+            dst = a.root / target
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dst.with_name(f".{dst.name}.new")
+            shutil.copy2(staged / target, tmp)
+            os.replace(tmp, dst)
+        tmp = current.with_suffix(".new")
+        tmp.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        os.replace(tmp, current)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/materialize_dspace_chat_runner.py
+++ b/scripts/materialize_dspace_chat_runner.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Construct and attest an independent immutable DSPACE smoke runner."""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+CRITICAL = (
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "scripts/run-remote-chat-smoke.mjs",
+    "tests/remote-chat-smoke.spec.ts",
+)
+
+
+def run(*args, cwd=None, env=None):
+    return subprocess.run(
+        args, cwd=cwd, env=env, check=True, text=True, capture_output=True
+    ).stdout.strip()
+
+
+def validate_source(source: Path, revision: str, repository: str) -> None:
+    if len(revision) != 40 or run("git", "-C", str(source), "cat-file", "-t", revision) != "commit":
+        raise ValueError("exact commit object is missing")
+    if run("git", "-C", str(source), "rev-parse", "HEAD") != revision:
+        raise ValueError("source HEAD is not the requested exact commit")
+    if run("git", "-C", str(source), "status", "--porcelain", "--untracked-files=no"):
+        raise ValueError("source tracked/index state is dirty")
+    remotes = run("git", "-C", str(source), "remote", "get-url", "origin")
+    if remotes.rstrip("/").removesuffix(".git") != repository.rstrip("/").removesuffix(".git"):
+        raise ValueError("source repository identity mismatch")
+
+
+def validate(snapshot: Path, revision: str) -> dict:
+    if (
+        not (snapshot / ".git/objects").is_dir()
+        or (snapshot / ".git/objects/info/alternates").exists()
+    ):
+        raise ValueError("incomplete or externally dependent Git metadata")
+    if run("git", "-C", str(snapshot), "rev-parse", "HEAD") != revision or run(
+        "git", "-C", str(snapshot), "fsck", "--full"
+    ):
+        raise ValueError("snapshot Git state mismatch")
+    if run("git", "-C", str(snapshot), "status", "--porcelain", "--untracked-files=no"):
+        raise ValueError("snapshot tracked/index state is dirty")
+    if not (snapshot / "node_modules/.pnpm").is_dir():
+        raise ValueError("root pnpm store is missing")
+    cli = snapshot / "node_modules/.bin/playwright"
+    if (
+        not cli.exists()
+        or not os.access(cli, os.X_OK)
+        or (cli.is_symlink() and not cli.resolve().exists())
+    ):
+        raise ValueError("Playwright CLI/shim is invalid")
+    run("node", "-e", "require.resolve('@playwright/test')", cwd=snapshot)
+    files = {}
+    for name in CRITICAL:
+        path = snapshot / name
+        if not path.is_file():
+            raise ValueError(f"critical file is missing: {name}")
+        files[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    for path in (snapshot / "apps/frontend/node_modules").glob("*"):
+        if path.is_symlink() and not path.resolve().exists():
+            raise ValueError("broken frontend dependency symlink")
+    return {"schema_version": 1, "revision": revision, "files": files}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", required=True, type=Path)
+    p.add_argument("--revision", required=True)
+    p.add_argument("--repository", required=True)
+    p.add_argument("--output", required=True, type=Path)
+    p.add_argument("--pnpm", default="pnpm")
+    a = p.parse_args()
+    validate_source(a.source.resolve(), a.revision, a.repository)
+    if a.output.exists():
+        p.error("output already exists")
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=a.output.parent) as temporary:
+        stage = Path(temporary) / a.revision
+        # --no-local forces copied objects and prevents hardlinks/alternates.
+        run("git", "clone", "--no-local", "--no-checkout", str(a.source.resolve()), str(stage))
+        run("git", "checkout", "--detach", a.revision, cwd=stage)
+        env = {**os.environ, "CI": "true"}
+        run(a.pnpm, "install", "--frozen-lockfile", cwd=stage, env=env)
+        manifest = validate(stage, a.revision)
+        (stage / "sugarkube-runner-manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        )
+        os.replace(stage, a.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/systemd/dspace-chat-synthetic.service
+++ b/scripts/systemd/dspace-chat-synthetic.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Bounded repository-owned DSPACE chat synthetic producer
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/dspace-chat-synthetic-producer.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/local/libexec/sugarkube-dspace-chat-synthetic --config /etc/sugarkube/dspace-chat-synthetic.json
+TimeoutStartSec=240
+UMask=0077
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadOnlyPaths=/var/lib/sugarkube/dspace-chat-runners
+ReadWritePaths=/run/sugarkube /var/lib/node_exporter/textfile_collector
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+LockPersonality=yes
+MemoryDenyWriteExecute=no

--- a/scripts/systemd/dspace-chat-synthetic.timer
+++ b/scripts/systemd/dspace-chat-synthetic.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run the DSPACE chat synthetic every five minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+AccuracySec=15s
+RandomizedDelaySec=15s
+Persistent=true
+Unit=dspace-chat-synthetic.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -1,0 +1,232 @@
+import hashlib
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    value = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(value)
+    return value
+
+
+producer = module(ROOT / "scripts/dspace_chat_synthetic.py", "producer")
+installer = module(ROOT / "scripts/install_dspace_chat_synthetic.py", "installer")
+materializer = module(ROOT / "scripts/materialize_dspace_chat_runner.py", "materializer")
+
+
+def config(tmp_path):
+    value = json.loads((ROOT / "config/dspace-chat-synthetic.json").read_text())
+    value.update(
+        runner_root=str(tmp_path / "runners"),
+        result_root=str(tmp_path / "results"),
+        metric_path=str(tmp_path / "metric.prom"),
+    )
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(value))
+    return path, value
+
+
+def test_contracts_are_explicit_and_legacy_coordinates_are_exact(tmp_path):
+    path, value = config(tmp_path)
+    assert producer.load_config(path)["provider_config_contract"] == "legacy-no-default-provider-v1"
+    del value["provider_config_contract"]
+    path.write_text(json.dumps(value))
+    try:
+        producer.load_config(path)
+        assert False
+    except ValueError:
+        pass
+    value["provider_config_contract"] = "legacy-no-default-provider-v1"
+    value["dspace_version"] = "3.1.2"
+    path.write_text(json.dumps(value))
+    try:
+        producer.load_config(path)
+        assert False
+    except ValueError:
+        pass
+
+
+def test_metric_contract_and_atomic_replacement(tmp_path):
+    path = tmp_path / "metric.prom"
+    path.write_bytes(b"old")
+    producer.publish(path, producer.metric({}, True, 123))
+    content = path.read_bytes()
+    assert (
+        b"dspace_chat_synthetic_success" in content
+        and b" 1\n" in content
+        and not list(tmp_path.glob(".dspace-chat.*"))
+    )
+
+
+def test_installer_dry_run_and_status_are_non_mutating(tmp_path, capsys):
+    before = list(tmp_path.rglob("*"))
+    assert installer.main.__name__ == "main"
+    result = subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/install_dspace_chat_synthetic.py"),
+            "dry-run",
+            "--root",
+            str(tmp_path),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0 and list(tmp_path.rglob("*")) == before
+    result = subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/install_dspace_chat_synthetic.py"),
+            "status",
+            "--root",
+            str(tmp_path),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0 and json.loads(result.stdout) == {
+        "installed": False,
+        "timer_enabled": None,
+    }
+
+
+def test_installer_failed_preflight_leaves_root_unchanged(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    marker = tmp_path / "installed"
+    marker.write_text("unchanged")
+    result = subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/install_dspace_chat_synthetic.py"),
+            "apply",
+            "--root",
+            str(tmp_path),
+            "--repo",
+            str(repo),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode != 0 and marker.read_text() == "unchanged"
+
+
+def test_units_are_persistent_bounded_and_not_implicitly_managed():
+    timer = (ROOT / "scripts/systemd/dspace-chat-synthetic.timer").read_text()
+    service = (ROOT / "scripts/systemd/dspace-chat-synthetic.service").read_text()
+    installer_text = (ROOT / "scripts/install_dspace_chat_synthetic.py").read_text()
+    assert "Persistent=true" in timer and "TimeoutStartSec=240" in service
+    assert all(
+        word not in installer_text
+        for word in (
+            "systemctl enable",
+            "systemctl start",
+            "systemctl restart",
+            "systemctl disable",
+        )
+    )
+
+
+def test_wrapper_safety_and_provider_is_in_real_argv():
+    wrapper = (ROOT / "scripts/dspace-chat-synthetic").read_text().splitlines()
+    assert wrapper[1:5] == [
+        "set +x",
+        "set -Eeuo pipefail",
+        "umask 077",
+        "export PYTHONDONTWRITEBYTECODE=1",
+    ]
+    source = (ROOT / "scripts/dspace_chat_synthetic.py").read_text()
+    assert '"--provider",' in source and 'config["provider"]' in source
+    assert "stdout=subprocess.DEVNULL" in source
+    assert "subprocess.run(" in source and "argv," in source
+    assert "shutil.rmtree(invocation_dir)" in source
+
+
+def test_manifest_hash_mismatch_is_detectable(tmp_path):
+    file = tmp_path / "critical"
+    file.write_text("one")
+    expected = hashlib.sha256(file.read_bytes()).hexdigest()
+    file.write_text("two")
+    assert hashlib.sha256(file.read_bytes()).hexdigest() != expected
+
+
+def runner_fixture(tmp_path):
+    runner = tmp_path / "runner"
+    (runner / ".git/objects/info").mkdir(parents=True)
+    (runner / "node_modules/.pnpm").mkdir(parents=True)
+    (runner / "node_modules/.bin").mkdir(parents=True)
+    cli = runner / "node_modules/.bin/playwright"
+    cli.write_text("#!/bin/sh\n")
+    cli.chmod(0o755)
+    for relative in materializer.CRITICAL:
+        path = runner / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(relative)
+    return runner
+
+
+def test_materializer_rejects_missing_store_alternates_and_invalid_cli(tmp_path, monkeypatch):
+    revision = "a" * 40
+    monkeypatch.setattr(
+        materializer,
+        "run",
+        lambda *args, **kwargs: revision if "rev-parse" in args else "",
+    )
+    runner = runner_fixture(tmp_path)
+    (runner / "node_modules/.pnpm").rmdir()
+    try:
+        materializer.validate(runner, revision)
+        assert False
+    except ValueError as error:
+        assert "pnpm store" in str(error)
+    (runner / "node_modules/.pnpm").mkdir()
+    (runner / ".git/objects/info/alternates").write_text("/external/objects\n")
+    try:
+        materializer.validate(runner, revision)
+        assert False
+    except ValueError as error:
+        assert "externally dependent" in str(error)
+    (runner / ".git/objects/info/alternates").unlink()
+    (runner / "node_modules/.bin/playwright").chmod(0o644)
+    try:
+        materializer.validate(runner, revision)
+        assert False
+    except ValueError as error:
+        assert "Playwright" in str(error)
+
+
+def test_materializer_rejects_wrong_head_dirty_state_and_missing_object(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+    revision = "b" * 40
+    monkeypatch.setattr(
+        materializer, "run", lambda *args, **kwargs: "tree" if "cat-file" in args else ""
+    )
+    try:
+        materializer.validate_source(source, revision, "https://example.invalid/dspace")
+        assert False
+    except ValueError as error:
+        assert "commit object" in str(error)
+    answers = iter(["commit", "c" * 40])
+    monkeypatch.setattr(materializer, "run", lambda *args, **kwargs: next(answers))
+    try:
+        materializer.validate_source(source, revision, "https://example.invalid/dspace")
+        assert False
+    except ValueError as error:
+        assert "HEAD" in str(error)
+
+
+def test_result_directory_contract_checks_exact_owner_group_and_mode(tmp_path):
+    directory = tmp_path / "results"
+    directory.mkdir(mode=0o700)
+    info = directory.stat()
+    producer.check_dir(directory, info.st_uid, info.st_gid, 0o700)
+    try:
+        producer.check_dir(directory, info.st_uid, info.st_gid, 0o710)
+        assert False
+    except ValueError:
+        pass


### PR DESCRIPTION
### Motivation
- Replace private/manual staging recovery with a reviewed, reproducible, repository-owned implementation that can be staged and validated without performing a host cutover. 
- Provide deterministic runner materialization, fail-closed wrapper behavior, an installer that stages and validates revisions, repository-owned systemd unit/timer templates, and a runbook to make a later host cutover explicit and auditable. 

### Description
- Add a declarative non-secret configuration `config/dspace-chat-synthetic.json` selecting exact runner and DSPACE coordinates, explicit `identity_contract` and `provider_config_contract`, provider/origin/model, bounded timeout, user/group, result and metric paths, and wrapper target. 
- Implement a minimal shell entrypoint `scripts/dspace-chat-synthetic` and a fail-closed invocation-bound wrapper `scripts/dspace_chat_synthetic.py` that validates config, runner Git metadata, pnpm root store, Playwright resolution, invocation `INVOCATION_ID`, result ownership/mode/schema/window, overlap locking, atomic metric publication, and preserves the provider option in the actual argv. 
- Add a deterministic runner materializer `scripts/materialize_dspace_chat_runner.py` that clones with no alternates, checks exact commit object, runs a frozen `pnpm install`, validates root `node_modules/.pnpm` and critical-file hashes, and writes `sugarkube-runner-manifest.json`. 
- Add a dry-run-by-default installer/updater `scripts/install_dspace_chat_synthetic.py` with temporary staging, manifest hashing, atomic replacement, retained validated revisions for explicit rollback, and non-mutating `status`/`dry-run` modes, plus systemd assets `scripts/systemd/dspace-chat-synthetic.service` and `scripts/systemd/dspace-chat-synthetic.timer`, and a runbook `docs/dspace-chat-synthetic-producer.md`. 
- Add deterministic tests `tests/test_dspace_chat_synthetic_producer.py` covering explicit contract selection, atomic metric replacement, non-mutating installer modes, failed preflight preservation, timer/service constraints, wrapper safety (argv/provider), materializer rejections, and invocation-directory ownership/mode checks. 

### Testing
- Verified ancestry with `git merge-base --is-ancestor e59adc53111ff4519c41148f7bcf389f9b43af4b HEAD` (succeeded). 
- Ran focused and repository tests with `pytest` including the new tests and relevant existing suites (`tests/test_dspace_*`), producing `251 passed`. 
- Static and formatting checks `python -m black --check`, `python -m isort --check-only`, `python -m flake8`, `python -m compileall`, `bash -n scripts/dspace-chat-synthetic`, `git diff --cached --check`, and `git diff --cached | ./scripts/scan-secrets.py` all passed for the staged changes. 
- Link check `linkchecker --no-warnings README.md docs/dspace-chat-synthetic-producer.md` completed with no errors or warnings. 
- `pre-commit run --all-files` failed only due to unrelated, pre-existing repository YAML multi-document/Helm-template parsing problems and an unrelated external `just` installer download issue in the repo-check hook (these are existing repository issues; hook output was inspected and unrelated whitespace auto-fixes were not committed). 
- `pyspelling -c .spellcheck.yaml` could not run in this environment because `aspell` is not available. 

Branch and commit notes: branch `codex/durable-dspace-synthetic-producer` was created and committed as `f7d18cb070560f3f95389e73f930b81bc3275b88`, and a push attempt failed because this environment has no GitHub credentials; no draft PR was opened. 

No live installation, systemd mutation, cluster access, Helm operation, DSPACE repository modification, or host cutover was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8599bdb214832fb7a9601d6d458fb6)