### PR TITLE
Add fail-closed `system-chromium-v1` browser contract for DSPACE synthetic producer

### DIFF
--- a/config/dspace-chat-synthetic.json
+++ b/config/dspace-chat-synthetic.json
@@ -16,5 +16,19 @@
   "resultRoot": "/run/sugarkube/dspace-chat-synthetic",
   "metricPath": "/var/lib/node_exporter/textfile_collector/dspace-chat.prom",
   "metricsConsumer": "/usr/local/libexec/sugarkube-dspace-chat-synthetic-metrics",
+  "browserContract": {
+    "name": "system-chromium-v1",
+    "architecture": "aarch64",
+    "launcherPath": "/usr/bin/chromium",
+    "launcherRealpath": "/usr/bin/chromium",
+    "launcherSha256": "be1d239c2a7a9298c202d506e589d23056064bd52b82fa3d3cf72a0a2de3337c",
+    "executablePath": "/usr/lib/chromium/chromium",
+    "executableRealpath": "/usr/lib/chromium/chromium",
+    "executableSha256": "f8cf8a41a3406375dc9b9af5ce25a3fececa3d4e9e72d18671db07cdee7a75a6",
+    "owner": "root",
+    "group": "root",
+    "mode": "0755",
+    "launcherExecutableRelationship": "distinct-files"
+  },
   "dspaceOrigin": "https://staging.democratized.space"
 }

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -32,14 +32,28 @@ python3 scripts/install_dspace_chat_synthetic.py materialize \
   --repository-identity https://github.com/democratizedspace/dspace.git \
   --output /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5 \
   --pnpm /absolute/toolchain/pnpm --pnpm-version 9.0.0 \
-  --browser-bundle /absolute/path/to/browser-bundle
+  --browser-source-root /absolute/private/target-root
 ```
 
 The explicitly selected pnpm executable must report exactly `9.0.0`, matching the pinned DSPACE
-commit's `packageManager`. The supplied local browser bundle is copied into the runner and used through a runner-local `PLAYWRIGHT_BROWSERS_PATH`; no `$HOME` cache is trusted. The local pnpm cache must already contain the exact lockfile's packages. Construction fails for a
+commit's `packageManager`. The staging configuration explicitly selects `system-chromium-v1` for
+architecture `aarch64`, launcher `/usr/bin/chromium`, and scheduled executable
+`/usr/lib/chromium/chromium`. Its committed SHA-256 values are validated along with realpaths,
+regular/executable state, `root:root:0755` ownership/mode, and the configured distinct-file
+relationship. `--browser-source-root` maps those absolute coordinates into a private root; it must
+never point a private rehearsal at the live host by accident. This contract neither accepts
+`--browser-bundle` nor installs, downloads, copies, searches for, or modifies a browser.
+
+The alternative explicit `runner-local-playwright-v1` contract preserves the original construction
+behavior: supply `--browser-bundle`, copy it into the runner, discover and hash Playwright's exact
+runner-local executable, and launch with runner-local `PLAYWRIGHT_BROWSERS_PATH`. No `$HOME` cache
+is trusted. Contract selection is mandatory: absence, ambiguity, an unsupported value, or resources
+belonging only to the other contract fails closed without fallback. The local pnpm cache must
+already contain the exact lockfile's packages. Construction fails for a
 missing object, wrong HEAD, dirty tracked/index state, alternates, missing root store, broken
 frontend link, unusable Playwright shim/module resolution, or missing critical file. Its manifest
-records hashes for the runner, spec, workspace manifests, and lockfile.
+records hashes for the runner, spec, workspace manifests, lockfile, selected browser contract, and
+safe browser provenance.
 
 ## 2. Validate and dry-run installation
 
@@ -54,11 +68,15 @@ python3 scripts/install_dspace_chat_synthetic.py dry-run --root /tmp/rehearsal-r
 python3 scripts/install_dspace_chat_synthetic.py status --root /tmp/rehearsal-root
 ```
 
-The preflight first loads the rendered configuration and validates its exact runner revision against
-the snapshot basename, manifest hashes, independent Git metadata, dependencies, and Node/Playwright
-resolution. Review all hashes and coordinates. `status` is read-only and, for alternate roots, reports activation as not queried; only `/` queries unit activation without
-printing configuration secrets (the committed configuration contains none). A failed staging or
-preflight leaves installed fixtures unchanged.
+For an alternate installation root, both runner and absolute browser coordinates are resolved under
+that root; the installer never substitutes the live host's `/usr`. Populate private fixtures before
+the command. The preflight first loads the rendered configuration and validates its exact runner
+revision against the snapshot basename, manifest hashes, independent Git metadata, dependencies,
+and Node/Playwright resolution. It also validates architecture and browser provenance before any
+installation mutation. Review all hashes and coordinates. `status` is read-only and, for alternate
+roots, reports activation as not queried; only `/` queries unit activation without printing
+configuration secrets (the committed configuration contains none). A failed staging or preflight
+leaves installed fixtures unchanged.
 
 ## 3. Separately authorized installation and controlled execution
 
@@ -86,6 +104,11 @@ The required access model is exact: result root `root:pi` mode `0710`; each invo
 `0600`. The browser runs as `pi`. systemd creates the volatile result root on each boot. The service
 binds the path to systemd's exact 32-hex
 `INVOCATION_ID` and UTC epoch start/end window. It cleans only that invocation's path.
+Immediately before every child launch the runtime revalidates the selected contract. For the system
+contract it passes the already validated exact executable through the pinned runner's supported
+`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`; it does not hash one binary while launching another. Drift
+blocks Playwright before result creation, preserves the previous metric, and therefore retains the
+existing stale-signal behavior.
 
 After inspecting status, a controlled one-shot and timer activation are distinct, explicit operator
 actions; neither is performed by installation:

--- a/scripts/dspace_chat_synthetic_runtime.py
+++ b/scripts/dspace_chat_synthetic_runtime.py
@@ -213,6 +213,13 @@ def validate_browser_contract(config: dict, runner: Path, root: Path = Path("/")
         }
     if contract["name"] != SYSTEM_CHROMIUM or platform.machine() != contract["architecture"]:
         raise Invalid("browser architecture or contract")
+    try:
+        # Browser coordinates are absolute host paths.  Resolve an alternate root
+        # once so relative rehearsal roots cannot accidentally compare against,
+        # or fall through to, the live filesystem.
+        root = root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        raise Invalid("system browser source root") from None
     validated = []
     for prefix in ("launcher", "executable"):
         configured = contract[f"{prefix}Path"]

--- a/scripts/dspace_chat_synthetic_runtime.py
+++ b/scripts/dspace_chat_synthetic_runtime.py
@@ -147,6 +147,21 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def normalize_root(root: Path) -> Path:
+    """Return an existing real root without dereferencing caller identity."""
+    if ".." in root.parts:
+        raise Invalid("filesystem source root")
+    supplied = Path(os.path.abspath(root))
+    try:
+        info = supplied.lstat()
+        resolved = supplied.resolve(strict=True)
+    except (OSError, RuntimeError):
+        raise Invalid("filesystem source root") from None
+    if not stat.S_ISDIR(info.st_mode) or supplied != resolved:
+        raise Invalid("filesystem source root")
+    return resolved
+
+
 def discover_playwright_browser(runner: Path) -> Path:
     """Return Playwright's executable only when it is runner-local and usable."""
     browser_root = runner / "playwright-browser"
@@ -197,7 +212,10 @@ def discover_playwright_browser(runner: Path) -> Path:
 
 
 def _rooted(root: Path, absolute: str) -> Path:
-    return root / Path(absolute).relative_to("/")
+    coordinate = Path(absolute)
+    if not coordinate.is_absolute() or ".." in coordinate.parts:
+        raise Invalid("rooted coordinate")
+    return root / coordinate.relative_to("/")
 
 
 def validate_browser_contract(config: dict, runner: Path, root: Path = Path("/")) -> dict:
@@ -213,13 +231,7 @@ def validate_browser_contract(config: dict, runner: Path, root: Path = Path("/")
         }
     if contract["name"] != SYSTEM_CHROMIUM or platform.machine() != contract["architecture"]:
         raise Invalid("browser architecture or contract")
