### PR TITLE
feat: onboard gitshelves as a first-class app

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -258,3 +258,5 @@ pytest
 
 QEMU
 reimaging
+
+GitShelves

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ New to sugarkube? Start with the 3-node HA happy path and follow it end-to-end:
     [image package](https://github.com/futuroptimist/jobbot3000/pkgs/container/jobbot3000),
     [chart workflow](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci-helm.yml),
     [chart package](https://github.com/futuroptimist/jobbot3000/pkgs/container/charts%2Fjobbot3000).
+  - [GitShelves runbook](docs/apps/gitshelves.md) for `ghcr.io/futuroptimist/gitshelves`:
+    [image workflow](https://github.com/futuroptimist/gitshelves/actions/workflows/ci-image.yml),
+    [image package](https://github.com/futuroptimist/gitshelves/pkgs/container/gitshelves),
+    [chart workflow](https://github.com/futuroptimist/gitshelves/actions/workflows/ci-helm.yml),
+    [chart package](https://github.com/futuroptimist/gitshelves/pkgs/container/charts%2Fgitshelves).
 - **Environment shortcuts:** token.place
   [dev](docs/k3s-tokenplace-dev.md), [staging](docs/k3s-tokenplace-staging.md), and
   [production](docs/k3s-tokenplace-prod.md); danielsmith.io

--- a/clusters/staging/observability/probes/public-apps.yaml
+++ b/clusters/staging/observability/probes/public-apps.yaml
@@ -446,3 +446,143 @@ spec:
         environment: staging
         route: manifest
         criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-gitshelves-staging-root
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app: gitshelves
+    environment: staging
+    route: root
+    criticality: critical
+spec:
+  interval: 60s
+  module: https_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+    path: "/probe"
+  targets:
+    staticConfig:
+      static:
+      - https://staging.gitshelves.com/
+      labels:
+        app: gitshelves
+        environment: staging
+        route: root
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-gitshelves-staging-healthz
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app: gitshelves
+    environment: staging
+    route: healthz
+    criticality: critical
+spec:
+  interval: 60s
+  module: json_health_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+    path: "/probe"
+  targets:
+    staticConfig:
+      static:
+      - https://staging.gitshelves.com/healthz
+      labels:
+        app: gitshelves
+        environment: staging
+        route: healthz
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-gitshelves-staging-livez
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app: gitshelves
+    environment: staging
+    route: livez
+    criticality: critical
+spec:
+  interval: 60s
+  module: json_health_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+    path: "/probe"
+  targets:
+    staticConfig:
+      static:
+      - https://staging.gitshelves.com/livez
+      labels:
+        app: gitshelves
+        environment: staging
+        route: livez
+        criticality: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-gitshelves-staging-baseplate
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app: gitshelves
+    environment: staging
+    route: baseplate
+    criticality: warning
+spec:
+  interval: 60s
+  module: static_content_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+    path: "/probe"
+  targets:
+    staticConfig:
+      static:
+      - https://staging.gitshelves.com/models/baseplate_2x6.stl
+      labels:
+        app: gitshelves
+        environment: staging
+        route: baseplate
+        criticality: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: blackbox-gitshelves-staging-module
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app: gitshelves
+    environment: staging
+    route: module
+    criticality: warning
+spec:
+  interval: 60s
+  module: static_content_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+    path: "/probe"
+  targets:
+    staticConfig:
+      static:
+      - https://staging.gitshelves.com/models/contrib_cube.stl
+      labels:
+        app: gitshelves
+        environment: staging
+        route: module
+        criticality: warning

--- a/docs/app_deployment_contract.md
+++ b/docs/app_deployment_contract.md
@@ -106,6 +106,7 @@ historical-configuration replay is outside this recovery exception.
 Future onboarding examples such as wove should only get Sugarkube app configs
 after their app repositories have published compatible images and charts.
 jobbot3000 now follows this contract through the generic app config and runbook.
+GitShelves also follows it through the generic app config and runbook; no app-specific recipes exist.
 Use the [future-app onboarding guide](app_onboarding.md) for the checklist, minimal config template, and release decision tree.
 
 ## Standard artifact model
@@ -145,6 +146,7 @@ The current apps map to that model as examples:
 | token.place | `ghcr.io/futuroptimist/tokenplace-relay` | `oci://ghcr.io/futuroptimist/charts/tokenplace` | `tokenplace` | `tokenplace` | `docs/apps/tokenplace.version` | `docs/apps/tokenplace.prod.tag` |
 | danielsmith.io | `ghcr.io/futuroptimist/danielsmith.io` | `oci://ghcr.io/futuroptimist/charts/danielsmith` | `danielsmith` | `danielsmith` | `docs/apps/danielsmith.version` | `docs/apps/danielsmith.prod.tag` |
 | jobbot3000 | `ghcr.io/futuroptimist/jobbot3000` | `oci://ghcr.io/futuroptimist/charts/jobbot3000` | `jobbot3000` | `jobbot3000` | `docs/apps/jobbot3000.version` | `docs/apps/jobbot3000.prod.tag` |
+| GitShelves | `ghcr.io/futuroptimist/gitshelves` | `oci://ghcr.io/futuroptimist/charts/gitshelves` | `gitshelves` | `gitshelves` | `docs/apps/gitshelves.version` | `docs/apps/gitshelves.prod.tag` |
 
 ## Standard image tag model
 
@@ -396,6 +398,7 @@ shared `SUGARKUBE_VERIFY_PATHS` value:
 - [`docs/examples/apps/tokenplace.env`](examples/apps/tokenplace.env)
 - [`docs/examples/apps/danielsmith.env`](examples/apps/danielsmith.env)
 - [`docs/examples/apps/jobbot3000.env`](examples/apps/jobbot3000.env)
+- [`docs/examples/apps/gitshelves.env`](examples/apps/gitshelves.env)
 
 Current values chains:
 
@@ -405,3 +408,4 @@ Current values chains:
 | token.place | `docs/examples/tokenplace.values.dev.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.staging.yaml` | `docs/examples/tokenplace.values.dev.yaml,docs/examples/tokenplace.values.prod.yaml` | `/,/livez,/healthz,/relay/diagnostics` |
 | danielsmith.io | `docs/examples/danielsmith.values.dev.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.staging.yaml` | `docs/examples/danielsmith.values.dev.yaml,docs/examples/danielsmith.values.prod.yaml` | `/,/livez,/healthz` |
 | jobbot3000 | `docs/examples/jobbot3000.values.dev.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.staging.yaml` | `docs/examples/jobbot3000.values.dev.yaml,docs/examples/jobbot3000.values.prod.yaml` | `/,/healthz,/livez` |
+| GitShelves | `docs/examples/gitshelves.values.dev.yaml` | `docs/examples/gitshelves.values.dev.yaml,docs/examples/gitshelves.values.staging.yaml` | `docs/examples/gitshelves.values.dev.yaml,docs/examples/gitshelves.values.prod.yaml` | `/,/healthz,/livez` |

--- a/docs/app_onboarding.md
+++ b/docs/app_onboarding.md
@@ -105,7 +105,7 @@ Create a base values file plus one overlay per environment.
 
 ## Questions before onboarding future apps
 
-Do not invent real configs for future apps such as `wove` until their app repos have the required image and chart details. jobbot3000 is now onboarded because its image and chart details are known. Capture these answers first:
+Do not invent real configs for future apps such as `wove` until their app repos have the required image and chart details. DSPACE, token.place, danielsmith.io, jobbot3000, and GitShelves are currently supported because their image and chart details are known. Capture these answers first:
 
 | Question | Why Sugarkube needs it |
 | --- | --- |

--- a/docs/apps/gitshelves.md
+++ b/docs/apps/gitshelves.md
@@ -1,0 +1,114 @@
+# GitShelves on Sugarkube
+
+This is the canonical runbook for GitShelves, a static, browser-only, local-first application. Sugarkube serves static files; user shelf data remains in browser storage and is not sent to a Kubernetes backend.
+
+## Ownership and coordinates
+
+- The [GitShelves repository](https://github.com/futuroptimist/gitshelves) owns application source, image builds, immutable image tags, the Dockerfile, chart source, and chart publication.
+- Sugarkube owns the generic app configuration, environment overlays, artifact pins, Helm desired state, rollout verification, and staging Probe definitions.
+- Cloudflare owns DNS and Tunnel routing. Those external resources are not managed by Helm or by this change.
+
+| Coordinate | Value |
+| --- | --- |
+| Image | `ghcr.io/futuroptimist/gitshelves` |
+| Chart | `oci://ghcr.io/futuroptimist/charts/gitshelves` |
+| Release / namespace | `gitshelves` / `gitshelves` |
+| App config | `docs/examples/apps/gitshelves.env` |
+| Chart version pin | `docs/apps/gitshelves.version` (`0.1.0`) |
+| Production tag pin | `docs/apps/gitshelves.prod.tag` (intentionally empty) |
+| Container port | `8080` |
+| Verify paths | `/`, `/healthz`, `/livez` |
+| Staging / future production | `staging.gitshelves.com` / `gitshelves.com` |
+
+### Artifact links
+
+| Artifact | Link |
+| --- | --- |
+| App repository | [GitShelves app repository](https://github.com/futuroptimist/gitshelves) |
+| Image workflow | [Recent image workflow runs](https://github.com/futuroptimist/gitshelves/actions/workflows/ci-image.yml) |
+| Successful main images | [Successful main image workflow runs](https://github.com/futuroptimist/gitshelves/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess) |
+| GHCR image package | [GHCR image package](https://github.com/futuroptimist/gitshelves/pkgs/container/gitshelves) |
+| Chart workflow | [Recent chart workflow runs](https://github.com/futuroptimist/gitshelves/actions/workflows/ci-helm.yml) |
+| GHCR chart package | [GHCR chart package](https://github.com/futuroptimist/gitshelves/pkgs/container/charts%2Fgitshelves) |
+| Dockerfile | [Application Dockerfile](https://github.com/futuroptimist/gitshelves/blob/main/Dockerfile) |
+| Chart source path | [Helm chart source](https://github.com/futuroptimist/gitshelves/tree/main/charts/gitshelves) |
+| Release guide | [GitShelves release documentation](https://github.com/futuroptimist/gitshelves/tree/main/docs) |
+
+Web UI shortcuts: use the image workflow, GHCR image package, chart workflow, and GHCR chart package above to confirm immutable artifacts.
+
+## Verified preflight and data model
+
+Operator evidence ties merge commit `2125943cca1c3369f0b49bf11ec6ef3f26da5b42` to candidate `main-2125943cca1c`. Its AMD64 digest is `sha256:60669ca6ab1b0d4a9db965624361f74e6bc8339c90731450d8af3dd9eed0f731`; its ARM64 digest is `sha256:23970f301e2798ebd3195381bde1b5f1acf0e06d47bcd99e73a6eb2f9eb89b43`. Ready staging nodes `sugarkube3`, `sugarkube4`, and `sugarkube5` are ARM64. Chart `0.1.0` was verified at digest `sha256:ebeeff198bce16896c70786f11f6814a28841077b93c98047c2e1e30be66e703`.
+
+The application is static and local-first. It needs no Kubernetes Secret, GitHub credentials, database, queue, PVC, backend configuration, or ServiceMonitor. It does not expose `/metrics`; public blackbox checks cover its service contract. Never place private browser data in images, values, or cluster resources.
+
+Only branch-SHA tags ending in a 7–40 character lowercase Git SHA are deployment coordinates. Reject `latest`, `main`, environment names, and other moving tags.
+
+## Initial staging rollout
+
+The Cloudflare Tunnel route is external to Helm and must eventually route hostname `staging.gitshelves.com` to service `http://traefik.kube-system.svc.cluster.local:80`. Do not create it from this repository task.
+
+Run this exact sequence only after the operator establishes that route:
+
+```bash
+just app-config app=gitshelves env=staging
+just app-chart-status app=gitshelves
+just app-deploy app=gitshelves env=staging tag=main-2125943cca1c
+just app-status app=gitshelves env=staging
+just app-verify app=gitshelves env=staging
+```
+
+Preview public verification without network calls:
+
+```bash
+just app-verify app=gitshelves env=staging print_only=1
+```
+
+Apply and verify staging blackbox Probes only after both the workload and Cloudflare route exist, using the repository's existing blackbox lifecycle commands documented in `docs/observability-blackbox.md`.
+
+## Troubleshooting and evidence
+
+All cluster diagnostics explicitly pin staging:
+
+```bash
+kubectl --context sugar-staging get deployment gitshelves -n gitshelves -o wide
+kubectl --context sugar-staging get pods -n gitshelves -l app.kubernetes.io/name=gitshelves -o wide
+kubectl --context sugar-staging describe pods -n gitshelves -l app.kubernetes.io/name=gitshelves
+kubectl --context sugar-staging get service,endpoints -n gitshelves
+kubectl --context sugar-staging get ingress -n gitshelves gitshelves -o wide
+kubectl --context sugar-staging describe ingress -n gitshelves gitshelves
+kubectl --context sugar-staging get certificate,order,challenge -n gitshelves
+kubectl --context sugar-staging describe certificate -n gitshelves gitshelves-staging-tls
+kubectl --context sugar-staging logs -n kube-system -l app.kubernetes.io/name=traefik --tail=200
+kubectl --context sugar-staging logs -n cert-manager deploy/cert-manager --tail=200
+```
+
+```bash
+helm --kube-context sugar-staging -n gitshelves status gitshelves
+helm --kube-context sugar-staging -n gitshelves get values gitshelves
+kubectl --context sugar-staging get deployment gitshelves -n gitshelves -o jsonpath='{.spec.template.spec.containers[*].image}{"\n"}'
+```
+
+Capture public health and asset evidence:
+
+```bash
+curl -fsS https://staging.gitshelves.com/
+curl -fsS https://staging.gitshelves.com/healthz
+curl -fsS https://staging.gitshelves.com/livez
+curl -fSLo /tmp/baseplate_2x6.stl https://staging.gitshelves.com/models/baseplate_2x6.stl
+curl -fSLo /tmp/contrib_cube.stl https://staging.gitshelves.com/models/contrib_cube.stl
+```
+
+## Promotion and rollback
+
+Production remains blocked. Keep `docs/apps/gitshelves.prod.tag` empty until public staging verification is captured and an operator explicitly approves the exact candidate. A later approved promotion uses `just app-promote-prod app=gitshelves tag=<APPROVED_IMMUTABLE_TAG>`; this PR does not run it.
+
+Rollback normally by redeploying the previous immutable tag:
+
+```bash
+just app-redeploy app=gitshelves env=staging tag=main-REPLACE_PREVIOUS_SHORTSHA
+just app-status app=gitshelves env=staging
+just app-verify app=gitshelves env=staging
+```
+
+As an emergency alternative after identifying a known-good revision, use `helm --kube-context sugar-staging -n gitshelves rollback gitshelves <REVISION>` and repeat status and verification. Record the deployed image, Helm revision, public checks, and rollback evidence.

--- a/docs/apps/gitshelves.prod.tag
+++ b/docs/apps/gitshelves.prod.tag
@@ -1,0 +1,3 @@
+# Approved production image tag for GitShelves.
+# Leave empty until the staging candidate is publicly verified and explicitly approved.
+# Never place a moving tag or an unapproved staging candidate here.

--- a/docs/apps/gitshelves.version
+++ b/docs/apps/gitshelves.version
@@ -1,0 +1,2 @@
+# Published GitShelves chart version verified by the operator.
+0.1.0

--- a/docs/examples/apps/gitshelves.env
+++ b/docs/examples/apps/gitshelves.env
@@ -1,0 +1,14 @@
+# Example Sugarkube app config for GitShelves.
+# This committed, sanitized config is the generic-recipe fallback.
+SUGARKUBE_APP=gitshelves
+SUGARKUBE_RELEASE=gitshelves
+SUGARKUBE_NAMESPACE=gitshelves
+SUGARKUBE_CHART=oci://ghcr.io/futuroptimist/charts/gitshelves
+SUGARKUBE_VERSION_FILE=docs/apps/gitshelves.version
+SUGARKUBE_PROD_TAG_FILE=docs/apps/gitshelves.prod.tag
+SUGARKUBE_VALUES_DEV=docs/examples/gitshelves.values.dev.yaml
+SUGARKUBE_VALUES_STAGING=docs/examples/gitshelves.values.dev.yaml,docs/examples/gitshelves.values.staging.yaml
+SUGARKUBE_VALUES_PROD=docs/examples/gitshelves.values.dev.yaml,docs/examples/gitshelves.values.prod.yaml
+SUGARKUBE_STATUS_HOST_KEY=ingress.host
+SUGARKUBE_VERIFY_PATHS=/,/healthz,/livez
+SUGARKUBE_DEBUG_SELECTOR=app.kubernetes.io/name=gitshelves

--- a/docs/examples/gitshelves.values.dev.yaml
+++ b/docs/examples/gitshelves.values.dev.yaml
@@ -1,0 +1,23 @@
+# Shared GitShelves values. The published 0.1.0 chart consumes only these keys.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/gitshelves
+  # Replace with an immutable branch-SHA tag; moving tags are forbidden.
+  tag: main-REPLACE_SHORTSHA
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: traefik
+  host: gitshelves.dev.example.test
+  annotations: {}
+  tls: []
+
+resources:
+  requests: {cpu: 25m, memory: 32Mi}
+  limits: {cpu: 250m, memory: 128Mi}

--- a/docs/examples/gitshelves.values.prod.yaml
+++ b/docs/examples/gitshelves.values.prod.yaml
@@ -1,0 +1,11 @@
+# Desired production overlay; production promotion remains blocked.
+ingress:
+  enabled: true
+  className: traefik
+  host: gitshelves.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    - secretName: gitshelves-prod-tls
+      hosts:
+        - gitshelves.com

--- a/docs/examples/gitshelves.values.staging.yaml
+++ b/docs/examples/gitshelves.values.staging.yaml
@@ -1,0 +1,11 @@
+# Staging overlay layered on gitshelves.values.dev.yaml.
+ingress:
+  enabled: true
+  className: traefik
+  host: staging.gitshelves.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  tls:
+    - secretName: gitshelves-staging-tls
+      hosts:
+        - staging.gitshelves.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Review the safety notes before working with power components.
 - [pi_support_bundles.md](pi_support_bundles.md) — collect diagnostics into shareable archives
 - [pi_image_telemetry.md](pi_image_telemetry.md) — opt-in anonymized telemetry for fleet dashboards
 - [observability-design.md](observability-design.md) — canonical Prometheus/Grafana observability
-  design across Sugarkube, DSPACE, token.place, danielsmith.io, and jobbot3000
+  design across Sugarkube, DSPACE, token.place, danielsmith.io, jobbot3000, and GitShelves
 - [observability-operations.md](observability-operations.md) — staging-only non-Flux kube-prometheus-stack operations runbook
 - [observability-blackbox.md](observability-blackbox.md) — staging blackbox exporter and public probe lifecycle runbook
 - [observability-alerting.md](observability-alerting.md) — canonical alerting strategy: PagerDuty/Healthchecks.io target architecture, routing policy, and rollout/drill plan
@@ -49,7 +49,8 @@ Review the safety notes before working with power components.
 - [docker_repo_walkthrough.md](docker_repo_walkthrough.md) — deploy any Docker-based repo
 - [projects-compose.md](projects-compose.md) — run token.place & dspace via docker compose
 - [app_deployment_contract.md](app_deployment_contract.md) — shared Sugarkube app artifact, tag, chart, config, and generic command contract
-- [app_onboarding.md](app_onboarding.md) — future-app onboarding checklist and release decision tree for wove, jobbot3000, and later apps
+- [app_onboarding.md](app_onboarding.md) — future-app onboarding checklist and release decision tree for wove and later apps
+- [apps/gitshelves.md](apps/gitshelves.md) — GitShelves staging, verification, promotion, and rollback runbook
 - [tokenplace_sugarkube_onboarding.md](tokenplace_sugarkube_onboarding.md) — legacy token.place-specific onboarding context
 - [apps/dspace.md](apps/dspace.md) — DSPACE GHCR-first deploy, verify, promote, rollback, and troubleshooting runbook
 - [apps/tokenplace.md](apps/tokenplace.md) — token.place GHCR-first deploy, verify, promote, rollback, and troubleshooting runbook

--- a/docs/observability-blackbox.md
+++ b/docs/observability-blackbox.md
@@ -70,8 +70,11 @@ pruning or staging Probe deletion is used. Neither uses
 | token.place (`tokenplace`) | `https://staging.token.place` | `/` (`root`), `/healthz` (`healthz`), `/livez` (`livez`), `/api/v1/meta` (`metadata`) |
 | danielsmith.io (`danielsmith`) | `https://staging.danielsmith.io` | `/` (`root`), `/healthz` (`healthz`), `/livez` (`livez`) |
 | jobbot3000 | `https://staging.jobbot3000.tech` | `/` (`root`), `/healthz` (`healthz`), `/livez` (`livez`), `/tracker` (`tracker`), `/manifest.webmanifest` (`manifest`) |
+| GitShelves | `https://staging.gitshelves.com` | `/` (`root`), `/healthz` (`healthz`), `/livez` (`livez`), `/models/baseplate_2x6.stl` (`baseplate`), `/models/contrib_cube.stl` (`module`) |
 
-These are exactly 16 Probes. Labels are bounded to `release`, `app`,
+Apply and verify the GitShelves Probe resources only after its staging workload and external Cloudflare Tunnel route exist. GitShelves exposes no `/metrics`, so it requires no ServiceMonitor.
+
+These are exactly 21 Probes. Labels are bounded to `release`, `app`,
 `environment: staging`, `route`, and `criticality`. Verification uses the
 Prometheus Kubernetes service proxy and bounded polling to prove the exact
 app/route target matrix, `probe_success == 1`, and the duration, HTTP status,

--- a/justfile
+++ b/justfile
@@ -1500,6 +1500,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
       oci://ghcr.io/futuroptimist/charts/tokenplace) chart_identity=tokenplace ;;
       oci://ghcr.io/futuroptimist/charts/danielsmith) chart_identity=danielsmith ;;
       oci://ghcr.io/futuroptimist/charts/jobbot3000) chart_identity=jobbot3000 ;;
+      oci://ghcr.io/futuroptimist/charts/gitshelves) chart_identity=gitshelves ;;
     esac
     if [ -z "${app}" ]; then
       app="${chart_identity}"
@@ -1513,7 +1514,7 @@ _helm-oci-deploy release='' namespace='' chart='' values='' host='' version='' v
     fi
     if [ -n "${app}" ]; then
       case "${app}" in
-        dspace|tokenplace|danielsmith|jobbot3000) ;;
+        dspace|tokenplace|danielsmith|jobbot3000|gitshelves) ;;
         *) echo "ERROR: app=${app} is not an onboarded Sugarkube application." >&2; exit 2 ;;
       esac
       if [ -z "${image_tag}" ]; then

--- a/scripts/app_config.py
+++ b/scripts/app_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterable
 
 SUPPORTED_ENVS = {"dev", "staging", "prod"}
-EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "jobbot3000", "tokenplace"}
+EXAMPLE_FALLBACK_APPS = {"danielsmith", "dspace", "gitshelves", "jobbot3000", "tokenplace"}
 MOVING_TAGS = {
     "latest",
     "main",

--- a/scripts/verify_blackbox_prometheus.py
+++ b/scripts/verify_blackbox_prometheus.py
@@ -22,6 +22,11 @@ EXPECTED = {
     "blackbox-jobbot3000-staging-livez": ("jobbot3000", "livez"),
     "blackbox-jobbot3000-staging-tracker": ("jobbot3000", "tracker"),
     "blackbox-jobbot3000-staging-manifest": ("jobbot3000", "manifest"),
+    "blackbox-gitshelves-staging-root": ("gitshelves", "root"),
+    "blackbox-gitshelves-staging-healthz": ("gitshelves", "healthz"),
+    "blackbox-gitshelves-staging-livez": ("gitshelves", "livez"),
+    "blackbox-gitshelves-staging-baseplate": ("gitshelves", "baseplate"),
+    "blackbox-gitshelves-staging-module": ("gitshelves", "module"),
 }
 EXPECTED_JOBS = {f"probe/monitoring/{name}": labels for name, labels in EXPECTED.items()}
 

--- a/tests/test_app_runbook_links.py
+++ b/tests/test_app_runbook_links.py
@@ -10,6 +10,7 @@ DSPACE_REPO = "https://github.com/democratizedspace/dspace"
 TOKENPLACE_REPO = "https://github.com/futuroptimist/token.place"
 DANIELSMITH_REPO = "https://github.com/futuroptimist/danielsmith.io"
 JOBBOT3000_REPO = "https://github.com/futuroptimist/jobbot3000"
+GITSHELVES_REPO = "https://github.com/futuroptimist/gitshelves"
 DSPACE_CHART_PACKAGE_LOOKUP = (
     "https://github.com/orgs/democratizedspace/"
     "packages?repo_name=dspace&q=charts%2Fdspace"
@@ -79,6 +80,20 @@ APP_LINKS = {
             f"{JOBBOT3000_REPO}/tree/main/docs",
         ],
     },
+    "gitshelves": {
+        "runbook": "docs/apps/gitshelves.md",
+        "urls": [
+            GITSHELVES_REPO,
+            f"{GITSHELVES_REPO}/actions/workflows/ci-image.yml",
+            f"{GITSHELVES_REPO}/actions/workflows/ci-image.yml?query=branch%3Amain+is%3Asuccess",
+            f"{GITSHELVES_REPO}/pkgs/container/gitshelves",
+            f"{GITSHELVES_REPO}/actions/workflows/ci-helm.yml",
+            f"{GITSHELVES_REPO}/pkgs/container/charts%2Fgitshelves",
+            f"{GITSHELVES_REPO}/blob/main/Dockerfile",
+            f"{GITSHELVES_REPO}/tree/main/charts/gitshelves",
+            f"{GITSHELVES_REPO}/tree/main/docs",
+        ],
+    },
 }
 
 README_QUICK_LINKS = {
@@ -109,6 +124,13 @@ README_QUICK_LINKS = {
         f"{JOBBOT3000_REPO}/pkgs/container/jobbot3000",
         f"{JOBBOT3000_REPO}/actions/workflows/ci-helm.yml",
         f"{JOBBOT3000_REPO}/pkgs/container/charts%2Fjobbot3000",
+    ],
+    "gitshelves": [
+        "docs/apps/gitshelves.md",
+        f"{GITSHELVES_REPO}/actions/workflows/ci-image.yml",
+        f"{GITSHELVES_REPO}/pkgs/container/gitshelves",
+        f"{GITSHELVES_REPO}/actions/workflows/ci-helm.yml",
+        f"{GITSHELVES_REPO}/pkgs/container/charts%2Fgitshelves",
     ],
 }
 

--- a/tests/test_generic_app_just_recipes.py
+++ b/tests/test_generic_app_just_recipes.py
@@ -316,6 +316,8 @@ spec:
     [[ "$*" != *danielsmith.values.prod.yaml* ]] || host=danielsmith.io
     [[ "$*" != *jobbot3000.values.staging.yaml* ]] || host=staging.jobbot3000.tech
     [[ "$*" != *jobbot3000.values.prod.yaml* ]] || host=jobbot3000.example.test
+    [[ "$*" != *gitshelves.values.staging.yaml* ]] || host=staging.gitshelves.com
+    [[ "$*" != *gitshelves.values.prod.yaml* ]] || host=gitshelves.com
     cat <<YAML
 apiVersion: apps/v1
 kind: Deployment
@@ -2550,6 +2552,15 @@ def test_app_deploy_danielsmith_passes_image_tag(generic_app_stub_env: dict[str,
             [
                 "docs/examples/jobbot3000.values.dev.yaml",
                 "docs/examples/jobbot3000.values.staging.yaml",
+            ],
+        ),
+        (
+            "gitshelves",
+            "oci://ghcr.io/futuroptimist/charts/gitshelves",
+            "gitshelves",
+            [
+                "docs/examples/gitshelves.values.dev.yaml",
+                "docs/examples/gitshelves.values.staging.yaml",
             ],
         ),
     ],
@@ -8531,3 +8542,53 @@ def test_non_opted_in_missing_family_remains_missing(monkeypatch):
     with pytest.raises(app_metrics.Error, match="required metric family missing"):
         app_metrics.verify("tokenplace", "staging")
     assert metadata_queries == []
+
+
+@pytest.mark.parametrize("env", ["dev", "staging", "prod"])
+def test_gitshelves_example_config_resolves(env: str) -> None:
+    result = subprocess.run(
+        [
+            "python3", "scripts/app_config.py", "json", "--app", "gitshelves",
+            "--env", env, "--config", "",
+        ],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["SUGARKUBE_CHART"] == "oci://ghcr.io/futuroptimist/charts/gitshelves"
+    assert data["SUGARKUBE_VALUES"].startswith("docs/examples/gitshelves.values.dev.yaml")
+
+
+def test_gitshelves_values_and_pins_are_safe() -> None:
+    staging = (REPO_ROOT / "docs/examples/gitshelves.values.staging.yaml").read_text()
+    prod = (REPO_ROOT / "docs/examples/gitshelves.values.prod.yaml").read_text()
+    combined = "\n".join(
+        path.read_text().lower()
+        for path in (REPO_ROOT / "docs/examples").glob("gitshelves.values.*.yaml")
+    )
+    assert "host: staging.gitshelves.com" in staging
+    assert "secretName: gitshelves-staging-tls" in staging
+    assert "host: gitshelves.com" in prod
+    assert "secretName: gitshelves-prod-tls" in prod
+    assert (REPO_ROOT / "docs/apps/gitshelves.version").read_text().splitlines()[-1] == "0.1.0"
+    active = [line for line in (REPO_ROOT / "docs/apps/gitshelves.prod.tag").read_text().splitlines()
+              if line.strip() and not line.lstrip().startswith("#")]
+    assert not active
+    for forbidden in ("secret:", "persistence:", "persistentvolumeclaim", "database:", "queue:"):
+        assert forbidden not in combined
+
+
+@pytest.mark.usefixtures("ensure_just_available")
+def test_app_verify_print_only_gitshelves_paths(
+    generic_app_stub_env: dict[str, str],
+) -> None:
+    result = _run_just(
+        ["app-verify", "app=gitshelves", "env=staging", "print_only=1"],
+        generic_app_stub_env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert result.stdout.splitlines() == [
+        "curl -fsS https://example.test/",
+        "curl -fsS https://example.test/healthz",
+        "curl -fsS https://example.test/livez",
+    ]

--- a/tests/test_monitoring_blackbox.py
+++ b/tests/test_monitoring_blackbox.py
@@ -30,6 +30,11 @@ EXPECTED = {
         "https://staging.jobbot3000.tech/manifest.webmanifest",
         "static_content_2xx",
     ),
+    ("gitshelves", "root", "https://staging.gitshelves.com/", "https_2xx"),
+    ("gitshelves", "healthz", "https://staging.gitshelves.com/healthz", "json_health_2xx"),
+    ("gitshelves", "livez", "https://staging.gitshelves.com/livez", "json_health_2xx"),
+    ("gitshelves", "baseplate", "https://staging.gitshelves.com/models/baseplate_2x6.stl", "static_content_2xx"),
+    ("gitshelves", "module", "https://staging.gitshelves.com/models/contrib_cube.stl", "static_content_2xx"),
 }
 
 
@@ -83,7 +88,7 @@ def test_pinned_chart_values_are_private_and_bounded():
 
 def test_staging_probe_matrix_is_exact():
     docs = yaml(PROBES)
-    assert len(docs) == 16
+    assert len(docs) == 21
     actual = set()
     for doc in docs:
         labels = doc["metadata"]["labels"]


### PR DESCRIPTION
### Motivation

- Bring GitShelves into the Sugarkube generic app deployment/verification/runbook lifecycle to match DSPACE, token.place, danielsmith.io, and jobbot3000. 
- Provide committed example env/values overlays, chart and production pins, and a canonical runbook so operators can stage an immutable candidate without guessing coordinates. 
- Add staging blackbox observability entries so Sugarkube can verify public health endpoints and key static assets for staging once the external Cloudflare Tunnel exists.

### Description

- Added generic app example discovery and fallback: `docs/examples/apps/gitshelves.env` and added `gitshelves` to `EXAMPLE_FALLBACK_APPS` in `scripts/app_config.py` so generic `just app-*` flows work from the committed examples. 
- Created chart-consumed values overlays: `docs/examples/gitshelves.values.dev.yaml`, `docs/examples/gitshelves.values.staging.yaml`, and `docs/examples/gitshelves.values.prod.yaml` that only set keys the `gitshelves` chart requires (image repo, placeholder immutable tag, ClusterIP service, disabled dev ingress, staging/prod ingress with Traefik class, cert-manager issuer annotations and TLS secret names). 
- Pinned chart and production pin files: `docs/apps/gitshelves.version` (0.1.0) and `docs/apps/gitshelves.prod.tag` (intentionally empty). 
- Added canonical runbook: `docs/apps/gitshelves.md` documenting ownership boundaries, artifact coordinates, verified preflight evidence, static/local-first data model, exact staging command sequence (with `print_only=1` verification), troubleshooting commands that explicitly use `--context sugar-staging`, and production-blocking guidance. 
- Staging blackbox probes: extended `clusters/staging/observability/probes/public-apps.yaml` with five GitShelves Probes (`root`, `healthz`, `livez`, `baseplate`, `module`) carrying lifecycle labels and appropriate modules/criticalities; updated the expected staging matrix count from 16 → 21. 
- Tests and inventory updates: updated `tests/test_generic_app_just_recipes.py`, `tests/test_app_runbook_links.py`, and `tests/test_monitoring_blackbox.py` to include GitShelves coverage (example config resolution, values overlays, TLS secrets/hosts, chart pin, `print_only=1` verification checks, and blackbox matrix expectations). 
- Small tooling and recipe integration: added `gitshelves` to the `justfile` chart identity and allowed-app checks so `just app-*` Helm preflight validations run for the new app; updated `scripts/verify_blackbox_prometheus.py` to expect the new probes. 

### Testing

- Ran the focused test trio: `pytest -q tests/test_generic_app_just_recipes.py tests/test_app_runbook_links.py tests/test_monitoring_blackbox.py` and observed the focused suite passing (`537 passed, 1 warning`). 
- Rendered the published Helm chart to verify effective values chains and TLS secrets/hosts for each env with `helm template` (dev/staging/prod) using `--version 0.1.0` and a verified immutable tag; renders produced the expected `Ingress` rules, TLS secret names, and image repository/tag placeholders. 
- Documentation validators: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` passed after adding GitShelves to the wordlist; spelling and link checks report no blocking issues. 
- Secret scan and commit hooks: ran `git diff --cached | ./scripts/scan-secrets.py` and invoked `pre-commit`; `pre-commit` initially flagged and automatically fixed repository-wide whitespace/YAML formatting issues (these are unrelated baseline fixes and were committed), and no policy gates were weakened. 

Notes and residuals

- No live deployment, Cloudflare Tunnel creation, or external service mutation was performed in this PR—this change only defines the repository state. 
- The branch `feat/onboard-gitshelves` was committed locally in this environment but pushing to the remote `origin` was not possible from this checkout (no remote configured here). Post-merge operator steps are documented in `docs/apps/gitshelves.md` (Cloudflare Tunnel, `just app-deploy ... tag=main-2125943cca1c`, verify, apply Probes, capture evidence).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87475fbfe4832fa9aace4022419bdf)