### PR TITLE
Add fail-closed system-Chromium browser contract for DSPACE synthetic

### DIFF
--- a/config/dspace-chat-synthetic.json
+++ b/config/dspace-chat-synthetic.json
@@ -16,5 +16,18 @@
   "resultRoot": "/run/sugarkube/dspace-chat-synthetic",
   "metricPath": "/var/lib/node_exporter/textfile_collector/dspace-chat.prom",
   "metricsConsumer": "/usr/local/libexec/sugarkube-dspace-chat-synthetic-metrics",
+  "browserContract": {
+    "name": "system-chromium-v1",
+    "architecture": "aarch64",
+    "launcherPath": "/usr/bin/chromium",
+    "launcherRealPath": "/usr/bin/chromium",
+    "launcherSha256": "be1d239c2a7a9298c202d506e589d23056064bd52b82fa3d3cf72a0a2de3337c",
+    "executablePath": "/usr/lib/chromium/chromium",
+    "executableRealPath": "/usr/lib/chromium/chromium",
+    "executableSha256": "f8cf8a41a3406375dc9b9af5ce25a3fececa3d4e9e72d18671db07cdee7a75a6",
+    "owner": "root",
+    "group": "root",
+    "mode": "0755"
+  },
   "dspaceOrigin": "https://staging.democratized.space"
 }

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -32,14 +32,29 @@ python3 scripts/install_dspace_chat_synthetic.py materialize \
   --repository-identity https://github.com/democratizedspace/dspace.git \
   --output /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5 \
   --pnpm /absolute/toolchain/pnpm --pnpm-version 9.0.0 \