-    try:
-        # Browser coordinates are absolute host paths.  Resolve an alternate root
-        # once so relative rehearsal roots cannot accidentally compare against,
-        # or fall through to, the live filesystem.
-        root = root.resolve(strict=True)
-    except (OSError, RuntimeError):
-        raise Invalid("system browser source root") from None
+    root = normalize_root(root)
     validated = []
     for prefix in ("launcher", "executable"):
         configured = contract[f"{prefix}Path"]
@@ -227,9 +239,10 @@ def validate_browser_contract(config: dict, runner: Path, root: Path = Path("/")
         try:
             info = path.lstat()
             resolved = path.resolve(strict=True)
+            resolved.relative_to(root)
             owner = pwd.getpwuid(info.st_uid).pw_name
             group = grp.getgrgid(info.st_gid).gr_name
-        except (OSError, KeyError):
+        except (OSError, KeyError, ValueError):
             raise Invalid("system browser provenance") from None
         expected_realpath = _rooted(root, contract[f"{prefix}Realpath"])
         if (

--- a/scripts/dspace_chat_synthetic_runtime.py
+++ b/scripts/dspace_chat_synthetic_runtime.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import pwd
+import platform
 import re
 import shutil
 import stat
@@ -45,7 +46,10 @@ REQUIRED = {
     "resultRoot",
     "metricPath",
     "metricsConsumer",
+    "browserContract",
 }
+RUNNER_LOCAL = "runner-local-playwright-v1"
+SYSTEM_CHROMIUM = "system-chromium-v1"
 
 
 class Invalid(RuntimeError):
@@ -60,7 +64,7 @@ def load_config(path: Path) -> dict:
         or not REQUIRED <= value.keys()
     ):
         raise Invalid("configuration schema")
-    string_keys = REQUIRED - {"timeoutSeconds"}
+    string_keys = REQUIRED - {"timeoutSeconds", "browserContract"}
     if (
         any(not isinstance(value[key], str) for key in string_keys)
         or not isinstance(value["timeoutSeconds"], int)
@@ -92,6 +96,46 @@ def load_config(path: Path) -> dict:
     for key in ("runnerRoot", "resultRoot", "metricPath", "metricsConsumer"):
         if not Path(value[key]).is_absolute():
             raise Invalid("configured path")
+    browser = value["browserContract"]
+    if not isinstance(browser, dict) or browser.get("name") not in (RUNNER_LOCAL, SYSTEM_CHROMIUM):
+        raise Invalid("browser contract must be selected explicitly")
+    if browser["name"] == RUNNER_LOCAL:
+        if set(browser) != {"name"}:
+            raise Invalid("runner-local browser contract")
+    else:
+        required = {
+            "name",
+            "architecture",
+            "launcherPath",
+            "launcherRealpath",
+            "launcherSha256",
+            "executablePath",
+            "executableRealpath",
+            "executableSha256",
+            "owner",
+            "group",
+            "mode",
+            "launcherExecutableRelationship",
+        }
+        if set(browser) != required or any(not isinstance(browser[key], str) for key in required):
+            raise Invalid("system browser contract")
+        if (
+            browser["architecture"] not in {"aarch64", "x86_64"}
+            or browser["launcherExecutableRelationship"] not in {"same-file", "distinct-files"}
+            or browser["mode"] != "0755"
+            or not SHA256.fullmatch(browser["launcherSha256"])
+            or not SHA256.fullmatch(browser["executableSha256"])
+            or any(
+                not Path(browser[key]).is_absolute()
+                for key in (
+                    "launcherPath",
+                    "launcherRealpath",
+                    "executablePath",
+                    "executableRealpath",
+                )
+            )
+        ):
+            raise Invalid("system browser contract")
     return value
 
 
@@ -118,7 +162,8 @@ def discover_playwright_browser(runner: Path) -> Path:
             "-e",
             "const {chromium}=require('@playwright/test');"
             "const p=chromium.executablePath();"
-            f"if(typeof p!=='string'||Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})process.exit(2);"
+            f"if(typeof p!=='string'||Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})"
+            "process.exit(2);"
             "process.stdout.write(p);",
         ],
         cwd=runner / "frontend",
@@ -151,6 +196,66 @@ def discover_playwright_browser(runner: Path) -> Path:
     return resolved
 
 
+def _rooted(root: Path, absolute: str) -> Path:
+    return root / Path(absolute).relative_to("/")
+
+
+def validate_browser_contract(config: dict, runner: Path, root: Path = Path("/")) -> dict:
+    """Validate and describe the explicitly selected browser without fallback."""
+    contract = config["browserContract"]
+    if contract["name"] == RUNNER_LOCAL:
+        executable = discover_playwright_browser(runner)
+        return {
+            "name": RUNNER_LOCAL,
+            "architecture": platform.machine(),
+            "executablePath": str(executable.relative_to(runner)),
+            "executableSha256": sha256(executable),
+        }
+    if contract["name"] != SYSTEM_CHROMIUM or platform.machine() != contract["architecture"]:
+        raise Invalid("browser architecture or contract")
+    validated = []
+    for prefix in ("launcher", "executable"):
+        configured = contract[f"{prefix}Path"]
+        path = _rooted(root, configured)
+        try:
+            info = path.lstat()
+            resolved = path.resolve(strict=True)
+            owner = pwd.getpwuid(info.st_uid).pw_name
+            group = grp.getgrgid(info.st_gid).gr_name
+        except (OSError, KeyError):
+            raise Invalid("system browser provenance") from None
+        expected_realpath = _rooted(root, contract[f"{prefix}Realpath"])
+        if (
+            path.is_symlink()
+            or not stat.S_ISREG(info.st_mode)
+            or not os.access(path, os.X_OK)
+            or resolved != expected_realpath
+            or sha256(path) != contract[f"{prefix}Sha256"]
+            or owner != contract["owner"]
+            or group != contract["group"]
+            or f"{stat.S_IMODE(info.st_mode):04o}" != contract["mode"]
+        ):
+            raise Invalid("system browser provenance")
+        validated.append(resolved)
+    same = validated[0].samefile(validated[1])
+    if same != (contract["launcherExecutableRelationship"] == "same-file"):
+        raise Invalid("system browser provenance relationship")
+    return {
+        "name": SYSTEM_CHROMIUM,
+        "architecture": contract["architecture"],
+        "launcherPath": contract["launcherPath"],
+        "launcherRealpath": contract["launcherRealpath"],
+        "launcherSha256": contract["launcherSha256"],
+        "executablePath": contract["executablePath"],
+        "executableRealpath": contract["executableRealpath"],
+        "executableSha256": contract["executableSha256"],
+        "owner": contract["owner"],
+        "group": contract["group"],
+        "mode": contract["mode"],
+        "launcherExecutableRelationship": contract["launcherExecutableRelationship"],
+    }
+
+
 def validate_runner(config: dict) -> Path:
     runner = Path(config["runnerRoot"]) / config["runnerRevision"]
     manifest = json.loads((runner / "sugarkube-runner-manifest.json").read_text(encoding="utf-8"))
@@ -162,7 +267,7 @@ def validate_runner(config: dict) -> Path:
         or not files
         or manifest.get("runnerRevision") != config["runnerRevision"]
         or manifest.get("repositoryIdentity") != config["repositoryIdentity"]
-        or not isinstance(browser_relative, str)
+        or manifest.get("browserContract") != config["browserContract"]
     ):
         raise Invalid("wrapper/config coordinate mismatch")
     for relative, expected in files.items():
@@ -175,15 +280,20 @@ def validate_runner(config: dict) -> Path:
             or not SHA256.fullmatch(expected)
         ):
             raise Invalid("critical file manifest")
-    browser_path = Path(browser_relative)
-    if (
-        browser_path.is_absolute()
-        or ".." in browser_path.parts
-        or not browser_path.parts
-        or browser_path.parts[0] != "playwright-browser"
-        or browser_relative not in files
-    ):
-        raise Invalid("Playwright browser manifest")
+    if config["browserContract"]["name"] == RUNNER_LOCAL:
+        if not isinstance(browser_relative, str):
+            raise Invalid("Playwright browser manifest")
+        browser_path = Path(browser_relative)
+        if (
+            browser_path.is_absolute()
+            or ".." in browser_path.parts
+            or not browser_path.parts
+            or browser_path.parts[0] != "playwright-browser"
+            or browser_relative not in files
+        ):
+            raise Invalid("Playwright browser manifest")
+    elif browser_relative is not None:
+        raise Invalid("system browser manifest")
     git_metadata = runner / ".git"
     if git_metadata.is_symlink() or not git_metadata.is_dir():
         raise Invalid("complete Git metadata")
