### PR TITLE
Add durable repository-owned DSPACE chat synthetic producer

### DIFF
--- a/config/dspace-chat-synthetic.json
+++ b/config/dspace-chat-synthetic.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "repository": "https://github.com/democratizedspace/dspace.git",
+  "runnerRevision": "97ab09f13fb098de928a878bf1fe9b8d13032cb5",
+  "dspaceVersion": "3.1.1",
+  "dspaceSourceRevision": "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2",
+  "identityContract": "build-info-v1",
+  "providerConfigContract": "legacy-no-default-provider-v1",
+  "provider": "token-place",
+  "origin": "https://staging.token.place",
+  "model": "qwen3-8b-instruct",
+  "timeoutSeconds": 180,
+  "serviceUser": "pi",
+  "serviceGroup": "pi",
+  "runnerRoot": "/var/lib/sugarkube/dspace-chat-runner",
+  "resultRoot": "/run/sugarkube/dspace-chat-synthetic",
+  "metricPath": "/var/lib/node_exporter/textfile_collector/dspace-chat-synthetic.prom",
+  "runnerCommand": "frontend/node_modules/.bin/playwright",
+  "runnerArguments": ["test", "frontend/tests/remote-chat-smoke.spec.ts"]
+}

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -1,0 +1,65 @@
+# DSPACE chat synthetic producer
+
+This repository owns the wrapper, non-secret coordinates, construction tool, units, and validation
+logic for the staging chat synthetic. The earlier private wrapper SHA
+`5a160f1e4c077c09cda5fec062733cd9b31ed8cbfbc5b7f0779403f4a829e70e` is provenance only: it is
+not a source input and the repository wrapper legitimately has a different hash. **Nothing in this
+runbook authorizes a live cutover.** Host installation and activation require a separate reviewed,
+explicitly authorized operation.
+
+## Trust and filesystem model
+
+[`config/dspace-chat-synthetic.json`](../config/dspace-chat-synthetic.json) explicitly binds the
+immutable runner and deployed source revisions, DSPACE 3.1.1, `build-info-v1`, the narrowly approved
+`legacy-no-default-provider-v1` contract, provider, origin, model, timeout, and paths. Contract choice
+is never inferred from an absent field. Complete Git metadata is retained so HEAD, object
+availability, repository identity, cleanliness, and independence from alternates remain auditable.
+The root `node_modules/.pnpm` store and frontend links are retained because pnpm workspace links are
+not a self-contained frontend install.
+
+The result root is `root:pi` mode `0710`; each invocation directory is `root:pi` mode `0770`; and the
+unprivileged `pi` child atomically renames its same-directory temporary result to a `pi:pi` mode
+`0600` final file. The wrapper accepts only the current `INVOCATION_ID` and bounded UTC epoch window,
+then removes only that invocation directory. Cleanup is normal lifecycle behavior, not evidence
+loss. Missing, stale, malformed, pre-existing, shared, wrongly owned, wrongly permissioned, timed
+out, or launch-failed results leave the prior metric byte-for-byte unchanged. A valid failure emits
+success `0`; only a valid pass emits `1`. A passing Playwright summary alone does **not** prove that
+result publication succeeded.
+
+## Separate operator steps
+
+All examples below are review examples. Use temporary targets until a live operation is separately
+authorized. They never contact a cluster or invoke Helm.
+
+1. **Construct.** From an explicitly identified clean local DSPACE checkout at the exact runner
+   commit, run `python3 scripts/dspace_chat_synthetic.py materialize --config
+   config/dspace-chat-synthetic.json --source /absolute/local/dspace --revision
+   97ab09f13fb098de928a878bf1fe9b8d13032cb5 --destination /absolute/staging/runner`. The offline,
+   frozen-lockfile install must already have all pnpm packages available; no mutable global store is
+   used as an installed dependency.
+2. **Validate/dry run.** Run the `validate` subcommand, then `install` with explicit wrapper, service,
+   timer, runner, and temporary `--prefix` arguments. Without `--apply`, installation is
+   non-mutating. Review hashes with `status`; it prints coordinates and provenance, not secrets.
+3. **Install.** Only after separate authorization, repeat with `--apply`. Staging is validated first,
+   replacement is atomic per file, retained revision directories are not deleted, and no unit is
+   enabled, started, stopped, restarted, or disabled.
+4. **Controlled execution.** Review `systemctl cat` and unit hashes, create the exact ownership model,
+   and invoke the oneshot once. Do not retry automatically. Record only bounded status, timestamps,
+   hashes, `systemctl show` activation properties, and metric metadata—not raw journals, results,
+   browser output, credentials, Secrets, or wrapper contents.
+5. **Timer activation.** This is a distinct authorized action. Confirm `Persistent=true`, then enable
+   the timer explicitly. Observe at least two scheduled windows and metric freshness; installation
+   never activates it.
+6. **Classify before retry.** Read only service exit status, `InvocationID`, start/end properties,
+   file owner/mode, configured hashes, timer state, and metric timestamp. Classify preflight,
+   overlap, launch, timeout, publication, schema/window, or valid journey failure. Do not expose raw
+   payloads and do not retry until a reviewer explicitly authorizes it.
+7. **Rollback.** Select an exact retained commit with `rollback --prefix / --revision <40-hex>`.
+   Validation precedes the atomic pointer change. Rollback never restarts a service; controlled
+   execution and timer decisions remain separate. An invalid or absent retained revision fails
+   closed without changing the pointer.
+
+Residual operational risk includes browser/runtime compatibility, availability of the offline pnpm
+package set during construction, host account/permission drift, and staging network behavior. These
+can only be resolved during the separately reviewed host cutover and observation; merge alone makes
+no host change.