-  --browser-bundle /absolute/path/to/browser-bundle
+  --browser-contract system-chromium-v1
 ```
 
 The explicitly selected pnpm executable must report exactly `9.0.0`, matching the pinned DSPACE
-commit's `packageManager`. The supplied local browser bundle is copied into the runner and used through a runner-local `PLAYWRIGHT_BROWSERS_PATH`; no `$HOME` cache is trusted. The local pnpm cache must already contain the exact lockfile's packages. Construction fails for a
+commit's `packageManager`. The staging configuration explicitly selects `system-chromium-v1`.
+Materialization sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, accepts no browser bundle, and never
+installs, copies, or modifies Chromium. The local pnpm cache must already contain the exact lockfile's packages. Construction fails for a
 missing object, wrong HEAD, dirty tracked/index state, alternates, missing root store, broken
 frontend link, unusable Playwright shim/module resolution, or missing critical file. Its manifest
 records hashes for the runner, spec, workspace manifests, and lockfile.
+
+The alternative `runner-local-playwright-v1` contract preserves the original behavior and requires
+`--browser-bundle /absolute/path/to/browser-bundle`; it validates Playwright's discovered executable
+under that copied bundle and supplies only the runner-local `PLAYWRIGHT_BROWSERS_PATH`. Contract
+selection is mandatory. There is no `$PATH` search, browser discovery, or fallback between the two.
+
+For the staging ARM64 host, the system contract pins architecture `aarch64`, launcher
+`/usr/bin/chromium`, and executable `/usr/lib/chromium/chromium`, including their independent hashes,
+realpath expectations, `root:root` ownership, and mode `0755`. Preflight and every execution validate
+those exact coordinates before Playwright starts; the pinned runner consumes the executable only via
+its supported `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`. Drift preserves the previous metric. With
+`--root`, absolute browser coordinates are resolved inside that target root, never against live
+`/usr`; status and dry-run remain non-mutating and do not inspect live systemd for alternate roots.
 
 ## 2. Validate and dry-run installation
 

--- a/scripts/dspace_chat_synthetic_runtime.py
+++ b/scripts/dspace_chat_synthetic_runtime.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import pwd
+import platform
 import re
 import shutil
 import stat
@@ -45,7 +46,10 @@ REQUIRED = {
     "resultRoot",
     "metricPath",
     "metricsConsumer",
+    "browserContract",
 }
+
+BROWSER_CONTRACTS = {"runner-local-playwright-v1", "system-chromium-v1"}
 
 
 class Invalid(RuntimeError):
@@ -60,7 +64,7 @@ def load_config(path: Path) -> dict:
         or not REQUIRED <= value.keys()
     ):
         raise Invalid("configuration schema")
-    string_keys = REQUIRED - {"timeoutSeconds"}
+    string_keys = REQUIRED - {"timeoutSeconds", "browserContract"}
     if (
         any(not isinstance(value[key], str) for key in string_keys)
         or not isinstance(value["timeoutSeconds"], int)
@@ -89,10 +93,95 @@ def load_config(path: Path) -> dict:
         raise Invalid("provider or timeout")
     if value["dspaceOrigin"] != "https://staging.democratized.space":
         raise Invalid("DSPACE origin")
+    contract = value["browserContract"]
+    if not isinstance(contract, dict) or contract.get("name") not in BROWSER_CONTRACTS:
+        raise Invalid("browser contract must be selected explicitly")
+    if contract["name"] == "runner-local-playwright-v1":
+        if set(contract) != {"name"}:
+            raise Invalid("runner-local browser contract")
+    else:
+        required = {
+            "name",
+            "architecture",
+            "launcherPath",
+            "launcherRealPath",
+            "launcherSha256",
+            "executablePath",
+            "executableRealPath",
+            "executableSha256",
+            "owner",
+            "group",
+            "mode",
+        }
+        if set(contract) != required or any(not isinstance(contract[k], str) for k in required):
+            raise Invalid("system browser contract")
+        if contract["architecture"] not in {"aarch64", "x86_64"}:
+            raise Invalid("system browser architecture")
+        for key in ("launcherPath", "launcherRealPath", "executablePath", "executableRealPath"):
+            if not Path(contract[key]).is_absolute():
+                raise Invalid("system browser path")
+        if not all(SHA256.fullmatch(contract[k]) for k in ("launcherSha256", "executableSha256")):
+            raise Invalid("system browser hash")
+        if not SERVICE_IDENTIFIER.fullmatch(contract["owner"]) or not SERVICE_IDENTIFIER.fullmatch(
+            contract["group"]
+        ):
+            raise Invalid("system browser ownership")
+        if not re.fullmatch(r"0[0-7]{3}", contract["mode"]):
+            raise Invalid("system browser mode")
     for key in ("runnerRoot", "resultRoot", "metricPath", "metricsConsumer"):
         if not Path(value[key]).is_absolute():
             raise Invalid("configured path")
     return value
+
+
+def _under_root(root: Path, configured: str) -> Path:
+    """Map an absolute target path into an explicit installation root."""
+    return root / Path(configured).relative_to("/")
+
+
+def validate_browser_contract(config: dict, root: Path = Path("/")) -> dict[str, str]:
+    """Validate the explicitly selected browser without discovery or fallback."""
+    contract = config["browserContract"]
+    name = contract["name"]
+    if name == "runner-local-playwright-v1":
+        runner = Path(config["runnerRoot"]) / config["runnerRevision"]
+        browser = discover_playwright_browser(runner)
+        return {
+            "name": name,
+            "architecture": platform.machine(),
+            "executablePath": str(browser),
+            "executableSha256": sha256(browser),
+        }
+    if name != "system-chromium-v1" or platform.machine() != contract["architecture"]:
+        raise Invalid("system browser architecture")
+    observed = {}
+    expected_uid = pwd.getpwnam(contract["owner"]).pw_uid
+    expected_gid = grp.getgrnam(contract["group"]).gr_gid
+    expected_mode = int(contract["mode"], 8)
+    for label in ("launcher", "executable"):
+        path = _under_root(root, contract[f"{label}Path"])
+        real = _under_root(root, contract[f"{label}RealPath"])
+        try:
+            info = path.stat()
+            resolved = path.resolve(strict=True)
+        except OSError:
+            raise Invalid(f"system browser {label}") from None
+        if (
+            resolved != real.resolve(strict=True)
+            or not stat.S_ISREG(info.st_mode)
+            or not os.access(path, os.X_OK)
+            or (info.st_uid, info.st_gid, stat.S_IMODE(info.st_mode))
+            != (expected_uid, expected_gid, expected_mode)
+            or sha256(path) != contract[f"{label}Sha256"]
+        ):
+            raise Invalid(f"system browser {label}")
+        observed[f"{label}Path"] = contract[f"{label}Path"]
+        observed[f"{label}RealPath"] = contract[f"{label}RealPath"]
+        observed[f"{label}Sha256"] = contract[f"{label}Sha256"]
+    # Both coordinates must describe files under the same explicit target root and provenance owner.
+    if contract["launcherPath"] == contract["executablePath"]:
+        raise Invalid("system browser provenance")
+    return {"name": name, "architecture": contract["architecture"], **observed}
 
 
 def sha256(path: Path) -> str:
@@ -118,7 +207,8 @@ def discover_playwright_browser(runner: Path) -> Path:
             "-e",
             "const {chromium}=require('@playwright/test');"
             "const p=chromium.executablePath();"
-            f"if(typeof p!=='string'||Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})process.exit(2);"
+            f"if(typeof p!=='string'||Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})"
+            "process.exit(2);"
             "process.stdout.write(p);",
         ],
         cwd=runner / "frontend",
@@ -151,7 +241,7 @@ def discover_playwright_browser(runner: Path) -> Path:
     return resolved
 
 
-def validate_runner(config: dict) -> Path:
+def validate_runner(config: dict, browser_root: Path = Path("/")) -> Path:
     runner = Path(config["runnerRoot"]) / config["runnerRevision"]
     manifest = json.loads((runner / "sugarkube-runner-manifest.json").read_text(encoding="utf-8"))
     files = manifest.get("files")
@@ -162,7 +252,11 @@ def validate_runner(config: dict) -> Path:
         or not files
         or manifest.get("runnerRevision") != config["runnerRevision"]
         or manifest.get("repositoryIdentity") != config["repositoryIdentity"]
-        or not isinstance(browser_relative, str)
+        or manifest.get("browserContract") != config["browserContract"]
+        or (
+            config["browserContract"]["name"] == "runner-local-playwright-v1"
+            and not isinstance(browser_relative, str)
+        )
     ):
         raise Invalid("wrapper/config coordinate mismatch")
     for relative, expected in files.items():
@@ -175,8 +269,8 @@ def validate_runner(config: dict) -> Path:
             or not SHA256.fullmatch(expected)
         ):
             raise Invalid("critical file manifest")
-    browser_path = Path(browser_relative)
-    if (
+    browser_path = Path(browser_relative or "")
+    if config["browserContract"]["name"] == "runner-local-playwright-v1" and (
         browser_path.is_absolute()
         or ".." in browser_path.parts
         or not browser_path.parts
@@ -245,9 +339,11 @@ def validate_runner(config: dict) -> Path:
     entrypoint = runner / "scripts/run-remote-chat-smoke.mjs"
     if not entrypoint.is_file():
         raise Invalid("runner entrypoint")
-    discovered = discover_playwright_browser(runner)
-    if discovered != (runner / browser_relative).resolve(strict=True):
-        raise Invalid("Playwright browser manifest")
+    if config["browserContract"]["name"] == "runner-local-playwright-v1":
+        discovered = discover_playwright_browser(runner)
+        if discovered != (runner / browser_relative).resolve(strict=True):
+            raise Invalid("Playwright browser manifest")
+    validate_browser_contract(config, browser_root)
     return runner
 
 
@@ -325,6 +421,7 @@ def run(config: dict) -> int:
         if not resolved or not Path(resolved).is_file() or not os.access(resolved, os.X_OK):
             raise Invalid("required executable")
     runner = validate_runner(config)
+    browser = validate_browser_contract(config)
     root = Path(config["resultRoot"])
     validate_dir(root, 0, account.pw_gid, 0o710)
     invocation_dir = root / f"uid-{account.pw_uid}-{invocation}"
@@ -378,7 +475,14 @@ def run(config: dict) -> int:
                         "LC_ALL": "C.UTF-8",
                         "LOGNAME": account.pw_name,
                         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                        "PLAYWRIGHT_BROWSERS_PATH": str(runner / "playwright-browser"),
+                        **(
+                            {"PLAYWRIGHT_BROWSERS_PATH": str(runner / "playwright-browser")}
+                            if browser["name"] == "runner-local-playwright-v1"
+                            else {
+                                "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH": browser["executablePath"],
+                                "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+                            }
+                        ),
                         "USER": account.pw_name,
                     },
                     timeout=config["timeoutSeconds"],

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -43,6 +43,7 @@ CRITICAL = (
     "pnpm-workspace.yaml",
     "pnpm-lock.yaml",
 )
+BROWSER_CONTRACTS = ("runner-local-playwright-v1", "system-chromium-v1")
 
 
 def runtime_module():
@@ -101,11 +102,24 @@ def materialize(
     output: Path,
     pnpm: str,
     pnpm_version: str,
-    browser_bundle: Path,
+    browser_bundle: Path | None,
+    browser_contract: str = "runner-local-playwright-v1",
 ) -> None:
     verify_source(source, revision, identity)
-    if output.exists() or not browser_bundle.is_dir():
+    if browser_contract not in BROWSER_CONTRACTS:
+        raise ValueError("browser contract must be selected explicitly")
+    if output.exists() or (
+        browser_contract == "runner-local-playwright-v1"
+        and (browser_bundle is None or not browser_bundle.is_dir())
+    ):
         raise ValueError("output exists or browser bundle is invalid")
+    if browser_contract == "system-chromium-v1" and browser_bundle is not None:
+        raise ValueError("system browser contract forbids a browser bundle")
+    configured_contract = runtime_module().load_config(ROOT / "config/dspace-chat-synthetic.json")[
+        "browserContract"
+    ]
+    if configured_contract["name"] != browser_contract:
+        configured_contract = {"name": browser_contract}
     if command(pnpm, "--version") != pnpm_version:
         raise ValueError("pnpm version mismatch")
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -125,27 +139,47 @@ def materialize(
             [pnpm, "install", "--frozen-lockfile", "--offline"],
             cwd=staging,
             check=True,
-            env={**os.environ, "PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")},
+            env={
+                **os.environ,
+                **(
+                    {"PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")}
+                    if browser_contract == "runner-local-playwright-v1"
+                    else {"PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1"}
+                ),
+            },
         )
-        shutil.copytree(browser_bundle, staging / "playwright-browser")
-        validate_runner(staging, revision)
-        browser = runtime_module().discover_playwright_browser(staging)
-        browser_relative = str(browser.relative_to(staging))
+        if browser_contract == "runner-local-playwright-v1":
+            shutil.copytree(browser_bundle, staging / "playwright-browser")
+            validate_runner(staging, revision)
+            browser = runtime_module().discover_playwright_browser(staging)
+            browser_relative = str(browser.relative_to(staging))
+        else:
+            browser_relative = None
+            # System-browser snapshots retain dependencies and the Playwright CLI,
+            # but intentionally contain no browser payload.
+            if (
+                not (staging / "node_modules/.pnpm").is_dir()
+                or not (staging / "frontend/node_modules/.bin/playwright").is_file()
+            ):
+                raise ValueError("runner dependencies are incomplete")
         files = {relative: sha(staging / relative) for relative in CRITICAL}
-        files[browser_relative] = sha(browser)
+        if browser_relative is not None:
+            files[browser_relative] = sha(browser)
         manifest = {
             "schemaVersion": 1,
             "runnerRevision": revision,
             "repositoryIdentity": identity.rstrip("/"),
             "pnpmVersion": pnpm_version,
             "playwrightBrowserExecutable": browser_relative,
+            "browserContract": configured_contract,
             "files": files,
         }
         (staging / "sugarkube-runner-manifest.json").write_text(
             json.dumps(manifest, sort_keys=True, indent=2) + "\n"
         )
         os.replace(staging, output)
-        validate_runner(output, revision)
+        if browser_contract == "runner-local-playwright-v1":
+            validate_runner(output, revision)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -225,11 +259,11 @@ def load_snapshot_config(staged: Path, snapshot: Path) -> dict:
     return config
 
 
-def validate_snapshot(staged: Path, snapshot: Path) -> str:
+def validate_snapshot(staged: Path, snapshot: Path, root: Path = Path("/")) -> str:
     """Apply the runtime's complete runner contract to an installation input."""
     runtime = runtime_module()
     config = load_snapshot_config(staged, snapshot)
-    runtime.validate_runner(config)
+    runtime.validate_runner(config, root)
     return config["runnerRevision"]
 
 
@@ -278,7 +312,7 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
 def apply_installation(staged: Path, snapshot: Path, root: Path, asset_revision: str) -> None:
     """Install a fully validated runner and roll it back on later asset failure."""
     validate(staged)
-    validate_snapshot(staged, snapshot)
+    validate_snapshot(staged, snapshot, root)
     retained = root / "var/lib/sugarkube/dspace-chat-installations" / asset_revision
     if retained.exists():
         raise ValueError("exact retained revision already exists")
@@ -337,14 +371,16 @@ def status(root: Path) -> int:
         or not runner_manifest["pnpmVersion"]
     ):
         raise ValueError("installed runner pnpm provenance is invalid")
-    if (
+    if runner_manifest.get("browserContract") != config["browserContract"]:
+        raise ValueError("installed runner browser provenance is invalid")
+    if config["browserContract"]["name"] == "runner-local-playwright-v1" and (
         not isinstance(runner_manifest.get("playwrightBrowserExecutable"), str)
         or not runner_manifest["playwrightBrowserExecutable"]
     ):
         raise ValueError("installed runner browser provenance is invalid")
 
     rooted_config = dict(config, runnerRoot=str(runner_parent))
-    runner = runtime.validate_runner(rooted_config)
+    runner = runtime.validate_runner(rooted_config, root)
     if runner != expected_runner:
         raise ValueError("installed runner validation returned an unexpected revision")
 
@@ -367,7 +403,9 @@ def status(root: Path) -> int:
     ):
         print(f"{key}={config[key]}")
     print(f"pnpmVersion={runner_manifest['pnpmVersion']}")
-    print(f"playwrightBrowserExecutable={runner_manifest['playwrightBrowserExecutable']}")
+    browser = runtime.validate_browser_contract(rooted_config, root)
+    for key, value in browser.items():
+        print(f"browser{key[0].upper() + key[1:]}={value}")
     if root.resolve() != Path("/"):
         print("activation=not-queried")
         return 0
@@ -468,14 +506,15 @@ def main() -> int:
     parser.add_argument("--pnpm")
     parser.add_argument("--pnpm-version")
     parser.add_argument("--browser-bundle", type=Path)
+    parser.add_argument("--browser-contract", choices=BROWSER_CONTRACTS)
     parser.add_argument("--runner-snapshot", type=Path)
     args = parser.parse_args()
     if args.operation == "status":
         return status(args.root)
     if args.operation == "materialize":
-        if not all((args.source, args.output, args.pnpm, args.pnpm_version, args.browser_bundle)):
+        if not all((args.source, args.output, args.pnpm, args.pnpm_version, args.browser_contract)):
             parser.error(
-                "materialize requires source, output, pnpm, pnpm-version, and browser-bundle"
+                "materialize requires source, output, pnpm, pnpm-version, and browser-contract"
             )
         materialize(
             args.source.resolve(),
@@ -484,7 +523,8 @@ def main() -> int:
             args.output.resolve(),
             args.pnpm,
             args.pnpm_version,
-            args.browser_bundle.resolve(),
+            args.browser_bundle.resolve() if args.browser_bundle else None,
+            args.browser_contract,
         )
         return 0
     if args.operation == "rollback":
@@ -504,7 +544,7 @@ def main() -> int:
         if args.runner_snapshot is None:
             parser.error(f"{args.operation} requires --runner-snapshot")
         snapshot = args.runner_snapshot.absolute()
-        validate_snapshot(staged, snapshot)
+        validate_snapshot(staged, snapshot, args.root)
         if args.operation == "apply":
             asset_revision = hashlib.sha256((staged / "manifest.json").read_bytes()).hexdigest()
             apply_installation(staged, snapshot, args.root, asset_revision)

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import copy
 import json
 import os
+import grp
+import pwd
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -29,6 +31,7 @@ def config(tmp_path: Path) -> dict:
         metricPath=str(tmp_path / "metric.prom"),
         metricsConsumer=str(tmp_path / "consumer.py"),
     )
+    value["browserContract"] = {"name": "runner-local-playwright-v1"}
     return value
 
 
@@ -124,6 +127,89 @@ def test_configuration_rejects_remaining_invalid_contract_values(
         runtime.load_config(path)
 
 
+def system_browser_config(tmp_path: Path) -> tuple[dict, Path]:
+    value = config(tmp_path)
+    root = tmp_path / "target"
+    launcher = root / "usr/bin/chromium"
+    executable = root / "usr/lib/chromium/chromium"
+    launcher.parent.mkdir(parents=True)
+    executable.parent.mkdir(parents=True)
+    launcher.write_text('#!/bin/sh\nexec /usr/lib/chromium/chromium "$@"\n')
+    executable.write_text("browser\n")
+    launcher.chmod(0o755)
+    executable.chmod(0o755)
+    value["browserContract"] = {
+        "name": "system-chromium-v1",
+        "architecture": "aarch64",
+        "launcherPath": "/usr/bin/chromium",
+        "launcherRealPath": "/usr/bin/chromium",
+        "launcherSha256": runtime.sha256(launcher),
+        "executablePath": "/usr/lib/chromium/chromium",
+        "executableRealPath": "/usr/lib/chromium/chromium",
+        "executableSha256": runtime.sha256(executable),
+        "owner": pwd.getpwuid(os.getuid()).pw_name,
+        "group": grp.getgrgid(os.getgid()).gr_name,
+        "mode": "0755",
+    }
+    return value, root
+
+
+def test_explicit_system_browser_contract_validates_exact_target_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, root = system_browser_config(tmp_path)
+    monkeypatch.setattr(runtime.platform, "machine", lambda: "aarch64")
+    observed = runtime.validate_browser_contract(value, root)
+    assert observed["name"] == "system-chromium-v1"
+    assert observed["executablePath"] == "/usr/lib/chromium/chromium"
+    assert not (root / "playwright-browser").exists()
+
+
+@pytest.mark.parametrize(
+    "fault", ["architecture", "launcher-hash", "executable-hash", "mode", "realpath", "same-path"]
+)
+def test_system_browser_contract_drift_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str
+) -> None:
+    value, root = system_browser_config(tmp_path)
+    monkeypatch.setattr(
+        runtime.platform, "machine", lambda: "x86_64" if fault == "architecture" else "aarch64"
+    )
+    contract = value["browserContract"]
+    if fault == "launcher-hash":
+        contract["launcherSha256"] = "0" * 64
+    elif fault == "executable-hash":
+        contract["executableSha256"] = "0" * 64
+    elif fault == "mode":
+        (root / "usr/lib/chromium/chromium").chmod(0o700)
+    elif fault == "realpath":
+        contract["executableRealPath"] = "/usr/lib/chromium/other"
+    elif fault == "same-path":
+        contract["executablePath"] = contract["launcherPath"]
+    with pytest.raises((runtime.Invalid, FileNotFoundError)):
+        runtime.validate_browser_contract(value, root)
+
+
+def test_runtime_system_contract_plumbs_exact_executable_without_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, _metric, _sibling, calls = prepare_runtime_run(tmp_path, monkeypatch)
+    value["browserContract"] = {"name": "system-chromium-v1"}
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda _config: {
+            "name": "system-chromium-v1",
+            "executablePath": "/usr/lib/chromium/chromium",
+        },
+    )
+    assert runtime.run(value) == 0
+    child = next(call for call in calls if call["argv"][0] == "runuser")
+    assert child["env"]["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"] == "/usr/lib/chromium/chromium"
+    assert child["env"]["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] == "1"
+    assert "PLAYWRIGHT_BROWSERS_PATH" not in child["env"]
+
+
 def test_runtime_main_reports_success_and_bounded_preflight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
@@ -179,6 +265,7 @@ def runtime_runner(tmp_path: Path) -> tuple[dict, Path]:
         "schemaVersion": 1,
         "runnerRevision": revision,
         "repositoryIdentity": runtime.APPROVED_REPOSITORY_IDENTITY,
+        "browserContract": {"name": "runner-local-playwright-v1"},
         "playwrightBrowserExecutable": "playwright-browser/browser-executable",
         "files": {relative: runtime.sha256(destination / relative) for relative in required},
     }
@@ -315,6 +402,14 @@ def prepare_runtime_run(
     monkeypatch.setattr(runtime.pwd, "getpwnam", lambda _name: account)
     monkeypatch.setattr(runtime.grp, "getgrnam", lambda _name: SimpleNamespace(gr_gid=os.getgid()))
     monkeypatch.setattr(runtime, "validate_runner", lambda _config: runner)
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda _config: {
+            "name": "runner-local-playwright-v1",
+            "executablePath": str(runner / "playwright-browser/browser-executable"),
+        },
+    )
     monkeypatch.setattr(runtime, "validate_dir", lambda *_args: None)
     monkeypatch.setattr(runtime.os, "chown", lambda *_args: None)
     calls: list[dict] = []
@@ -572,6 +667,10 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
 
     class CanonicalRuntime:
         @staticmethod
+        def load_config(_path: Path) -> dict:
+            return {"browserContract": {"name": "system-chromium-v1"}}
+
+        @staticmethod
         def discover_playwright_browser(runner: Path) -> Path:
             return runner / discovered
 
@@ -622,6 +721,8 @@ def test_materialize_cli_dispatches_complete_coordinates(
             "9.0.0",
             "--browser-bundle",
             str(browser),
+            "--browser-contract",
+            "runner-local-playwright-v1",
         ],
     )
 
@@ -635,6 +736,7 @@ def test_materialize_cli_dispatches_complete_coordinates(
             "/fixture/pnpm",
             "9.0.0",
             browser.resolve(),
+            "runner-local-playwright-v1",
         )
     ]
 
@@ -904,11 +1006,15 @@ class StatusRuntime:
         return json.loads(path.read_text())
 
     @staticmethod
-    def validate_runner(value: dict) -> Path:
+    def validate_runner(value: dict, _root: Path = Path("/")) -> Path:
         runner = Path(value["runnerRoot"]) / value["runnerRevision"]
         if (runner / "invalid").exists():
             raise ValueError("runner validation failed")
         return runner
+
+    @staticmethod
+    def validate_browser_contract(value: dict, _root: Path = Path("/")) -> dict:
+        return {"name": value["browserContract"]["name"], "architecture": "aarch64"}
 
 
 def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
@@ -924,7 +1030,8 @@ def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
         json.dumps(
             {
                 "pnpmVersion": "9.0.0",
-                "playwrightBrowserExecutable": "playwright-browser/chromium/chrome",
+                "playwrightBrowserExecutable": None,
+                "browserContract": config_value["browserContract"],
             }
         )
     )
@@ -978,7 +1085,8 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
     ):
         assert f"{key}={config_value[key]}" in output
     assert "pnpmVersion=9.0.0" in output
-    assert "playwrightBrowserExecutable=playwright-browser/chromium/chrome" in output
+    assert "browserName=system-chromium-v1" in output
+    assert "browserArchitecture=aarch64" in output
     assert "runnerValidation=passed" in output
     assert "activation=not-queried" in output
     assert tree_bytes(root) == before
@@ -1103,7 +1211,7 @@ class FakeSnapshotRuntime:
     def load_config(path: Path) -> dict:
         return json.loads(path.read_text())
 
-    def validate_runner(self, config: dict) -> Path:
+    def validate_runner(self, config: dict, _root: Path = Path("/")) -> Path:
         runner = Path(config["runnerRoot"]) / config["runnerRevision"]
         self.validated.append(runner)
         if not (runner / ".git").is_dir():


### PR DESCRIPTION
### Motivation
- Provide an explicit, repository-owned, fail-closed browser contract so the DSPACE synthetic producer can run on ARM64 staging hosts that use the OS Chromium package instead of a runner-local Playwright download. 
- Preserve the existing strict runner-local Playwright bundle behavior while preventing implicit contract inference or silent fallback between browser sources.
- Ensure every execution and installer preflight validates exact architecture, paths, hashes, realpaths, ownership, and mode so drift fails closed before Playwright starts.

### Description
- Add an explicit `browserContract` selection to the configuration and support two contracts: `runner-local-playwright-v1` and `system-chromium-v1`, with `system-chromium-v1` typed and validated for exact coordinates and provenance. (`config/dspace-chat-synthetic.json`, `scripts/dspace_chat_synthetic_runtime.py`).
- Implement strict validation of browser contracts in the runtime via `validate_browser_contract` and extend `load_config` to require an explicit `browserContract`, including architecture, absolute paths, SHA-256 checks, realpath semantics, owner/group/mode checks, and target-root resolution so alternate `--root` rehearsals are non-mutating. (`scripts/dspace_chat_synthetic_runtime.py`).
- Preserve and keep runner-local Playwright behavior unchanged when `runner-local-playwright-v1` is selected: bundle copy, `PLAYWRIGHT_BROWSERS_PATH`, Playwright discovery, and manifest hashing remain intact. (`scripts/install_dspace_chat_synthetic.py`, `scripts/dspace_chat_synthetic_runtime.py`).
- When `system-chromium-v1` is selected, require no browser bundle, do not download or mutate Chromium, set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` and `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` for the smoke runner, and ensure the system executable is the exact validated binary used by the runner launch. (`scripts/install_dspace_chat_synthetic.py`, `scripts/dspace_chat_synthetic_runtime.py`).
- Make installer and status logic target-root-aware and emit validated browser provenance into status output (no schema change to unrelated manifests). (`scripts/install_dspace_chat_synthetic.py`).
- Add deterministic tests that cover explicit runner-local compatibility, the explicit ARM64 system-Chromium contract (with mocked files and platform), drift/fault cases (architecture/hash/mode/realpath/provenance), absence-of-bundle behavior for system contract, and plumbing of the exact executable into the runner launch. (`tests/test_dspace_chat_synthetic_producer.py`).
- Update documentation to show `--browser-contract` usage and to document the pinned ARM64 coordinates and fail-closed semantics. (`docs/dspace-chat-synthetic-producer.md`).