@@ -245,9 +355,10 @@ def validate_runner(config: dict) -> Path:
     entrypoint = runner / "scripts/run-remote-chat-smoke.mjs"
     if not entrypoint.is_file():
         raise Invalid("runner entrypoint")
-    discovered = discover_playwright_browser(runner)
-    if discovered != (runner / browser_relative).resolve(strict=True):
-        raise Invalid("Playwright browser manifest")
+    if config["browserContract"]["name"] == RUNNER_LOCAL:
+        discovered = discover_playwright_browser(runner)
+        if discovered != (runner / browser_relative).resolve(strict=True):
+            raise Invalid("Playwright browser manifest")
     return runner
 
 
@@ -325,6 +436,12 @@ def run(config: dict) -> int:
         if not resolved or not Path(resolved).is_file() or not os.access(resolved, os.X_OK):
             raise Invalid("required executable")
     runner = validate_runner(config)
+    browser = validate_browser_contract(config, runner)
+    if (
+        browser
+        != json.loads((runner / "sugarkube-runner-manifest.json").read_text())["browserProvenance"]
+    ):
+        raise Invalid("runner browser provenance")
     root = Path(config["resultRoot"])
     validate_dir(root, 0, account.pw_gid, 0o710)
     invocation_dir = root / f"uid-{account.pw_uid}-{invocation}"
@@ -367,20 +484,26 @@ def run(config: dict) -> int:
                 config["runnerRevision"],
             ]
             try:
+                # Revalidate immediately before launch so drift cannot produce a current result.
+                browser = validate_browser_contract(config, runner)
+                child_env = {
+                    "HOME": account.pw_dir,
+                    "LANG": "C.UTF-8",
+                    "LC_ALL": "C.UTF-8",
+                    "LOGNAME": account.pw_name,
+                    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                    "USER": account.pw_name,
+                }
+                if browser["name"] == RUNNER_LOCAL:
+                    child_env["PLAYWRIGHT_BROWSERS_PATH"] = str(runner / "playwright-browser")
+                else:
+                    child_env["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"] = browser["executablePath"]
                 completed = subprocess.run(
                     ["runuser", "--user", config["serviceAccount"], "--", *argv],
                     cwd=runner,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    env={
-                        "HOME": account.pw_dir,
-                        "LANG": "C.UTF-8",
-                        "LC_ALL": "C.UTF-8",
-                        "LOGNAME": account.pw_name,
-                        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                        "PLAYWRIGHT_BROWSERS_PATH": str(runner / "playwright-browser"),
-                        "USER": account.pw_name,
-                    },
+                    env=child_env,
                     timeout=config["timeoutSeconds"],
                     check=False,
                 )

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -88,7 +88,6 @@ def validate_runner(snapshot: Path, revision: str) -> None:
     cli = snapshot / "frontend/node_modules/.bin/playwright"
     if not cli.is_file() or not os.access(cli, os.X_OK):
         raise ValueError("frontend Playwright CLI missing")
-    runtime_module().discover_playwright_browser(snapshot)
     for link in (snapshot / "frontend/node_modules").rglob("*"):
         if link.is_symlink() and not link.exists():
             raise ValueError("broken frontend dependency link")
@@ -101,11 +100,22 @@ def materialize(
     output: Path,
     pnpm: str,
     pnpm_version: str,
-    browser_bundle: Path,
+    browser_bundle: Path | None,
+    browser_contract: dict,
+    browser_source_root: Path,
 ) -> None:
     verify_source(source, revision, identity)
-    if output.exists() or not browser_bundle.is_dir():
-        raise ValueError("output exists or browser bundle is invalid")
+    if output.exists():
+        raise ValueError("output exists")
+    runtime = runtime_module()
+    if browser_contract["name"] == runtime.RUNNER_LOCAL:
+        if browser_bundle is None or not browser_bundle.is_dir():
+            raise ValueError("browser bundle is invalid")
+    elif browser_contract["name"] == runtime.SYSTEM_CHROMIUM:
+        if browser_bundle is not None:
+            raise ValueError("system browser contract forbids a browser bundle")
+    else:
+        raise ValueError("unsupported browser contract")
     if command(pnpm, "--version") != pnpm_version:
         raise ValueError("pnpm version mismatch")
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -125,20 +135,35 @@ def materialize(
             [pnpm, "install", "--frozen-lockfile", "--offline"],
             cwd=staging,
             check=True,
-            env={**os.environ, "PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")},
+            env={
+                **os.environ,
+                "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+                **(
+                    {"PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")}
+                    if browser_contract["name"] == runtime.RUNNER_LOCAL
+                    else {}
+                ),
+            },
         )
-        shutil.copytree(browser_bundle, staging / "playwright-browser")
+        if browser_bundle is not None:
+            shutil.copytree(browser_bundle, staging / "playwright-browser")
         validate_runner(staging, revision)
-        browser = runtime_module().discover_playwright_browser(staging)
-        browser_relative = str(browser.relative_to(staging))
+        browser_provenance = runtime.validate_browser_contract(
+            {"browserContract": browser_contract}, staging, browser_source_root
+        )
         files = {relative: sha(staging / relative) for relative in CRITICAL}
-        files[browser_relative] = sha(browser)
+        browser_relative = None
+        if browser_contract["name"] == runtime.RUNNER_LOCAL:
+            browser_relative = browser_provenance["executablePath"]
+            files[browser_relative] = sha(staging / browser_relative)
         manifest = {
             "schemaVersion": 1,
             "runnerRevision": revision,
             "repositoryIdentity": identity.rstrip("/"),
             "pnpmVersion": pnpm_version,
             "playwrightBrowserExecutable": browser_relative,
+            "browserContract": browser_contract,
+            "browserProvenance": browser_provenance,
             "files": files,
         }
         (staging / "sugarkube-runner-manifest.json").write_text(
@@ -225,11 +250,15 @@ def load_snapshot_config(staged: Path, snapshot: Path) -> dict:
     return config
 
 
-def validate_snapshot(staged: Path, snapshot: Path) -> str:
+def validate_snapshot(staged: Path, snapshot: Path, root: Path = Path("/")) -> str:
     """Apply the runtime's complete runner contract to an installation input."""
     runtime = runtime_module()
     config = load_snapshot_config(staged, snapshot)
-    runtime.validate_runner(config)
+    runner = runtime.validate_runner(config)
+    provenance = runtime.validate_browser_contract(config, runner, root)
+    manifest = json.loads((runner / "sugarkube-runner-manifest.json").read_text())
+    if provenance != manifest.get("browserProvenance"):
+        raise ValueError("runner browser provenance mismatch")
     return config["runnerRevision"]
 
 
@@ -244,28 +273,26 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
     revision = config["runnerRevision"]
     parent = rooted(root, config["runnerRoot"])
     destination = parent / revision
-    rooted_config = dict(config, runnerRoot=str(parent))
     if destination.exists() or destination.is_symlink():
         if destination.is_symlink() or not destination.is_dir():
             raise ValueError("runner revision destination is invalid")
-        runtime.validate_runner(rooted_config)
         manifest = "sugarkube-runner-manifest.json"
         if (snapshot / manifest).read_bytes() != (destination / manifest).read_bytes():
             raise ValueError("existing runner manifest does not match snapshot")
+        validate_snapshot(staged, destination, root)
         return destination, False
     parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(tempfile.mkdtemp(prefix=f".{revision}.", dir=parent))
     temporary.rmdir()
     try:
         shutil.copytree(snapshot, temporary, symlinks=True)
-        copied_config = dict(rooted_config, runnerRoot=str(temporary.parent))
         # Validation expects the immutable revision basename, so validate through
         # a private exact-name parent before the atomic destination rename.
         validation_parent = Path(tempfile.mkdtemp(prefix=".validate.", dir=parent))
         validation_runner = validation_parent / revision
         os.replace(temporary, validation_runner)
         try:
-            runtime.validate_runner(dict(copied_config, runnerRoot=str(validation_parent)))
+            validate_snapshot(staged, validation_runner, root)
             os.replace(validation_runner, destination)
         finally:
             shutil.rmtree(validation_parent, ignore_errors=True)
@@ -278,7 +305,7 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
 def apply_installation(staged: Path, snapshot: Path, root: Path, asset_revision: str) -> None:
     """Install a fully validated runner and roll it back on later asset failure."""
     validate(staged)
-    validate_snapshot(staged, snapshot)
+    validate_snapshot(staged, snapshot, root)
     retained = root / "var/lib/sugarkube/dspace-chat-installations" / asset_revision
     if retained.exists():
         raise ValueError("exact retained revision already exists")
@@ -337,7 +364,7 @@ def status(root: Path) -> int:
         or not runner_manifest["pnpmVersion"]
     ):
         raise ValueError("installed runner pnpm provenance is invalid")