--- a/scripts/dspace_chat_synthetic.py
+++ b/scripts/dspace_chat_synthetic.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Construct, validate, run, and install the pinned DSPACE chat synthetic."""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import pwd
+import grp
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+SHA = __import__("re").compile(r"[0-9a-f]{40}")
+APPROVED = ("3.1.1", "22f506e07e0b5abfd0cf756e9c5827c0458fb4b2", "legacy-no-default-provider-v1")
+REQUIRED = {
+    "schemaVersion",
+    "repository",
+    "runnerRevision",
+    "dspaceVersion",
+    "dspaceSourceRevision",
+    "identityContract",
+    "providerConfigContract",
+    "provider",
+    "origin",
+    "model",
+    "timeoutSeconds",
+    "serviceUser",
+    "serviceGroup",
+    "runnerRoot",
+    "resultRoot",
+    "metricPath",
+    "runnerCommand",
+    "runnerArguments",
+}
+
+
+class Invalid(RuntimeError):
+    pass
+
+
+def load_config(path: Path) -> dict:
+    value = json.loads(path.read_text())
+    if set(value) != REQUIRED or value["schemaVersion"] != 1:
+        raise Invalid("configuration fields do not match the explicit contract")
+    if not all(SHA.fullmatch(value[k]) for k in ("runnerRevision", "dspaceSourceRevision")):
+        raise Invalid("coordinates must be full commit IDs")
+    if value["identityContract"] != "build-info-v1":
+        raise Invalid("identity contract was not explicitly selected")
+    if (
+        value["dspaceVersion"],
+        value["dspaceSourceRevision"],
+        value["providerConfigContract"],
+    ) != APPROVED:
+        raise Invalid("legacy provider contract is restricted to approved immutable coordinates")
+    if value["provider"] != "token-place" or not 1 <= value["timeoutSeconds"] <= 600:
+        raise Invalid("provider or timeout is outside the approved contract")
+    for key in ("runnerRoot", "resultRoot", "metricPath"):
+        if not Path(value[key]).is_absolute() or "$" in value[key]:
+            raise Invalid(f"{key} must be an absolute resolved path")
+    return value
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", "-C", str(repo), *args], text=True, capture_output=True)
+    if result.returncode:
+        raise Invalid("git validation failed")
+    return result.stdout.strip()
+
+
+def validate_git(repo: Path, revision: str, repository: str | None = None) -> None:
+    if not (repo / ".git").exists() or (repo / ".git").is_file():
+        raise Invalid("complete independent Git metadata is required")
+    if (repo / ".git/objects/info/alternates").exists():
+        raise Invalid("external Git object stores are forbidden")
+    if (
+        git(repo, "rev-parse", "HEAD") != revision
+        or git(repo, "cat-file", "-t", revision) != "commit"
+    ):
+        raise Invalid("runner HEAD or commit object mismatch")
+    if git(repo, "status", "--porcelain", "--untracked-files=no"):
+        raise Invalid("tracked worktree/index is dirty")
+    if repository and git(repo, "remote", "get-url", "origin").rstrip("/") != repository.rstrip(
+        "/"
+    ):
+        raise Invalid("repository identity mismatch")
+    git(repo, "fsck", "--full", "--no-dangling")
+
+
+def hashes(root: Path) -> dict[str, str]:
+    names = (
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "frontend/package.json",
+        "frontend/tests/remote-chat-smoke.spec.ts",
+    )
+    result = {}
+    for name in names:
+        path = root / name
+        if not path.is_file():
+            raise Invalid(f"critical file missing: {name}")
+        result[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def validate_runner(root: Path, config: dict) -> None:
+    validate_git(root, config["runnerRevision"], config["repository"])
+    manifest = json.loads((root / "sugarkube-runner-manifest.json").read_text())
+    if manifest != {"revision": config["runnerRevision"], "files": hashes(root)}:
+        raise Invalid("critical-file hash mismatch")
+    store = root / "node_modules/.pnpm"
+    shim = root / config["runnerCommand"]
+    if not store.is_dir() or not shim.is_file() or not os.access(shim, os.X_OK):
+        raise Invalid("root pnpm store or executable Playwright shim missing")
+    if any(p.is_symlink() and not p.exists() for p in (root / "frontend/node_modules").rglob("*")):
+        raise Invalid("broken frontend dependency link")
+    subprocess.run(
+        [str(shim), "--version"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+
+
+def materialize(source: Path, revision: str, destination: Path, config: dict, pnpm: str) -> None:
+    if revision != config["runnerRevision"] or destination.exists():
+        raise Invalid("exact runner revision and a new destination are required")
+    validate_git(source, revision, config["repository"])
+    stage = destination.with_name(destination.name + ".staging")
+    if stage.exists():
+        raise Invalid("staging target already exists")
+    try:
+        subprocess.run(
+            ["git", "clone", "--no-local", str(source), str(stage)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "-C", str(stage), "checkout", "--detach", revision],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "-C", str(stage), "remote", "set-url", "origin", config["repository"]],
+            check=True,
+        )
+        subprocess.run([pnpm, "install", "--frozen-lockfile", "--offline"], cwd=stage, check=True)
+        manifest = {"revision": revision, "files": hashes(stage)}
+        (stage / "sugarkube-runner-manifest.json").write_text(
+            json.dumps(manifest, sort_keys=True) + "\n"
+        )
+        validate_runner(stage, config)
+        os.replace(stage, destination)
+    except Exception:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+
+def checked_dir(path: Path, uid: int, gid: int, mode: int) -> None:
+    s = path.stat()
+    if not stat.S_ISDIR(s.st_mode) or (s.st_uid, s.st_gid, stat.S_IMODE(s.st_mode)) != (
+        uid,
+        gid,
+        mode,
+    ):
+        raise Invalid(f"ownership/mode mismatch: {path}")
+
+
+def run(config: dict) -> None:
+    invocation = os.environ.get("INVOCATION_ID", "")
+    if not SHA.fullmatch(invocation):
+        raise Invalid("exact systemd INVOCATION_ID is required")
+    user, group = pwd.getpwnam(config["serviceUser"]), grp.getgrnam(config["serviceGroup"])
+    root = Path(config["resultRoot"])
+    checked_dir(root, 0, group.gr_gid, 0o710)
+    runner = Path(config["runnerRoot"]) / config["runnerRevision"]
+    validate_runner(runner, config)
+    lock = os.open(root / ".lock", os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        raise Invalid("overlapping invocation rejected") from exc
+    result_dir = root / f"{user.pw_name}-{invocation}"
+    if result_dir.exists():
+        raise Invalid("invocation result path already exists")
+    result_dir.mkdir(mode=0o770)
+    os.chown(result_dir, 0, group.gr_gid)
+    result = result_dir / "result.json"
+    started = int(time.time())
+    argv = [
+        str(runner / config["runnerCommand"]),
+        *config["runnerArguments"],
+        "--provider",
+        config["provider"],
+        "--origin",
+        config["origin"],
+        "--model",
+        config["model"],
+        "--identity-contract",
+        config["identityContract"],
+        "--provider-config-contract",
+        config["providerConfigContract"],
+        "--result",
+        str(result),
+        "--invocation-id",
+        invocation,
+        "--started-at",
+        str(started),
+    ]
+
+    def demote():
+        os.setgroups([group.gr_gid])
+        os.setgid(group.gr_gid)
+        os.setuid(user.pw_uid)
+
+    try:
+        subprocess.run(
+            argv,
+            cwd=runner,
+            preexec_fn=demote,
+            timeout=config["timeoutSeconds"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        ended = int(time.time())
+        s = result.stat()
+        if (s.st_uid, s.st_gid, stat.S_IMODE(s.st_mode)) != (user.pw_uid, group.gr_gid, 0o600):
+            raise Invalid("result ownership/mode mismatch")
+        value = json.loads(result.read_text())
+        expected = {
+            "schemaVersion",
+            "passed",
+            "runnerRevision",
+            "invocationId",
+            "startedAt",
+            "endedAt",
+        }
+        if (
+            set(value) != expected
+            or value["runnerRevision"] != config["runnerRevision"]
+            or value["invocationId"] != invocation
+        ):
+            raise Invalid("malformed or shared result")
+        if not (started <= value["startedAt"] <= value["endedAt"] <= ended):
+            raise Invalid("result is outside invocation window")
+        metric = (
+            "# HELP dspace_chat_synthetic_success Last executed isolated /chat result.\n"
+            "# TYPE dspace_chat_synthetic_success gauge\n"
+            f'dspace_chat_synthetic_success{{application="dspace",environment="staging",cluster="sugarkube-int"}} {int(value["passed"] is True)}\n'
+            "# HELP dspace_chat_synthetic_timestamp_seconds Unix time of the last execution.\n"
+            "# TYPE dspace_chat_synthetic_timestamp_seconds gauge\n"
+            f'dspace_chat_synthetic_timestamp_seconds{{application="dspace",environment="staging",cluster="sugarkube-int"}} {ended}\n'
+        )
+        target = Path(config["metricPath"])
+        fd, temporary = tempfile.mkstemp(prefix=".dspace-chat.", dir=target.parent)
+        with os.fdopen(fd, "w") as stream:
+            os.fchmod(stream.fileno(), 0o644)
+            stream.write(metric)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+        print(f"invocation={invocation} result=consumed start={started} end={ended}")
+    finally:
+        shutil.rmtree(result_dir, ignore_errors=True)
+        os.close(lock)
+
+
+def install(args, config: dict) -> None:
+    prefix = args.prefix.resolve()
+    runner = args.runner.resolve()
+    validate_runner(runner, config)
+    files = {
+        "usr/local/libexec/sugarkube-dspace-chat-synthetic": args.wrapper,
+        "usr/local/libexec/sugarkube-dspace-chat-synthetic.py": Path(__file__),
+        "etc/sugarkube/dspace-chat-synthetic.json": args.config,
+        "etc/systemd/system/sugarkube-dspace-chat-synthetic.service": args.service,
+        "etc/systemd/system/sugarkube-dspace-chat-synthetic.timer": args.timer,
+    }
+    if not args.apply:
+        print("validated dry-run; no files changed")
+        return
+    revision_dir = prefix / "var/lib/sugarkube/dspace-chat-runner" / config["runnerRevision"]
+    revision_dir.parent.mkdir(parents=True, exist_ok=True)
+    if not revision_dir.exists():
+        shutil.copytree(runner, revision_dir, symlinks=True)
+    for relative, source in files.items():
+        target = prefix / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temporary = target.with_name(target.name + ".new")
+        shutil.copy2(source, temporary)
+        os.replace(temporary, target)
+    print("installed without service or timer activation")
+
+
+def rollback(prefix: Path, revision: str, config: dict) -> None:
+    if not SHA.fullmatch(revision):
+        raise Invalid("rollback requires an exact revision")
+    retained = prefix.resolve() / "var/lib/sugarkube/dspace-chat-runner" / revision
+    rollback_config = dict(config)
+    rollback_config["runnerRevision"] = revision
+    validate_runner(retained, rollback_config)
+    pointer = retained.parent / "current"
+    temporary = pointer.with_name(".current.new")
+    temporary.unlink(missing_ok=True)
+    temporary.symlink_to(revision)
+    os.replace(temporary, pointer)
+    print(f"selected validated retained revision {revision}; no service action performed")
+
+
+def status(prefix: Path, config: dict) -> None:
+    root = prefix.resolve()
+    targets = {
+        "wrapper": root / "usr/local/libexec/sugarkube-dspace-chat-synthetic",
+        "configuration": root / "etc/sugarkube/dspace-chat-synthetic.json",
+        "service": root / "etc/systemd/system/sugarkube-dspace-chat-synthetic.service",
+        "timer": root / "etc/systemd/system/sugarkube-dspace-chat-synthetic.timer",
+    }
+    file_hashes = {
+        name: hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else "missing"
+        for name, path in targets.items()
+    }
+    activation = {"timerActive": "not-queried", "timerEnabled": "not-queried"}
+    if root == Path("/") and shutil.which("systemctl"):
+        for key, operation in (("timerActive", "is-active"), ("timerEnabled", "is-enabled")):
+            result = subprocess.run(
+                ["systemctl", operation, "sugarkube-dspace-chat-synthetic.timer"],
+                text=True,
+                capture_output=True,
+                timeout=5,
+            )
+            activation[key] = result.stdout.strip()[:32] or "unknown"
+    print(
+        json.dumps(
+            {
+                "runnerRevision": config["runnerRevision"],
+                "dspaceVersion": config["dspaceVersion"],
+                "dspaceSourceRevision": config["dspaceSourceRevision"],
+                "identityContract": config["identityContract"],
+                "providerConfigContract": config["providerConfigContract"],
+                "fileSha256": file_hashes,
+                **activation,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subs = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "run", "status"):
+        p = subs.add_parser(name)
+        p.add_argument("--config", required=True, type=Path)
+        if name == "status":
+            p.add_argument("--prefix", default=Path("/"), type=Path)
+    p = subs.add_parser("materialize")
+    p.add_argument("--config", required=True, type=Path)
+    p.add_argument("--source", required=True, type=Path)
+    p.add_argument("--revision", required=True)
+    p.add_argument("--destination", required=True, type=Path)
+    p.add_argument("--pnpm", default="pnpm")
+    p = subs.add_parser("install")
+    p.add_argument("--config", required=True, type=Path)
+    p.add_argument("--runner", required=True, type=Path)
+    p.add_argument("--prefix", required=True, type=Path)
+    p.add_argument("--wrapper", required=True, type=Path)
+    p.add_argument("--service", required=True, type=Path)
+    p.add_argument("--timer", required=True, type=Path)
+    p.add_argument("--apply", action="store_true")
+    p = subs.add_parser("rollback")
+    p.add_argument("--config", required=True, type=Path)
+    p.add_argument("--prefix", required=True, type=Path)
+    p.add_argument("--revision", required=True)
+    args = parser.parse_args()
+    config = load_config(args.config)
+    if args.command == "validate":
+        print("configuration valid")
+    elif args.command == "run":
+        run(config)
+    elif args.command == "materialize":
+        materialize(args.source, args.revision, args.destination, config, args.pnpm)
+    elif args.command == "install":
+        install(args, config)
+    elif args.command == "rollback":
+        rollback(args.prefix, args.revision, config)
+    elif args.command == "status":
+        status(args.prefix, config)
+    else:
+        raise Invalid("unsupported command")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (Invalid, OSError, ValueError, subprocess.SubprocessError) as error:
+        print(f"dspace synthetic validation failed: {error}", file=__import__("sys").stderr)
+        raise SystemExit(1)

--- a/scripts/sugarkube-dspace-chat-synthetic
+++ b/scripts/sugarkube-dspace-chat-synthetic
@@ -1,0 +1,8 @@
+#!/bin/bash
+set +x
+set -Eeuo pipefail
+umask 077
+export PYTHONDONTWRITEBYTECODE=1
+
+exec /usr/local/libexec/sugarkube-dspace-chat-synthetic.py run \
+  --config /etc/sugarkube/dspace-chat-synthetic.json

--- a/scripts/systemd/sugarkube-dspace-chat-synthetic.service
+++ b/scripts/systemd/sugarkube-dspace-chat-synthetic.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Sugarkube bounded DSPACE chat synthetic producer
+Documentation=https://github.com/futuroptimist/sugarkube/blob/main/docs/dspace-chat-synthetic-producer.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/sugarkube-dspace-chat-synthetic
+TimeoutStartSec=240
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/run/sugarkube/dspace-chat-synthetic /var/lib/node_exporter/textfile_collector
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+UMask=0077

--- a/scripts/systemd/sugarkube-dspace-chat-synthetic.timer
+++ b/scripts/systemd/sugarkube-dspace-chat-synthetic.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Schedule the Sugarkube DSPACE chat synthetic
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30s
+Persistent=true
+Unit=sugarkube-dspace-chat-synthetic.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_dspace_chat_synthetic.py
+++ b/tests/test_dspace_chat_synthetic.py
@@ -1,0 +1,180 @@
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "synthetic", ROOT / "scripts/dspace_chat_synthetic.py"
+)
+synthetic = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(synthetic)
+CONFIG = ROOT / "config/dspace-chat-synthetic.json"
+
+
+def config(tmp_path, **updates):
+    value = json.loads(CONFIG.read_text())
+    value.update(updates)
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(value))
+    return path
+
+
+def test_coordinates_and_contracts_are_explicit():
+    value = synthetic.load_config(CONFIG)
+    assert value["identityContract"] == "build-info-v1"
+    assert value["providerConfigContract"] == "legacy-no-default-provider-v1"
+    assert value["runnerRevision"] == "97ab09f13fb098de928a878bf1fe9b8d13032cb5"
+
+
+@pytest.mark.parametrize("field", ["identityContract", "providerConfigContract"])
+def test_contract_is_not_inferred_from_absence(tmp_path, field):
+    value = json.loads(CONFIG.read_text())
+    del value[field]
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(value))
+    with pytest.raises(synthetic.Invalid, match="explicit contract"):
+        synthetic.load_config(path)
+
+
+def test_legacy_contract_rejected_for_coordinate_mismatch(tmp_path):
+    with pytest.raises(synthetic.Invalid, match="approved immutable"):
+        synthetic.load_config(config(tmp_path, dspaceVersion="3.1.2"))
+
+
+def make_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", repo], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.email", "test@example.invalid"], check=True)
+    subprocess.run(["git", "-C", repo, "config", "user.name", "Test"], check=True)
+    for name in (
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "frontend/package.json",
+        "frontend/tests/remote-chat-smoke.spec.ts",
+    ):
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(name)
+    subprocess.run(["git", "-C", repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", repo, "commit", "-qm", "fixture"], check=True)
+    revision = subprocess.check_output(["git", "-C", repo, "rev-parse", "HEAD"], text=True).strip()
+    subprocess.run(
+        ["git", "-C", repo, "remote", "add", "origin", "https://example.invalid/repo.git"],
+        check=True,
+    )
+    return repo, revision
+
+
+def test_git_rejects_wrong_or_missing_commit_and_dirty_state(tmp_path):
+    repo, revision = make_repo(tmp_path)
+    synthetic.validate_git(repo, revision, "https://example.invalid/repo.git")
+    with pytest.raises(synthetic.Invalid, match="HEAD or commit"):
+        synthetic.validate_git(repo, "0" * 40)
+    (repo / "package.json").write_text("dirty")
+    with pytest.raises(synthetic.Invalid, match="dirty"):
+        synthetic.validate_git(repo, revision)
+
+
+def test_git_rejects_incomplete_metadata_and_alternates(tmp_path):
+    repo, revision = make_repo(tmp_path)
+    (repo / ".git/objects/info/alternates").write_text("/external/objects\n")
+    with pytest.raises(synthetic.Invalid, match="external Git"):
+        synthetic.validate_git(repo, revision)
+    shutil = __import__("shutil")
+    shutil.rmtree(repo / ".git")
+    with pytest.raises(synthetic.Invalid, match="complete independent"):
+        synthetic.validate_git(repo, revision)
+
+
+def test_runner_rejects_hash_store_shim_and_broken_link(tmp_path):
+    repo, revision = make_repo(tmp_path)
+    cfg = synthetic.load_config(
+        config(tmp_path, runnerRevision=revision, repository="https://example.invalid/repo.git")
+    )
+    (repo / "sugarkube-runner-manifest.json").write_text(
+        json.dumps({"revision": revision, "files": {}})
+    )
+    with pytest.raises(synthetic.Invalid, match="hash mismatch"):
+        synthetic.validate_runner(repo, cfg)
+    (repo / "sugarkube-runner-manifest.json").write_text(
+        json.dumps({"revision": revision, "files": synthetic.hashes(repo)})
+    )
+    with pytest.raises(synthetic.Invalid, match="pnpm store"):
+        synthetic.validate_runner(repo, cfg)
+    (repo / "node_modules/.pnpm").mkdir(parents=True)
+    shim = repo / cfg["runnerCommand"]
+    shim.parent.mkdir(parents=True)
+    shim.write_text("#!/bin/sh\nexit 0\n")
+    shim.chmod(0o755)
+    broken = repo / "frontend/node_modules/broken"
+    broken.symlink_to("missing")
+    with pytest.raises(synthetic.Invalid, match="broken frontend"):
+        synthetic.validate_runner(repo, cfg)
+
+
+def test_wrapper_argv_preserves_provider_and_redacts_output():
+    source = (ROOT / "scripts/dspace_chat_synthetic.py").read_text()
+    assert '"--provider",\n        config["provider"]' in source
+    assert source.count("subprocess.DEVNULL") >= 4
+    assert source.count("argv,") == 1 and "retry" not in source.lower()
+
+
+def test_units_are_bounded_persistent_and_never_activate():
+    service = (ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.service").read_text()
+    timer = (ROOT / "scripts/systemd/sugarkube-dspace-chat-synthetic.timer").read_text()
+    assert "Type=oneshot" in service and "TimeoutStartSec=240" in service
+    assert "Persistent=true" in timer
+    combined = service + timer + (ROOT / "scripts/dspace_chat_synthetic.py").read_text()
+    assert "systemctl enable" not in combined and "systemctl start" not in combined
+
+
+def test_dry_run_validation_failure_is_non_mutating(tmp_path, monkeypatch):
+    cfg = synthetic.load_config(CONFIG)
+    marker = tmp_path / "prefix/unchanged"
+    marker.parent.mkdir()
+    marker.write_text("before")
+    args = type(
+        "Args",
+        (),
+        {
+            "prefix": marker.parent,
+            "runner": tmp_path / "missing",
+            "wrapper": Path(),
+            "config": CONFIG,
+            "service": Path(),
+            "timer": Path(),
+            "apply": False,
+        },
+    )
+    with pytest.raises(Exception):
+        synthetic.install(args, cfg)
+    assert marker.read_text() == "before"
+
+
+def test_status_is_non_mutating_and_reports_missing_hashes(tmp_path, capsys):
+    before = list(tmp_path.iterdir())
+    synthetic.status(tmp_path, synthetic.load_config(CONFIG))
+    report = json.loads(capsys.readouterr().out)
+    assert set(report["fileSha256"].values()) == {"missing"}
+    assert report["timerActive"] == "not-queried"
+    assert list(tmp_path.iterdir()) == before
+
+
+def test_result_lifecycle_guards_are_present():
+    source = (ROOT / "scripts/dspace_chat_synthetic.py").read_text()
+    for contract in (
+        "INVOCATION_ID",
+        "LOCK_NB",
+        "result path already exists",
+        "outside invocation window",
+        "ownership/mode mismatch",
+        "os.replace(temporary, target)",
+        "shutil.rmtree(result_dir",
+    ):
+        assert contract in source


### PR DESCRIPTION
### Motivation
- Replace the previous private/manual DSPACE staging synthetic-producer with a reviewed, reproducible, repository-owned implementation that pins runner and source coordinates, enforces identity/provider contracts, and provides operator-controlled construction, install, run, and rollback steps.
- Preserve existing metric names/contracts and systemd/timer conventions while making invocation and installer behavior fail-closed, auditable, and deterministic for later host cutover.

### Description
- Add an explicit, non-secret declarative coordinate/configuration file `config/dspace-chat-synthetic.json` binding runner revision, DSPACE coordinates, identity/provider contracts, provider origin/model, bounded timeout, service user/group, runner/result/metric paths, and runner command/arguments.
- Add a canonical wrapper entrypoint `scripts/sugarkube-dspace-chat-synthetic` and a repository-owned Python lifecycle tool `scripts/dspace_chat_synthetic.py` that implement: strict config validation, complete Git metadata and fsck checks, frozen/offline pnpm materialization via a non-local clone, critical-file hashing, Playwright shim validation, invocation locking (overlap rejection), exact `INVOCATION_ID` binding, owner-scoped invocation directories, unprivileged child demotion, atomic 0600 result publication validation, and atomic metric publication while preserving prior metric bytes on failure.
- Add a dry-run-first installer, atomic per-file replacement, retained validated revision layout, explicit `rollback` selection of an exact retained revision, and a read-only `status` command that reports hashes and unit/timer activation state without exposing secrets.
- Provide hardened systemd unit and timer templates `scripts/systemd/sugarkube-dspace-chat-synthetic.service` and `scripts/systemd/sugarkube-dspace-chat-synthetic.timer` (oneshot service, persistent timer, bounded hardening, `ReadWritePaths` limited to result/metric directories) and a runbook `docs/dspace-chat-synthetic-producer.md` documenting trust, ownership/mode requirements, failure classification, and separate operator steps for construction, install, controlled execution, timer activation, and rollback.
- Add deterministic tests `tests/test_dspace_chat_synthetic.py` that cover explicit-contract enforcement, Git metadata/dirty/alternates checks, critical-file/hash/shim/pnpm/link checks, provider argv preservation, bounded/redacted execution, non-mutating dry-run behavior, status reporting, and lifecycle guard presence.
- Files added: `config/dspace-chat-synthetic.json`, `docs/dspace-chat-synthetic-producer.md`, `scripts/dspace_chat_synthetic.py`, `scripts/sugarkube-dspace-chat-synthetic`, `scripts/systemd/sugarkube-dspace-chat-synthetic.service`, `scripts/systemd/sugarkube-dspace-chat-synthetic.timer`, `tests/test_dspace_chat_synthetic.py`.
- Safety: wrapper begins with `set +x; set -Eeuo pipefail; umask 077; PYTHONDONTWRITEBYTECODE=1`; provider and provider-config contract are selected explicitly and preserved in the actual runner argv; no automatic retries or overlapping invocations allowed; installer defaults to non-mutating dry-run.

### Testing
- Commands run (representative):
  - `python -m pytest -q tests/test_dspace_chat_synthetic.py` — 12 passed.
  - `python -m pytest -q tests/test_dspace_observability_alerts.py` — 17 passed.
  - `python -m pytest -q tests/test_observability_helm.py` and `tests/test_dspace_runtime_verifier.py` were exercised as part of the suite runs; relevant suites ran to completion in this environment during verification steps.
  - `python scripts/dspace_chat_synthetic.py validate --config config/dspace-chat-synthetic.json` — configuration valid.
  - `python scripts/dspace_chat_synthetic.py status --config config/dspace-chat-synthetic.json --prefix "$(mktemp -d)"` — status printed and reported missing hashes for ephemeral prefix (non-mutating).
  - `bash -n scripts/sugarkube-dspace-chat-synthetic` — shell syntax ok.
  - `python -m black --check scripts/dspace_chat_synthetic.py tests/test_dspace_chat_synthetic.py` — passed after formatting.
  - `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` — passed for the diff.
- Environment limitations and unavailable checks: `pre-commit`, `pyspelling`, `linkchecker`, and `shellcheck` were not available in this execution environment and thus were not run here (commands attempted but binary missing). Network push/PR creation failed due to missing GitHub authentication; `git push` returned `fatal: could not read Username ...` so a draft PR URL could not be created from this environment.
- Commit / branch: changes committed on branch `codex/durable-dspace-synthetic-producer`, commit `4089295de67d543ac5fd7ba28963bc0380dc13f0` (local branch is one commit ahead of `origin/main`); `origin/main` contained `e59adc53111ff4519c41148f7bcf389f9b43af4b` as required.
- Safety declaration: no live installation, systemd mutation, cluster access, Helm operation, real producer invocation, or production mutation was performed during these changes or tests; construction and installation steps are intentionally dry-run-first and must be separately authorized for host cutover.

Residual risks / next steps (post-merge): offline pnpm package availability and Playwright/browser runtime compatibility must be validated on the target host during the separately authorized cutover; operate the materializer and installer against a verified local DSPACE checkout, then perform one controlled invocation and only then enable the timer after observation, per the runbook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8599c34ac8832faaae917f7b8b248a)