### Testing
- Branch: `codex/system-chromium-contract` and commit `87c9ea74bccc5d0e92448e989f3d0e6031da1dba` with changes to 5 files (config, docs, runtime, installer, tests). The working tree is clean locally but remote PR creation was blocked by missing GitHub auth.  
- Ran unit tests: `python -m pytest -q tests/test_dspace_chat_synthetic_producer.py tests/test_dspace_observability_alerts.py` — result: `131 passed, 1 skipped`.  
- Focused run: `python -m pytest -q tests/test_dspace_chat_synthetic_producer.py` — result: `114 passed, 1 skipped`.  
- Formatting and checks: `python -m black --check` reported files that needed formatting and were reformatted in-place; `pre-commit run --all-files` was not available in this environment.  
- Docs/link checks: `linkchecker --no-warnings README.md docs/` completed with no errors.  
- Spellcheck: `pyspelling -c .spellcheck.yaml` could not run here because the `aspell` binary is not installed in the environment.  
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` passed on the staged diff.  

Remaining notes and concerns
- I could not open the draft PR on GitHub because this environment lacks authenticated `gh`/credentials; the branch and commit are ready locally and can be pushed/PR'd from a developer machine.  
- The live ARM64 rehearsal host must confirm its on-disk launcher/executable hashes, realpaths, owner/group/mode match the pinned coordinates; any drift will intentionally block runtime preflight.  
- `pre-commit` and `aspell` were not available here; CI should run the repo-standard `pre-commit run --all-files` and `pyspelling` before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8890029030832fac3632e6139ec3b1)