-    if (
+    if config["browserContract"]["name"] == runtime.RUNNER_LOCAL and (
         not isinstance(runner_manifest.get("playwrightBrowserExecutable"), str)
         or not runner_manifest["playwrightBrowserExecutable"]
     ):
@@ -347,6 +374,9 @@ def status(root: Path) -> int:
     runner = runtime.validate_runner(rooted_config)
     if runner != expected_runner:
         raise ValueError("installed runner validation returned an unexpected revision")
+    provenance = runtime.validate_browser_contract(rooted_config, runner, root)
+    if provenance != runner_manifest.get("browserProvenance"):
+        raise ValueError("installed runner browser provenance is invalid")
 
     print(f"assetRevision={revision}")
     for target_name, path in live_paths.items():
@@ -367,7 +397,15 @@ def status(root: Path) -> int:
     ):
         print(f"{key}={config[key]}")
     print(f"pnpmVersion={runner_manifest['pnpmVersion']}")
-    print(f"playwrightBrowserExecutable={runner_manifest['playwrightBrowserExecutable']}")
+    playwright_executable = runner_manifest.get("playwrightBrowserExecutable") or "none"
+    print(f"playwrightBrowserExecutable={playwright_executable}")
+    print(f"browserContract={config['browserContract']['name']}")
+    print(f"browserArchitecture={provenance['architecture']}")
+    print(f"browserExecutablePath={provenance['executablePath']}")
+    print(f"browserExecutableSha256={provenance['executableSha256']}")
+    if provenance["name"] == runtime.SYSTEM_CHROMIUM:
+        print(f"browserLauncherPath={provenance['launcherPath']}")
+        print(f"browserLauncherSha256={provenance['launcherSha256']}")
     if root.resolve() != Path("/"):
         print("activation=not-queried")
         return 0
@@ -468,15 +506,20 @@ def main() -> int:
     parser.add_argument("--pnpm")
     parser.add_argument("--pnpm-version")
     parser.add_argument("--browser-bundle", type=Path)
+    parser.add_argument("--browser-source-root", type=Path)
     parser.add_argument("--runner-snapshot", type=Path)
     args = parser.parse_args()
     if args.operation == "status":
         return status(args.root)
     if args.operation == "materialize":
-        if not all((args.source, args.output, args.pnpm, args.pnpm_version, args.browser_bundle)):
-            parser.error(
-                "materialize requires source, output, pnpm, pnpm-version, and browser-bundle"
-            )
+        if not all((args.source, args.output, args.pnpm, args.pnpm_version)):
+            parser.error("materialize requires source, output, pnpm, and pnpm-version")
+        runtime = runtime_module()
+        browser_contract = runtime.load_config(ROOT / "config/dspace-chat-synthetic.json")[
+            "browserContract"
+        ]
+        if browser_contract["name"] == runtime.SYSTEM_CHROMIUM and args.browser_source_root is None:
+            parser.error("system browser materialize requires --browser-source-root")
         materialize(
             args.source.resolve(),
             args.revision,
@@ -484,7 +527,9 @@ def main() -> int:
             args.output.resolve(),
             args.pnpm,
             args.pnpm_version,
-            args.browser_bundle.resolve(),
+            args.browser_bundle.resolve() if args.browser_bundle else None,
+            browser_contract,
+            args.browser_source_root.resolve() if args.browser_source_root else Path("/"),
         )
         return 0
     if args.operation == "rollback":
@@ -504,7 +549,7 @@ def main() -> int:
         if args.runner_snapshot is None:
             parser.error(f"{args.operation} requires --runner-snapshot")
         snapshot = args.runner_snapshot.absolute()
-        validate_snapshot(staged, snapshot)
+        validate_snapshot(staged, snapshot, args.root)
         if args.operation == "apply":
             asset_revision = hashlib.sha256((staged / "manifest.json").read_bytes()).hexdigest()
             apply_installation(staged, snapshot, args.root, asset_revision)

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -114,6 +114,12 @@ def materialize(
     elif browser_contract["name"] == runtime.SYSTEM_CHROMIUM:
         if browser_bundle is not None:
             raise ValueError("system browser contract forbids a browser bundle")
+        # Validate host-owned inputs before creating the staging directory or
+        # running dependency installation. Runner-local discovery intentionally
+        # remains below, after its bundle has been copied into the snapshot.
+        browser_provenance = runtime.validate_browser_contract(
+            {"browserContract": browser_contract}, output, browser_source_root
+        )
     else:
         raise ValueError("unsupported browser contract")
     if command(pnpm, "--version") != pnpm_version:
@@ -148,9 +154,10 @@ def materialize(
         if browser_bundle is not None:
             shutil.copytree(browser_bundle, staging / "playwright-browser")
         validate_runner(staging, revision)
-        browser_provenance = runtime.validate_browser_contract(
-            {"browserContract": browser_contract}, staging, browser_source_root
-        )
+        if browser_contract["name"] == runtime.RUNNER_LOCAL:
+            browser_provenance = runtime.validate_browser_contract(
+                {"browserContract": browser_contract}, staging, browser_source_root
+            )
         files = {relative: sha(staging / relative) for relative in CRITICAL}
         browser_relative = None
         if browser_contract["name"] == runtime.RUNNER_LOCAL:
@@ -509,6 +516,7 @@ def main() -> int:
     parser.add_argument("--browser-source-root", type=Path)
     parser.add_argument("--runner-snapshot", type=Path)
     args = parser.parse_args()
+    args.root = args.root.resolve()
     if args.operation == "status":
         return status(args.root)
     if args.operation == "materialize":
@@ -542,6 +550,12 @@ def main() -> int:
             return 0
         activate(retained, args.root, args.revision)
         return 0
+    # The system contract is independent of the copied runner. Check it before
+    # rendering assets (and therefore before any installation-side output).
+    runtime = runtime_module()
+    configured = runtime.load_config(ROOT / "config/dspace-chat-synthetic.json")
+    if configured["browserContract"]["name"] == runtime.SYSTEM_CHROMIUM:
+        runtime.validate_browser_contract(configured, Path("."), args.root)
     with tempfile.TemporaryDirectory() as temporary:
         staged = Path(temporary)
         render(staged)

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -104,10 +104,11 @@ def materialize(
     browser_contract: dict,
     browser_source_root: Path,
 ) -> None:
+    runtime = runtime_module()
+    browser_source_root = runtime.normalize_root(browser_source_root)
     verify_source(source, revision, identity)
     if output.exists():
         raise ValueError("output exists")
-    runtime = runtime_module()
     if browser_contract["name"] == runtime.RUNNER_LOCAL:
         if browser_bundle is None or not browser_bundle.is_dir():
             raise ValueError("browser bundle is invalid")
@@ -270,7 +271,10 @@ def validate_snapshot(staged: Path, snapshot: Path, root: Path = Path("/")) -> s
 
 
 def rooted(root: Path, absolute: str) -> Path:
-    return root / Path(absolute).relative_to("/")
+    coordinate = Path(absolute)
+    if not coordinate.is_absolute() or ".." in coordinate.parts:
+        raise ValueError("rooted coordinate must be absolute and confined")
+    return root / coordinate.relative_to("/")
 
 
 def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool]:
@@ -327,6 +331,7 @@ def apply_installation(staged: Path, snapshot: Path, root: Path, asset_revision:
 
 
 def status(root: Path) -> int:
+    root = runtime_module().normalize_root(root)
     installations = root / "var/lib/sugarkube/dspace-chat-installations"
     current = installations / "current"
     live_paths = {target: root / target for target in ASSETS}
@@ -516,13 +521,13 @@ def main() -> int:
     parser.add_argument("--browser-source-root", type=Path)
     parser.add_argument("--runner-snapshot", type=Path)
     args = parser.parse_args()
-    args.root = args.root.resolve()
+    runtime = runtime_module()
+    args.root = runtime.normalize_root(args.root)
     if args.operation == "status":
         return status(args.root)
     if args.operation == "materialize":
         if not all((args.source, args.output, args.pnpm, args.pnpm_version)):
             parser.error("materialize requires source, output, pnpm, and pnpm-version")
-        runtime = runtime_module()
         browser_contract = runtime.load_config(ROOT / "config/dspace-chat-synthetic.json")[
             "browserContract"
         ]
@@ -537,7 +542,7 @@ def main() -> int:
             args.pnpm_version,
             args.browser_bundle.resolve() if args.browser_bundle else None,
             browser_contract,
-            args.browser_source_root.resolve() if args.browser_source_root else Path("/"),
+            args.browser_source_root if args.browser_source_root else Path("/"),
         )
         return 0
     if args.operation == "rollback":
@@ -552,7 +557,6 @@ def main() -> int:
         return 0
     # The system contract is independent of the copied runner. Check it before
     # rendering assets (and therefore before any installation-side output).
-    runtime = runtime_module()
     configured = runtime.load_config(ROOT / "config/dspace-chat-synthetic.json")
     if configured["browserContract"]["name"] == runtime.SYSTEM_CHROMIUM:
         runtime.validate_browser_contract(configured, Path("."), args.root)

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import platform
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -56,7 +57,7 @@ def test_configuration_selects_contracts_and_exact_legacy_coordinate(tmp_path: P
     value = config(tmp_path)
     path.write_text(json.dumps(value))
     assert runtime.load_config(path)["providerConfigContract"] == "legacy-no-default-provider-v1"
-    for key in ("identityContract", "providerConfigContract"):
+    for key in ("identityContract", "providerConfigContract", "browserContract"):
         broken = copy.deepcopy(value)
         broken.pop(key)
         path.write_text(json.dumps(broken))
@@ -124,6 +125,92 @@ def test_configuration_rejects_remaining_invalid_contract_values(
         runtime.load_config(path)
 
 
+def system_browser_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[dict, Path]:
+    root = tmp_path / "target"
+    launcher = root / "usr/bin/chromium"
+    executable = root / "usr/lib/chromium/chromium"
+    for path, contents in ((launcher, b"launcher"), (executable, b"executable")):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+        path.chmod(0o755)
+    info = launcher.stat()
+    contract = {
+        "name": runtime.SYSTEM_CHROMIUM,
+        "architecture": "aarch64",
+        "launcherPath": "/usr/bin/chromium",
+        "launcherRealpath": "/usr/bin/chromium",
+        "launcherSha256": runtime.sha256(launcher),
+        "executablePath": "/usr/lib/chromium/chromium",
+        "executableRealpath": "/usr/lib/chromium/chromium",
+        "executableSha256": runtime.sha256(executable),
+        "owner": runtime.pwd.getpwuid(info.st_uid).pw_name,
+        "group": runtime.grp.getgrgid(info.st_gid).gr_name,
+        "mode": "0755",
+        "launcherExecutableRelationship": "distinct-files",
+    }
+    monkeypatch.setattr(runtime.platform, "machine", lambda: "aarch64")
+    return contract, root
+
+
+def test_explicit_system_browser_contract_validates_target_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    value = {"browserContract": contract}
+    provenance = runtime.validate_browser_contract(value, tmp_path / "runner", root)
+    assert provenance["executablePath"] == "/usr/lib/chromium/chromium"
+    assert provenance["executableSha256"] == contract["executableSha256"]
+
+
+@pytest.mark.parametrize(
+    ("fault", "field"),
+    [
+        ("architecture", None),
+        ("launcher-hash", "launcherSha256"),
+        ("executable-hash", "executableSha256"),
+        ("mode", "mode"),
+        ("owner", "owner"),
+        ("group", "group"),
+        ("launcher-realpath", "launcherRealpath"),
+        ("executable-realpath", "executableRealpath"),
+        ("relationship", "launcherExecutableRelationship"),
+    ],
+)
+def test_system_browser_contract_fails_closed_on_provenance_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str, field: str | None
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    if fault == "architecture":
+        monkeypatch.setattr(runtime.platform, "machine", lambda: "x86_64")
+    elif fault in {"launcher-hash", "executable-hash"}:
+        contract[field] = "0" * 64
+    elif fault == "mode":
+        (root / "usr/bin/chromium").chmod(0o700)
+    elif fault in {"owner", "group"}:
+        contract[field] = "definitely-absent"
+    elif fault.endswith("realpath"):
+        contract[field] = "/unexpected"
+    else:
+        contract[field] = "same-file"
+    with pytest.raises(runtime.Invalid):
+        runtime.validate_browser_contract({"browserContract": contract}, tmp_path / "runner", root)
+
+
+def test_system_browser_contract_rejects_missing_nonregular_and_symlinked_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    launcher = root / "usr/bin/chromium"
+    launcher.unlink()
+    launcher.mkdir()
+    with pytest.raises(runtime.Invalid):
+        runtime.validate_browser_contract({"browserContract": contract}, tmp_path / "runner", root)
+    launcher.rmdir()
+    launcher.symlink_to(root / "usr/lib/chromium/chromium")
+    with pytest.raises(runtime.Invalid):
+        runtime.validate_browser_contract({"browserContract": contract}, tmp_path / "runner", root)
+
+
 def test_runtime_main_reports_success_and_bounded_preflight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
@@ -140,6 +227,7 @@ def test_runtime_main_reports_success_and_bounded_preflight(
 
 def runtime_runner(tmp_path: Path) -> tuple[dict, Path]:
     value = config(tmp_path)
+    value["browserContract"] = {"name": runtime.RUNNER_LOCAL}
     runner = Path(value["runnerRoot"]) / "fixture"
     runner.mkdir(parents=True)
     git("init", cwd=runner)
@@ -179,8 +267,15 @@ def runtime_runner(tmp_path: Path) -> tuple[dict, Path]:
         "schemaVersion": 1,
         "runnerRevision": revision,
         "repositoryIdentity": runtime.APPROVED_REPOSITORY_IDENTITY,
+        "browserContract": value["browserContract"],
         "playwrightBrowserExecutable": "playwright-browser/browser-executable",
         "files": {relative: runtime.sha256(destination / relative) for relative in required},
+    }
+    manifest["browserProvenance"] = {
+        "name": runtime.RUNNER_LOCAL,
+        "architecture": platform.machine(),
+        "executablePath": "playwright-browser/browser-executable",
+        "executableSha256": runtime.sha256(destination / "playwright-browser/browser-executable"),
     }
     (destination / "sugarkube-runner-manifest.json").write_text(json.dumps(manifest))
     return value, destination
@@ -315,6 +410,23 @@ def prepare_runtime_run(
     monkeypatch.setattr(runtime.pwd, "getpwnam", lambda _name: account)
     monkeypatch.setattr(runtime.grp, "getgrnam", lambda _name: SimpleNamespace(gr_gid=os.getgid()))
     monkeypatch.setattr(runtime, "validate_runner", lambda _config: runner)
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda *_args, **_kwargs: {
+            "name": runtime.RUNNER_LOCAL,
+            "architecture": platform.machine(),
+            "executablePath": "playwright-browser/browser-executable",
+            "executableSha256": "0" * 64,
+        },
+    )
+    (runner / "sugarkube-runner-manifest.json").write_text(
+        json.dumps(
+            {
+                "browserProvenance": runtime.validate_browser_contract(value, runner),
+            }
+        )
+    )
     monkeypatch.setattr(runtime, "validate_dir", lambda *_args: None)
     monkeypatch.setattr(runtime.os, "chown", lambda *_args: None)
     calls: list[dict] = []
@@ -383,6 +495,48 @@ def test_runtime_run_uses_minimal_environment_and_cleans_direct_entries(
     assert node_argv[provider_index + 1] == value["provider"] == "token-place"
     assert not (Path(value["resultRoot"]) / f"uid-{os.getuid()}-{'a' * 32}").exists()
     assert (sibling / "keep").read_text() == "untouched"
+
+
+def test_runtime_plumbs_exact_system_executable_and_not_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, _metric, _sibling, calls = prepare_runtime_run(tmp_path, monkeypatch)
+    provenance = {
+        "name": runtime.SYSTEM_CHROMIUM,
+        "architecture": "aarch64",
+        "executablePath": "/usr/lib/chromium/chromium",
+        "executableSha256": "f" * 64,
+    }
+    runner = tmp_path / "runner"
+    (runner / "sugarkube-runner-manifest.json").write_text(
+        json.dumps({"browserProvenance": provenance})
+    )
+    monkeypatch.setattr(runtime, "validate_browser_contract", lambda *_a, **_k: provenance)
+
+    assert runtime.run(value) == 0
+    child = next(call for call in calls if call["argv"][0] == "runuser")
+    assert child["env"]["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"] == provenance["executablePath"]
+    assert "PLAYWRIGHT_BROWSERS_PATH" not in child["env"]
+
+
+def test_runtime_browser_drift_blocks_playwright_and_preserves_metric(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, metric, _sibling, calls = prepare_runtime_run(tmp_path, monkeypatch)
+    provenance = runtime.validate_browser_contract(value, tmp_path / "runner")
+    validations = 0
+
+    def drift(*_args, **_kwargs):
+        nonlocal validations
+        validations += 1
+        if validations == 1:
+            return provenance
+        raise runtime.Invalid("system browser provenance")
+
+    monkeypatch.setattr(runtime, "validate_browser_contract", drift)
+    assert runtime.run(value) == 1
+    assert metric.read_bytes() == b"previous metric\n"
+    assert not any(call["argv"][0] == "runuser" for call in calls)
 
 
 @pytest.mark.parametrize(
@@ -548,6 +702,8 @@ def test_materialize_discovers_browser_and_is_source_independent(
         str(pnpm),
         "9.1.0",
         browser_bundle,
+        {"name": runtime.RUNNER_LOCAL},
+        Path("/"),
     )
     manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
     relative = manifest["playwrightBrowserExecutable"]
@@ -558,6 +714,7 @@ def test_materialize_discovers_browser_and_is_source_independent(
     __import__("shutil").rmtree(browser_bundle)
     value = config(tmp_path)
     value.update(runnerRoot=str(output.parent), runnerRevision=revision)
+    value["browserContract"] = {"name": runtime.RUNNER_LOCAL}
     assert runtime.validate_runner(value) == output
 
 
@@ -571,9 +728,22 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
     validations = []
 
     class CanonicalRuntime:
+        RUNNER_LOCAL = runtime.RUNNER_LOCAL
+        SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
+
         @staticmethod
         def discover_playwright_browser(runner: Path) -> Path:
             return runner / discovered
+
+        @staticmethod
+        def validate_browser_contract(_config: dict, runner: Path, _root: Path) -> dict:
+            browser = runner / discovered
+            return {
+                "name": runtime.RUNNER_LOCAL,
+                "architecture": platform.machine(),
+                "executablePath": str(discovered),
+                "executableSha256": runtime.sha256(browser),
+            }
 
     def validate_snapshot(snapshot: Path, expected_revision: str) -> None:
         validations.append((snapshot, expected_revision))
@@ -590,12 +760,61 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
         str(pnpm),
         "9.1.0",
         browser_bundle,
+        {"name": runtime.RUNNER_LOCAL},
+        Path("/"),
     )
 
     manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
     assert manifest["playwrightBrowserExecutable"] == str(discovered)
     assert manifest["files"][str(discovered)] == runtime.sha256(output / discovered)
     assert validations[-1] == (output, revision)
+
+
+def test_system_materialize_skips_browser_bundle_and_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, revision, _browser_bundle, pnpm = materialization_fixture(tmp_path)
+    contract, browser_root = system_browser_fixture(tmp_path, monkeypatch)
+    output = tmp_path / "output" / revision
+    environments = []
+    real_run = installer.subprocess.run
+
+    def record_run(argv, **kwargs):
+        if argv[0] == str(pnpm) and argv[1] == "install":
+            environments.append(kwargs["env"])
+        return real_run(argv, **kwargs)
+
+    monkeypatch.setattr(installer.subprocess, "run", record_run)
+    installer.materialize(
+        source,
+        revision,
+        runtime.APPROVED_REPOSITORY_IDENTITY,
+        output,
+        str(pnpm),
+        "9.1.0",
+        None,
+        contract,
+        browser_root,
+    )
+    manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
+    assert manifest["playwrightBrowserExecutable"] is None
+    assert manifest["browserContract"] == contract
+    assert not (output / "playwright-browser").exists()
+    assert environments[0]["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] == "1"
+    assert "PLAYWRIGHT_BROWSERS_PATH" not in environments[0]
+
+    with pytest.raises(ValueError, match="forbids"):
+        installer.materialize(
+            source,
+            revision,
+            runtime.APPROVED_REPOSITORY_IDENTITY,
+            tmp_path / "another-output",
+            str(pnpm),
+            "9.1.0",
+            tmp_path,
+            contract,
+            browser_root,
+        )
 
 
 def test_materialize_cli_dispatches_complete_coordinates(
@@ -622,6 +841,8 @@ def test_materialize_cli_dispatches_complete_coordinates(
             "9.0.0",
             "--browser-bundle",
             str(browser),
+            "--browser-source-root",
+            "/",
         ],
     )
 
@@ -635,6 +856,8 @@ def test_materialize_cli_dispatches_complete_coordinates(
             "/fixture/pnpm",
             "9.0.0",
             browser.resolve(),
+            json.loads(CONFIG.read_text())["browserContract"],
+            Path("/").resolve(),
         )
     ]
 
@@ -899,6 +1122,9 @@ def test_installer_dry_run_status_apply_and_exact_rollback(tmp_path: Path, capsy
 
 
 class StatusRuntime:
+    RUNNER_LOCAL = runtime.RUNNER_LOCAL
+    SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
+
     @staticmethod
     def load_config(path: Path) -> dict:
         return json.loads(path.read_text())
@@ -909,6 +1135,12 @@ class StatusRuntime:
         if (runner / "invalid").exists():
             raise ValueError("runner validation failed")
         return runner
+
+    @staticmethod
+    def validate_browser_contract(_value: dict, runner: Path, _root: Path) -> dict:
+        return json.loads((runner / "sugarkube-runner-manifest.json").read_text())[
+            "browserProvenance"
+        ]
 
 
 def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
@@ -924,7 +1156,25 @@ def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
         json.dumps(
             {
                 "pnpmVersion": "9.0.0",
-                "playwrightBrowserExecutable": "playwright-browser/chromium/chrome",
+                "playwrightBrowserExecutable": None,
+                "browserProvenance": {
+                    "name": runtime.SYSTEM_CHROMIUM,
+                    "architecture": "aarch64",
+                    "executablePath": "/usr/lib/chromium/chromium",
+                    "executableSha256": (
+                        "f8cf8a41a3406375dc9b9af5ce25a3fe" "ceca3d4e9e72d18671db07cdee7a75a6"
+                    ),
+                    "launcherPath": "/usr/bin/chromium",
+                    "launcherRealpath": "/usr/bin/chromium",
+                    "launcherSha256": (
+                        "be1d239c2a7a9298c202d506e589d230" "56064bd52b82fa3d3cf72a0a2de3337c"
+                    ),
+                    "executableRealpath": "/usr/lib/chromium/chromium",
+                    "owner": "root",
+                    "group": "root",
+                    "mode": "0755",
+                    "launcherExecutableRelationship": "distinct-files",
+                },
             }
         )
     )
@@ -978,7 +1228,7 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
     ):
         assert f"{key}={config_value[key]}" in output
     assert "pnpmVersion=9.0.0" in output
-    assert "playwrightBrowserExecutable=playwright-browser/chromium/chrome" in output
+    assert "playwrightBrowserExecutable=none" in output
     assert "runnerValidation=passed" in output
     assert "activation=not-queried" in output
     assert tree_bytes(root) == before
@@ -1090,11 +1340,16 @@ def runner_snapshot_fixture(tmp_path: Path) -> tuple[Path, str]:
     snapshot.mkdir(parents=True)
     (snapshot / ".git").mkdir()
     (snapshot / "dependency.ok").write_text("complete\n")
-    (snapshot / "sugarkube-runner-manifest.json").write_text("manifest\n")
+    (snapshot / "sugarkube-runner-manifest.json").write_text(
+        json.dumps({"browserProvenance": {"name": runtime.SYSTEM_CHROMIUM}})
+    )
     return snapshot, revision
 
 
 class FakeSnapshotRuntime:
+    RUNNER_LOCAL = runtime.RUNNER_LOCAL
+    SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
+
     def __init__(self, fail_copy: bool = False):
         self.fail_copy = fail_copy
         self.validated = []
@@ -1117,6 +1372,10 @@ class FakeSnapshotRuntime:
         if self.fail_copy and ".validate." in str(runner):
             raise ValueError("copied runner validation failed")
         return runner
+
+    @staticmethod
+    def validate_browser_contract(_config: dict, _runner: Path, _root: Path) -> dict:
+        return {"name": runtime.SYSTEM_CHROMIUM}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -125,6 +125,30 @@ def test_configuration_rejects_remaining_invalid_contract_values(
         runtime.load_config(path)
 
 
+@pytest.mark.parametrize(
+    "browser_contract",
+    [
+        None,
+        {"name": runtime.RUNNER_LOCAL, "unexpected": "field"},
+        {"name": runtime.SYSTEM_CHROMIUM},
+        dict(
+            json.loads(CONFIG.read_text())["browserContract"],
+            architecture="unsupported",
+        ),
+    ],
+)
+def test_configuration_rejects_malformed_browser_contracts(
+    tmp_path: Path, browser_contract: object
+) -> None:
+    path = tmp_path / "config.json"
+    value = config(tmp_path)
+    value["browserContract"] = browser_contract
+    path.write_text(json.dumps(value))
+
+    with pytest.raises(runtime.Invalid, match="browser contract"):
+        runtime.load_config(path)
+
+
 def system_browser_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[dict, Path]:
     root = tmp_path / "target"
     launcher = root / "usr/bin/chromium"
@@ -176,6 +200,36 @@ def test_system_browser_contract_resolves_relative_root_once(
     )
 
     assert relative == absolute
+
+
+def test_browser_contract_rejects_missing_source_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract, _root = system_browser_fixture(tmp_path, monkeypatch)
+
+    with pytest.raises(runtime.Invalid, match="source root"):
+        runtime.validate_browser_contract(
+            {"browserContract": contract}, tmp_path / "runner", tmp_path / "missing"
+        )
+
+
+def test_runner_local_browser_contract_reports_discovered_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = tmp_path / "runner"
+    executable = runner / "playwright-browser/chromium/chrome"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"browser")
+    monkeypatch.setattr(runtime, "discover_playwright_browser", lambda _runner: executable)
+
+    assert runtime.validate_browser_contract(
+        {"browserContract": {"name": runtime.RUNNER_LOCAL}}, runner
+    ) == {
+        "name": runtime.RUNNER_LOCAL,
+        "architecture": platform.machine(),
+        "executablePath": "playwright-browser/chromium/chrome",
+        "executableSha256": runtime.sha256(executable),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -162,6 +162,90 @@ def test_explicit_system_browser_contract_validates_target_root(
     assert provenance["executableSha256"] == contract["executableSha256"]
 
 
+def test_system_browser_contract_resolves_relative_root_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    relative = runtime.validate_browser_contract(
+        {"browserContract": contract}, tmp_path / "runner", Path(root.name)
+    )
+    absolute = runtime.validate_browser_contract(
+        {"browserContract": contract}, tmp_path / "runner", root.resolve()
+    )
+
+    assert relative == absolute
+
+
+@pytest.mark.parametrize(
+    ("prefix", "fault"),
+    [
+        ("launcher", "missing-path"),
+        ("launcher", "wrong-path"),
+        ("executable", "missing-path"),
+        ("executable", "wrong-path"),
+        ("executable", "directory"),
+        ("executable", "symlink"),
+        ("executable", "non-executable"),
+    ],
+)
+def test_system_browser_contract_rejects_exact_path_and_executable_faults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    prefix: str,
+    fault: str,
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    path = root / contract[f"{prefix}Path"].removeprefix("/")
+    if fault == "missing-path":
+        contract[f"{prefix}Path"] = f"/missing/{prefix}"
+    elif fault == "wrong-path":
+        wrong = root / f"wrong/{prefix}"
+        wrong.parent.mkdir()
+        wrong.write_bytes(path.read_bytes())
+        wrong.chmod(0o755)
+        contract[f"{prefix}Path"] = f"/wrong/{prefix}"
+    elif fault == "directory":
+        path.unlink()
+        path.mkdir()
+    elif fault == "symlink":
+        path.unlink()
+        path.symlink_to(root / "usr/bin/chromium")
+    else:
+        path.chmod(0o644)
+        contract["mode"] = "0644"  # isolate the executable-bit requirement
+
+    with pytest.raises(runtime.Invalid, match="system browser provenance"):
+        runtime.validate_browser_contract({"browserContract": contract}, tmp_path / "runner", root)
+
+
+def test_browser_contracts_never_fallback_to_the_other_direction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract, root = system_browser_fixture(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        runtime,
+        "discover_playwright_browser",
+        lambda _runner: pytest.fail("system contract fell back to runner-local discovery"),
+    )
+    runtime.validate_browser_contract(
+        {"browserContract": contract}, tmp_path / "missing-runner", root
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "discover_playwright_browser",
+        lambda _runner: (_ for _ in ()).throw(runtime.Invalid("runner bundle missing")),
+    )
+    with pytest.raises(runtime.Invalid, match="runner bundle missing"):
+        runtime.validate_browser_contract(
+            {"browserContract": {"name": runtime.RUNNER_LOCAL}},
+            tmp_path / "missing-runner",
+            root,
+        )
+
+
 @pytest.mark.parametrize(
     ("fault", "field"),
     [
@@ -1230,6 +1314,20 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
     assert "pnpmVersion=9.0.0" in output
     assert "playwrightBrowserExecutable=none" in output
     assert "runnerValidation=passed" in output
+    provenance = json.loads((runner / "sugarkube-runner-manifest.json").read_text())[
+        "browserProvenance"
+    ]
+    for key in (
+        "architecture",
+        "executablePath",
+        "executableSha256",
+        "launcherPath",
+        "launcherSha256",
+    ):
+        assert str(provenance[key]) in output
+    assert "browserContract=system-chromium-v1" in output
+    assert "credential" not in output.lower()
+    assert "rawResult" not in output
     assert "activation=not-queried" in output
     assert tree_bytes(root) == before
 
@@ -1332,6 +1430,37 @@ def test_failed_installer_preflight_leaves_installation_unchanged(tmp_path: Path
 def run_installer_main(monkeypatch: pytest.MonkeyPatch, *args: str) -> int:
     monkeypatch.setattr(sys, "argv", ["install_dspace_chat_synthetic.py", *args])
     return installer.main()
+
+
+def test_system_browser_preflight_precedes_all_installer_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class RejectingRuntime:
+        SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
+
+        @staticmethod
+        def load_config(_path: Path) -> dict:
+            return {"browserContract": {"name": runtime.SYSTEM_CHROMIUM}}
+
+        @staticmethod
+        def validate_browser_contract(*_args) -> dict:
+            raise runtime.Invalid("browser preflight")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(installer, "runtime_module", lambda: RejectingRuntime())
+    monkeypatch.setattr(installer, "render", lambda _path: pytest.fail("render mutated output"))
+
+    with pytest.raises(runtime.Invalid, match="browser preflight"):
+        run_installer_main(
+            monkeypatch,
+            "apply",
+            "--root",
+            "rehearsal-root",
+            "--runner-snapshot",
+            "snapshot",
+        )
+
+    assert not (tmp_path / "rehearsal-root").exists()
 
 
 def runner_snapshot_fixture(tmp_path: Path) -> tuple[Path, str]:

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -202,6 +202,29 @@ def test_system_browser_contract_resolves_relative_root_once(
     assert relative == absolute
 
 
+def test_root_normalization_rejects_symlink_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+
+    monkeypatch.chdir(tmp_path)
+    assert runtime.normalize_root(Path(real.name)) == real
+    assert runtime.normalize_root(real) == real
+    with pytest.raises(runtime.Invalid, match="source root"):
+        runtime.normalize_root(alias)
+
+
+@pytest.mark.parametrize("coordinate", ["relative/path", "/usr/../outside"])
+def test_rooted_coordinates_reject_relative_and_traversal(coordinate: str) -> None:
+    with pytest.raises(runtime.Invalid, match="rooted coordinate"):
+        runtime._rooted(Path("/private"), coordinate)
+    with pytest.raises(ValueError, match="rooted coordinate"):
+        installer.rooted(Path("/private"), coordinate)
+
+
 def test_browser_contract_rejects_missing_source_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -869,6 +892,8 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
         RUNNER_LOCAL = runtime.RUNNER_LOCAL
         SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
 
+        normalize_root = staticmethod(runtime.normalize_root)
+
         @staticmethod
         def discover_playwright_browser(runner: Path) -> Path:
             return runner / discovered
@@ -1263,6 +1288,8 @@ class StatusRuntime:
     RUNNER_LOCAL = runtime.RUNNER_LOCAL
     SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
 
+    normalize_root = staticmethod(runtime.normalize_root)
+
     @staticmethod
     def load_config(path: Path) -> dict:
         return json.loads(path.read_text())
@@ -1492,6 +1519,8 @@ def test_system_browser_preflight_precedes_all_installer_mutation(
     class RejectingRuntime:
         SYSTEM_CHROMIUM = runtime.SYSTEM_CHROMIUM
 
+        normalize_root = staticmethod(runtime.normalize_root)
+
         @staticmethod
         def load_config(_path: Path) -> dict:
             return {"browserContract": {"name": runtime.SYSTEM_CHROMIUM}}
@@ -1501,6 +1530,7 @@ def test_system_browser_preflight_precedes_all_installer_mutation(
             raise runtime.Invalid("browser preflight")
 
     monkeypatch.chdir(tmp_path)
+    (tmp_path / "rehearsal-root").mkdir()
     monkeypatch.setattr(installer, "runtime_module", lambda: RejectingRuntime())
     monkeypatch.setattr(installer, "render", lambda _path: pytest.fail("render mutated output"))
 
@@ -1514,7 +1544,66 @@ def test_system_browser_preflight_precedes_all_installer_mutation(
             "snapshot",
         )
 
-    assert not (tmp_path / "rehearsal-root").exists()
+    assert not any((tmp_path / "rehearsal-root").iterdir())
+
+
+@pytest.mark.parametrize("operation", ["status", "dry-run", "apply", "rollback"])
+def test_installer_rejects_symlink_root_before_probe_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    monkeypatch.setattr(installer, "status", lambda _root: pytest.fail("status probed"))
+    monkeypatch.setattr(installer, "render", lambda _root: pytest.fail("render mutated"))
+    monkeypatch.setattr(installer, "validate", lambda _root: pytest.fail("rollback probed"))
+
+    arguments = [operation, "--root", str(alias)]
+    if operation in {"dry-run", "apply"}:
+        arguments += ["--runner-snapshot", str(tmp_path / "snapshot")]
+    with pytest.raises(Exception, match="source root"):
+        run_installer_main(monkeypatch, *arguments)
+    assert not any(real.iterdir())
+
+
+def test_materialize_rejects_symlink_browser_root_before_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real = tmp_path / "browser-root"
+    real.mkdir()
+    alias = tmp_path / "browser-alias"
+    alias.symlink_to(real, target_is_directory=True)
+    output = tmp_path / "output"
+    monkeypatch.setattr(
+        installer, "verify_source", lambda *_args: pytest.fail("source validation started")
+    )
+
+    with pytest.raises(Exception, match="source root"):
+        installer.materialize(
+            tmp_path / "source",
+            "0" * 40,
+            "identity",
+            output,
+            "pnpm",
+            "1.0",
+            None,
+            {"name": runtime.SYSTEM_CHROMIUM},
+            alias,
+        )
+    assert not output.exists()
+
+
+def test_explicit_live_root_reaches_status_only_after_mocked_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = []
+    monkeypatch.setattr(runtime, "normalize_root", lambda root: seen.append(root) or Path("/"))
+    monkeypatch.setattr(installer, "runtime_module", lambda: runtime)
+    monkeypatch.setattr(installer, "status", lambda root: seen.append(root) or 0)
+
+    assert run_installer_main(monkeypatch, "status", "--root", "/") == 0
+    assert seen == [Path("/"), Path("/")]
 
 
 def runner_snapshot_fixture(tmp_path: Path) -> tuple[Path, str]:
@@ -1536,6 +1625,8 @@ class FakeSnapshotRuntime:
     def __init__(self, fail_copy: bool = False):
         self.fail_copy = fail_copy
         self.validated = []
+
+    normalize_root = staticmethod(runtime.normalize_root)
 
     @staticmethod
     def load_config(path: Path) -> dict:
@@ -1634,6 +1725,7 @@ def test_apply_installs_runner_only_after_copy_revalidation(
 ) -> None:
     snapshot, revision = runner_snapshot_fixture(tmp_path)
     root = tmp_path / "root"
+    root.mkdir()
     fake = FakeSnapshotRuntime()
     monkeypatch.setattr(installer, "runtime_module", lambda: fake)
 


### PR DESCRIPTION
### Motivation

Playwright’s pinned browser download failed during ARM64 staging-host rehearsal. The durable DSPACE chat synthetic producer from PR #2658 therefore needs an explicit, repository-owned contract for using the OS Chromium installation while preserving its existing runner-local Playwright behavior.

Contract selection remains explicit and fail-closed: there is no `$PATH` search, implicit inference, cross-contract fallback, or acceptance of an unconfigured browser installation.

### Summary

- Added two explicit browser contracts:
  - `runner-local-playwright-v1`
  - `system-chromium-v1`
- Preserved strict runner-local browser discovery, bundle validation, and `PLAYWRIGHT_BROWSERS_PATH` behavior.
- Added generic system-browser validation for:
  - architecture;
  - exact launcher and executable paths;
  - expected realpaths;
  - SHA-256 values;
  - regular-file and executable state;
  - owner, group, and mode;
  - configured same-file or distinct-file relationship.
- Configured staging for the operator-proven ARM64 coordinates:
  - architecture: `aarch64`
  - launcher: `/usr/bin/chromium`
  - launcher SHA-256: `be1d239c2a7a9298c202d506e589d23056064bd52b82fa3d3cf72a0a2de3337c`
  - executable: `/usr/lib/chromium/chromium`
  - executable SHA-256: `f8cf8a41a3406375dc9b9af5ce25a3fececa3d4e9e72d18671db07cdee7a75a6`
  - ownership/mode: `root:root:0755`
  - relationship: `distinct-files`
- Revalidates the selected contract immediately before every synthetic launch.
- Passes the exact validated system executable through `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`, ensuring Playwright launches the binary whose provenance was checked.
- Prevents the system contract from requiring, downloading, installing, copying, or modifying a browser bundle.
- Records the selected contract and safe browser provenance in runner/install/status output without credentials or private result data.
- Validates system-browser provenance before materialization or installation mutation.
- Supports ordinary relative alternate roots while rejecting missing, symlink-bearing, traversal-bearing, or escaping roots before filesystem probes, systemd inspection, or installation mutation.
- Preserves invocation-unique results, cleanup ownership, stale-metric behavior, dry-run/report-only behavior, rollback behavior, and existing fail-closed semantics.

### Files changed

- `config/dspace-chat-synthetic.json`
- `docs/dspace-chat-synthetic-producer.md`
- `scripts/dspace_chat_synthetic_runtime.py`
- `scripts/install_dspace_chat_synthetic.py`
- `tests/test_dspace_chat_synthetic_producer.py`

### Verification

Latest head: `cb0f74a730497c4209f31bc81f463bcde742dfdb`  
Branch: `codex/add-system-chromium-contract-for-dspace-chat`  
PR: #2668

- Focused producer suite: `145 passed, 1 skipped`
- Root/confinement-focused selection: `67 passed, 1 skipped`
- Full Test Suite: `3584 passed, 64 skipped`
- Overall coverage: `90%`
- Touched runtime coverage: `93%`
- Touched installer coverage: `90%`
- Codecov patch coverage: `91.36691%`, above the `90%` target
- Ruff and Black checks passed for the touched Python files
- GitHub Actions completed successfully:
  - `ci`
  - `Test Suite`
  - `Docs`
  - `Spellcheck`
  - `pi-image`
- Diff, secret-scan, and scope checks passed; the PR remains limited to the five intended files.

### Private-host rehearsal

No live cluster, systemd, package installation, browser download, deployment, promotion, or private-host rehearsal was performed, and no private operator evidence is committed.

Before rehearsal, the private target root must contain the exact configured Chromium files and provenance. Any architecture, path, realpath, hash, ownership, mode, executable-state, relationship, or root-confinement drift intentionally fails closed before Playwright starts.

Focused follow-up to PR #2658.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88900021b8832f8a1d2e400c859fad)