### PR TITLE
Add explicit system Chromium contract (`system-chromium-v1`) and fail-closed validation

### DIFF
--- a/config/dspace-chat-synthetic.json
+++ b/config/dspace-chat-synthetic.json
@@ -16,5 +16,19 @@
   "resultRoot": "/run/sugarkube/dspace-chat-synthetic",
   "metricPath": "/var/lib/node_exporter/textfile_collector/dspace-chat.prom",
   "metricsConsumer": "/usr/local/libexec/sugarkube-dspace-chat-synthetic-metrics",
+  "browserContract": {
+    "name": "system-chromium-v1",
+    "architecture": "aarch64",
+    "launcherPath": "/usr/bin/chromium",
+    "launcherRealpath": "/usr/bin/chromium",
+    "launcherSha256": "be1d239c2a7a9298c202d506e589d23056064bd52b82fa3d3cf72a0a2de3337c",
+    "launcherSymlink": false,
+    "executablePath": "/usr/lib/chromium/chromium",
+    "executableRealpath": "/usr/lib/chromium/chromium",
+    "executableSha256": "f8cf8a41a3406375dc9b9af5ce25a3fececa3d4e9e72d18671db07cdee7a75a6",
+    "owner": "root",
+    "group": "root",
+    "mode": "0755"
+  },
   "dspaceOrigin": "https://staging.democratized.space"
 }

--- a/docs/dspace-chat-synthetic-producer.md
+++ b/docs/dspace-chat-synthetic-producer.md
@@ -32,6 +32,7 @@ python3 scripts/install_dspace_chat_synthetic.py materialize \
   --repository-identity https://github.com/democratizedspace/dspace.git \
   --output /absolute/staging/97ab09f13fb098de928a878bf1fe9b8d13032cb5 \
   --pnpm /absolute/toolchain/pnpm --pnpm-version 9.0.0 \
+  --browser-contract runner-local-playwright-v1 \
   --browser-bundle /absolute/path/to/browser-bundle
 ```
 
@@ -40,6 +41,16 @@ commit's `packageManager`. The supplied local browser bundle is copied into the 
 missing object, wrong HEAD, dirty tracked/index state, alternates, missing root store, broken
 frontend link, unusable Playwright shim/module resolution, or missing critical file. Its manifest
 records hashes for the runner, spec, workspace manifests, and lockfile.
+
+The staging configuration instead explicitly selects `system-chromium-v1` for the proven ARM64
+host. For that contract, materialize with `--browser-contract system-chromium-v1` and omit
+`--browser-bundle`. Construction sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`; it neither downloads nor
+copies a browser. Installation and every execution require architecture `aarch64`, launcher
+`/usr/bin/chromium`, and executable `/usr/lib/chromium/chromium` to match the committed hashes,
+realpath/symlink expectations, `root:root` ownership, executable regular-file state, and mode
+`0755`. Playwright receives that exact executable through its pinned runner's supported
+`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` interface. No contract is inferred, `$PATH` is not searched,
+and there is no fallback between system and runner-local browsers.
 
 ## 2. Validate and dry-run installation
 
@@ -55,8 +66,10 @@ python3 scripts/install_dspace_chat_synthetic.py status --root /tmp/rehearsal-ro
 ```
 
 The preflight first loads the rendered configuration and validates its exact runner revision against
-the snapshot basename, manifest hashes, independent Git metadata, dependencies, and Node/Playwright
-resolution. Review all hashes and coordinates. `status` is read-only and, for alternate roots, reports activation as not queried; only `/` queries unit activation without
+the snapshot basename, manifest hashes, independent Git metadata, dependencies, and the explicitly
+selected browser contract. Review all hashes and coordinates. An alternate `--root` validates
+absolute browser coordinates beneath that target root, never against the live host. `status` is
+read-only and, for alternate roots, reports activation as not queried; only `/` queries unit activation without
 printing configuration secrets (the committed configuration contains none). A failed staging or
 preflight leaves installed fixtures unchanged.
 

--- a/scripts/dspace_chat_synthetic_runtime.py
+++ b/scripts/dspace_chat_synthetic_runtime.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import pwd
+import platform
 import re
 import shutil
 import stat
@@ -45,7 +46,10 @@ REQUIRED = {
     "resultRoot",
     "metricPath",
     "metricsConsumer",
+    "browserContract",
 }
+
+BROWSER_CONTRACTS = {"runner-local-playwright-v1", "system-chromium-v1"}
 
 
 class Invalid(RuntimeError):
@@ -60,10 +64,11 @@ def load_config(path: Path) -> dict:
         or not REQUIRED <= value.keys()
     ):
         raise Invalid("configuration schema")
-    string_keys = REQUIRED - {"timeoutSeconds"}
+    string_keys = REQUIRED - {"timeoutSeconds", "browserContract"}
     if (
         any(not isinstance(value[key], str) for key in string_keys)
         or not isinstance(value["timeoutSeconds"], int)
+        or not isinstance(value["browserContract"], dict)
         or isinstance(value["timeoutSeconds"], bool)
     ):
         raise Invalid("configuration value type")
@@ -76,7 +81,8 @@ def load_config(path: Path) -> dict:
     if value["tokenPlaceModel"] != APPROVED_TOKEN_PLACE_MODEL:
         raise Invalid("token.place model")
     if any(
-        not SERVICE_IDENTIFIER.fullmatch(value[key]) for key in ("serviceAccount", "serviceGroup")
+        not SERVICE_IDENTIFIER.fullmatch(value[key])
+        for key in ("serviceAccount", "serviceGroup")
     ):
         raise Invalid("service identifier")
     if value["identityContract"] != "build-info-v1":
@@ -92,6 +98,48 @@ def load_config(path: Path) -> dict:
     for key in ("runnerRoot", "resultRoot", "metricPath", "metricsConsumer"):
         if not Path(value[key]).is_absolute():
             raise Invalid("configured path")
+    contract = value["browserContract"]
+    name = contract.get("name")
+    if name not in BROWSER_CONTRACTS:
+        raise Invalid("browser contract must be selected explicitly")
+    expected = {"name"}
+    if name == "system-chromium-v1":
+        expected |= {
+            "architecture",
+            "launcherPath",
+            "launcherRealpath",
+            "launcherSha256",
+            "launcherSymlink",
+            "executablePath",
+            "executableRealpath",
+            "executableSha256",
+            "owner",
+            "group",
+            "mode",
+        }
+    if set(contract) != expected:
+        raise Invalid("browser contract schema")
+    if name == "system-chromium-v1":
+        if (
+            any(
+                not isinstance(contract[key], str)
+                for key in expected - {"launcherSymlink"}
+            )
+            or type(contract["launcherSymlink"]) is not bool
+            or not all(
+                Path(contract[key]).is_absolute()
+                for key in (
+                    "launcherPath",
+                    "launcherRealpath",
+                    "executablePath",
+                    "executableRealpath",
+                )
+            )
+            or not SHA256.fullmatch(contract["launcherSha256"])
+            or not SHA256.fullmatch(contract["executableSha256"])
+            or not re.fullmatch(r"0[0-7]{3}", contract["mode"])
+        ):
+            raise Invalid("browser contract value")
     return value
 
 
@@ -118,7 +166,8 @@ def discover_playwright_browser(runner: Path) -> Path:
             "-e",
             "const {chromium}=require('@playwright/test');"
             "const p=chromium.executablePath();"
-            f"if(typeof p!=='string'||Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})process.exit(2);"
+            "if(typeof p!=='string'||"
+            f"Buffer.byteLength(p)>{MAX_BROWSER_PATH_BYTES})process.exit(2);"
             "process.stdout.write(p);",
         ],
         cwd=runner / "frontend",
@@ -128,7 +177,11 @@ def discover_playwright_browser(runner: Path) -> Path:
         stderr=subprocess.DEVNULL,
     )
     output = completed.stdout
-    if not isinstance(output, bytes) or not output or len(output) > MAX_BROWSER_PATH_BYTES:
+    if (
+        not isinstance(output, bytes)
+        or not output
+        or len(output) > MAX_BROWSER_PATH_BYTES
+    ):
         raise Invalid("Playwright browser discovery")
     try:
         discovered = Path(output.decode("utf-8"))
@@ -151,18 +204,96 @@ def discover_playwright_browser(runner: Path) -> Path:
     return resolved
 
 
-def validate_runner(config: dict) -> Path:
+def _rooted(root: Path, absolute: str) -> Path:
+    return root / Path(absolute).relative_to("/")
+
+
+def _target_realpath(root: Path, configured: str) -> Path:
+    """Resolve one configured path without allowing absolute links to escape root."""
+    path = _rooted(root, configured)
+    if not path.is_symlink():
+        return path.resolve(strict=True)
+    link = Path(os.readlink(path))
+    candidate = _rooted(root, str(link)) if link.is_absolute() else path.parent / link
+    resolved = candidate.resolve(strict=True)
+    resolved.relative_to(root.resolve(strict=True))
+    return resolved
+
+
+def validate_browser_contract(
+    config: dict, runner: Path, root: Path = Path("/")
+) -> dict:
+    """Validate only the explicitly selected browser, confined to target root."""
+    contract = config["browserContract"]
+    name = contract["name"]
+    if name == "runner-local-playwright-v1":
+        browser = discover_playwright_browser(runner)
+        return {
+            "name": name,
+            "architecture": platform.machine(),
+            "executablePath": str(browser),
+            "executableSha256": sha256(browser),
+        }
+    if name != "system-chromium-v1" or platform.machine() != contract["architecture"]:
+        raise Invalid("browser architecture or contract")
+    launcher = _rooted(root, contract["launcherPath"])
+    executable = _rooted(root, contract["executablePath"])
+    try:
+        launcher_info = launcher.lstat()
+        executable_info = executable.lstat()
+    except OSError:
+        raise Invalid("system browser path") from None
+    if launcher.is_symlink() != contract["launcherSymlink"]:
+        raise Invalid("system browser launcher semantics")
+    try:
+        resolved = _target_realpath(root, contract["launcherPath"])
+        resolved_executable = _target_realpath(root, contract["executablePath"])
+    except (OSError, ValueError):
+        raise Invalid("system browser launcher resolution") from None
+    launcher_realpath = _rooted(root, contract["launcherRealpath"])
+    executable_realpath = _rooted(root, contract["executableRealpath"])
+    if resolved != launcher_realpath or resolved_executable != executable_realpath:
+        raise Invalid("system browser provenance mismatch")
+    owner = pwd.getpwuid(executable_info.st_uid).pw_name
+    group = grp.getgrgid(executable_info.st_gid).gr_name
+    launcher_owner = pwd.getpwuid(launcher_info.st_uid).pw_name
+    launcher_group = grp.getgrgid(launcher_info.st_gid).gr_name
+    if (
+        (not contract["launcherSymlink"] and not stat.S_ISREG(launcher_info.st_mode))
+        or not os.access(launcher, os.X_OK)
+        or not stat.S_ISREG(executable_info.st_mode)
+        or not os.access(executable, os.X_OK)
+        or (owner, group, f"0{stat.S_IMODE(executable_info.st_mode):03o}")
+        != (contract["owner"], contract["group"], contract["mode"])
+        or (
+            launcher_owner,
+            launcher_group,
+            f"0{stat.S_IMODE(launcher_info.st_mode):03o}",
+        )
+        != (contract["owner"], contract["group"], contract["mode"])
+        or sha256(launcher) != contract["launcherSha256"]
+        or sha256(executable) != contract["executableSha256"]
+    ):
+        raise Invalid("system browser provenance")
+    return {**contract}
+
+
+def validate_runner(config: dict, root: Path = Path("/")) -> Path:
     runner = Path(config["runnerRoot"]) / config["runnerRevision"]
-    manifest = json.loads((runner / "sugarkube-runner-manifest.json").read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (runner / "sugarkube-runner-manifest.json").read_text(encoding="utf-8")
+    )
     files = manifest.get("files")
     browser_relative = manifest.get("playwrightBrowserExecutable")
+    contract_name = config["browserContract"]["name"]
     if (
         manifest.get("schemaVersion") != 1
         or not isinstance(files, dict)
         or not files
         or manifest.get("runnerRevision") != config["runnerRevision"]
         or manifest.get("repositoryIdentity") != config["repositoryIdentity"]
-        or not isinstance(browser_relative, str)
+        or manifest.get("browserContract") != contract_name
+        or not isinstance(manifest.get("browserProvenance"), dict)
     ):
         raise Invalid("wrapper/config coordinate mismatch")
     for relative, expected in files.items():
@@ -175,15 +306,25 @@ def validate_runner(config: dict) -> Path:
             or not SHA256.fullmatch(expected)
         ):
             raise Invalid("critical file manifest")
-    browser_path = Path(browser_relative)
+    if contract_name == "runner-local-playwright-v1":
+        if not isinstance(browser_relative, str):
+            raise Invalid("Playwright browser manifest")
+        browser_path = Path(browser_relative)
+        if (
+            browser_path.is_absolute()
+            or ".." in browser_path.parts
+            or not browser_path.parts
+            or browser_path.parts[0] != "playwright-browser"
+            or browser_relative not in files
+        ):
+            raise Invalid("Playwright browser manifest")
+    elif browser_relative is not None:
+        raise Invalid("system browser manifest")
     if (
-        browser_path.is_absolute()
-        or ".." in browser_path.parts
-        or not browser_path.parts
-        or browser_path.parts[0] != "playwright-browser"
-        or browser_relative not in files
+        contract_name == "system-chromium-v1"
+        and manifest["browserProvenance"] != config["browserContract"]
     ):
-        raise Invalid("Playwright browser manifest")
+        raise Invalid("system browser manifest")
     git_metadata = runner / ".git"
     if git_metadata.is_symlink() or not git_metadata.is_dir():
         raise Invalid("complete Git metadata")
@@ -245,15 +386,28 @@ def validate_runner(config: dict) -> Path:
     entrypoint = runner / "scripts/run-remote-chat-smoke.mjs"
     if not entrypoint.is_file():
         raise Invalid("runner entrypoint")
-    discovered = discover_playwright_browser(runner)
-    if discovered != (runner / browser_relative).resolve(strict=True):
+    provenance = validate_browser_contract(config, runner, root)
+    if contract_name == "runner-local-playwright-v1" and provenance[
+        "executablePath"
+    ] != str((runner / browser_relative).resolve(strict=True)):
+        raise Invalid("Playwright browser manifest")
+    if contract_name == "runner-local-playwright-v1" and manifest[
+        "browserProvenance"
+    ] != {
+        "executablePath": browser_relative,
+        "executableSha256": provenance["executableSha256"],
+    }:
         raise Invalid("Playwright browser manifest")
     return runner
 
 
 def validate_dir(path: Path, uid: int, gid: int, mode: int) -> None:
     info = path.stat()
-    if not stat.S_ISDIR(info.st_mode) or (info.st_uid, info.st_gid, stat.S_IMODE(info.st_mode)) != (
+    if not stat.S_ISDIR(info.st_mode) or (
+        info.st_uid,
+        info.st_gid,
+        stat.S_IMODE(info.st_mode),
+    ) != (
         uid,
         gid,
         mode,
@@ -321,10 +475,17 @@ def run(config: dict) -> int:
     if account.pw_gid != group.gr_gid:
         raise Invalid("service account/group")
     for executable in ("/usr/bin/python3", "git", "runuser", config["metricsConsumer"]):
-        resolved = executable if Path(executable).is_absolute() else shutil.which(executable)
-        if not resolved or not Path(resolved).is_file() or not os.access(resolved, os.X_OK):
+        resolved = (
+            executable if Path(executable).is_absolute() else shutil.which(executable)
+        )
+        if (
+            not resolved
+            or not Path(resolved).is_file()
+            or not os.access(resolved, os.X_OK)
+        ):
             raise Invalid("required executable")
     runner = validate_runner(config)
+    browser = validate_browser_contract(config, runner)
     root = Path(config["resultRoot"])
     validate_dir(root, 0, account.pw_gid, 0o710)
     invocation_dir = root / f"uid-{account.pw_uid}-{invocation}"
@@ -378,8 +539,20 @@ def run(config: dict) -> int:
                         "LC_ALL": "C.UTF-8",
                         "LOGNAME": account.pw_name,
                         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                        "PLAYWRIGHT_BROWSERS_PATH": str(runner / "playwright-browser"),
                         "USER": account.pw_name,
+                        **(
+                            {
+                                "PLAYWRIGHT_BROWSERS_PATH": str(
+                                    runner / "playwright-browser"
+                                )
+                            }
+                            if browser["name"] == "runner-local-playwright-v1"
+                            else {
+                                "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH": browser[
+                                    "executablePath"
+                                ]
+                            }
+                        ),
                     },
                     timeout=config["timeoutSeconds"],
                     check=False,
@@ -453,7 +626,14 @@ def main() -> int:
     args = parser.parse_args()
     try:
         return run(load_config(args.config))
-    except (OSError, KeyError, TypeError, ValueError, subprocess.SubprocessError, Invalid):
+    except (
+        OSError,
+        KeyError,
+        TypeError,
+        ValueError,
+        subprocess.SubprocessError,
+        Invalid,
+    ):
         print("outcome=preserved reason=preflight")
         return 1
 

--- a/scripts/install_dspace_chat_synthetic.py
+++ b/scripts/install_dspace_chat_synthetic.py
@@ -57,27 +57,38 @@ def runtime_module():
 
 
 def command(*argv: str, cwd: Path | None = None) -> str:
-    return subprocess.run(argv, cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run(
+        argv, cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout.strip()
 
 
 def verify_source(source: Path, revision: str, identity: str) -> None:
     if not REVISION.fullmatch(revision) or not (source / ".git").is_dir():
         raise ValueError("complete Git metadata and an exact commit are required")
-    if command("git", "-C", str(source), "rev-parse", "--is-shallow-repository") != "false":
+    if (
+        command("git", "-C", str(source), "rev-parse", "--is-shallow-repository")
+        != "false"
+    ):
         raise ValueError("shallow Git metadata")
-    if (source / ".git/objects/info/alternates").exists() or (source / ".git").is_file():
+    if (source / ".git/objects/info/alternates").exists() or (
+        source / ".git"
+    ).is_file():
         raise ValueError("external or indirect Git metadata")
     if command("git", "-C", str(source), "rev-parse", "HEAD") != revision:
         raise ValueError("source HEAD does not equal revision")
     command("git", "-C", str(source), "cat-file", "-e", f"{revision}^{{commit}}")
     if command("git", "-C", str(source), "status", "--porcelain"):
         raise ValueError("source index or worktree is dirty")
-    origins = command("git", "-C", str(source), "remote", "get-url", "--all", "origin").splitlines()
+    origins = command(
+        "git", "-C", str(source), "remote", "get-url", "--all", "origin"
+    ).splitlines()
     if identity.rstrip("/") not in {origin.rstrip("/") for origin in origins}:
         raise ValueError("repository identity mismatch")
 
 
-def validate_runner(snapshot: Path, revision: str) -> None:
+def validate_runner(
+    snapshot: Path, revision: str, browser_contract: str = "runner-local-playwright-v1"
+) -> None:
     if command("git", "-C", str(snapshot), "rev-parse", "HEAD") != revision:
         raise ValueError("snapshot HEAD mismatch")
     command("git", "-C", str(snapshot), "fsck", "--full")
@@ -88,7 +99,10 @@ def validate_runner(snapshot: Path, revision: str) -> None:
     cli = snapshot / "frontend/node_modules/.bin/playwright"
     if not cli.is_file() or not os.access(cli, os.X_OK):
         raise ValueError("frontend Playwright CLI missing")
-    runtime_module().discover_playwright_browser(snapshot)
+    if browser_contract == "runner-local-playwright-v1":
+        runtime_module().discover_playwright_browser(snapshot)
+    elif browser_contract != "system-chromium-v1":
+        raise ValueError("browser contract must be selected explicitly")
     for link in (snapshot / "frontend/node_modules").rglob("*"):
         if link.is_symlink() and not link.exists():
             raise ValueError("broken frontend dependency link")
@@ -101,11 +115,19 @@ def materialize(
     output: Path,
     pnpm: str,
     pnpm_version: str,
-    browser_bundle: Path,
+    browser_contract: str,
+    browser_bundle: Path | None,
 ) -> None:
     verify_source(source, revision, identity)
-    if output.exists() or not browser_bundle.is_dir():
+    if browser_contract not in runtime_module().BROWSER_CONTRACTS:
+        raise ValueError("browser contract must be selected explicitly")
+    if output.exists() or (
+        browser_contract == "runner-local-playwright-v1"
+        and (browser_bundle is None or not browser_bundle.is_dir())
+    ):
         raise ValueError("output exists or browser bundle is invalid")
+    if browser_contract == "system-chromium-v1" and browser_bundle is not None:
+        raise ValueError("system browser contract forbids a browser bundle")
     if command(pnpm, "--version") != pnpm_version:
         raise ValueError("pnpm version mismatch")
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -125,27 +147,48 @@ def materialize(
             [pnpm, "install", "--frozen-lockfile", "--offline"],
             cwd=staging,
             check=True,
-            env={**os.environ, "PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")},
+            env={
+                **os.environ,
+                **(
+                    {"PLAYWRIGHT_BROWSERS_PATH": str(staging / "playwright-browser")}
+                    if browser_contract == "runner-local-playwright-v1"
+                    else {"PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1"}
+                ),
+            },
         )
-        shutil.copytree(browser_bundle, staging / "playwright-browser")
-        validate_runner(staging, revision)
-        browser = runtime_module().discover_playwright_browser(staging)
-        browser_relative = str(browser.relative_to(staging))
+        if browser_bundle is not None:
+            shutil.copytree(browser_bundle, staging / "playwright-browser")
+        validate_runner(staging, revision, browser_contract)
         files = {relative: sha(staging / relative) for relative in CRITICAL}
-        files[browser_relative] = sha(browser)
         manifest = {
             "schemaVersion": 1,
             "runnerRevision": revision,
             "repositoryIdentity": identity.rstrip("/"),
             "pnpmVersion": pnpm_version,
-            "playwrightBrowserExecutable": browser_relative,
+            "browserContract": browser_contract,
             "files": files,
         }
+        if browser_contract == "runner-local-playwright-v1":
+            browser = runtime_module().discover_playwright_browser(staging)
+            browser_relative = str(browser.relative_to(staging))
+            files[browser_relative] = sha(browser)
+            manifest["playwrightBrowserExecutable"] = browser_relative
+            manifest["browserProvenance"] = {
+                "executablePath": browser_relative,
+                "executableSha256": sha(browser),
+            }
+        else:
+            repository_config = runtime_module().load_config(
+                ROOT / "config/dspace-chat-synthetic.json"
+            )
+            if repository_config["browserContract"]["name"] != browser_contract:
+                raise ValueError("repository browser contract mismatch")
+            manifest["browserProvenance"] = repository_config["browserContract"]
         (staging / "sugarkube-runner-manifest.json").write_text(
             json.dumps(manifest, sort_keys=True, indent=2) + "\n"
         )
         os.replace(staging, output)
-        validate_runner(output, revision)
+        validate_runner(output, revision, browser_contract)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -164,7 +207,9 @@ def render(destination: Path) -> dict[str, str]:
         shutil.copyfile(src, out)
         out.chmod(0o755 if "/libexec/" in target else 0o644)
         hashes[target] = sha(out)
-    (destination / "manifest.json").write_text(json.dumps(hashes, sort_keys=True, indent=2) + "\n")
+    (destination / "manifest.json").write_text(
+        json.dumps(hashes, sort_keys=True, indent=2) + "\n"
+    )
     return hashes
 
 
@@ -225,11 +270,13 @@ def load_snapshot_config(staged: Path, snapshot: Path) -> dict:
     return config
 
 
-def validate_snapshot(staged: Path, snapshot: Path) -> str:
+def validate_snapshot(
+    staged: Path, snapshot: Path, browser_root: Path = Path("/")
+) -> str:
     """Apply the runtime's complete runner contract to an installation input."""
     runtime = runtime_module()
     config = load_snapshot_config(staged, snapshot)
-    runtime.validate_runner(config)
+    runtime.validate_runner(config, browser_root)
     return config["runnerRevision"]
 
 
@@ -248,7 +295,7 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
     if destination.exists() or destination.is_symlink():
         if destination.is_symlink() or not destination.is_dir():
             raise ValueError("runner revision destination is invalid")
-        runtime.validate_runner(rooted_config)
+        runtime.validate_runner(rooted_config, root)
         manifest = "sugarkube-runner-manifest.json"
         if (snapshot / manifest).read_bytes() != (destination / manifest).read_bytes():
             raise ValueError("existing runner manifest does not match snapshot")
@@ -265,7 +312,9 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
         validation_runner = validation_parent / revision
         os.replace(temporary, validation_runner)
         try:
-            runtime.validate_runner(dict(copied_config, runnerRoot=str(validation_parent)))
+            runtime.validate_runner(
+                dict(copied_config, runnerRoot=str(validation_parent)), root
+            )
             os.replace(validation_runner, destination)
         finally:
             shutil.rmtree(validation_parent, ignore_errors=True)
@@ -275,10 +324,12 @@ def install_runner(staged: Path, snapshot: Path, root: Path) -> tuple[Path, bool
         raise
 
 
-def apply_installation(staged: Path, snapshot: Path, root: Path, asset_revision: str) -> None:
+def apply_installation(
+    staged: Path, snapshot: Path, root: Path, asset_revision: str
+) -> None:
     """Install a fully validated runner and roll it back on later asset failure."""
     validate(staged)
-    validate_snapshot(staged, snapshot)
+    validate_snapshot(staged, snapshot, root)
     retained = root / "var/lib/sugarkube/dspace-chat-installations" / asset_revision
     if retained.exists():
         raise ValueError("exact retained revision already exists")
@@ -311,7 +362,11 @@ def status(root: Path) -> int:
         raise ValueError("current asset revision pointer is missing or invalid")
     revision = os.readlink(current)
     target = Path(revision)
-    if target.is_absolute() or len(target.parts) != 1 or not ASSET_REVISION.fullmatch(revision):
+    if (
+        target.is_absolute()
+        or len(target.parts) != 1
+        or not ASSET_REVISION.fullmatch(revision)
+    ):
         raise ValueError("current asset revision pointer is invalid")
     retained = installations / revision
     if retained.is_symlink() or not retained.is_dir():
@@ -337,14 +392,11 @@ def status(root: Path) -> int:
         or not runner_manifest["pnpmVersion"]
     ):
         raise ValueError("installed runner pnpm provenance is invalid")
-    if (
-        not isinstance(runner_manifest.get("playwrightBrowserExecutable"), str)
-        or not runner_manifest["playwrightBrowserExecutable"]
-    ):
+    if runner_manifest.get("browserContract") != config["browserContract"]["name"]:
         raise ValueError("installed runner browser provenance is invalid")
 
     rooted_config = dict(config, runnerRoot=str(runner_parent))
-    runner = runtime.validate_runner(rooted_config)
+    runner = runtime.validate_runner(rooted_config, root)
     if runner != expected_runner:
         raise ValueError("installed runner validation returned an unexpected revision")
 
@@ -367,7 +419,14 @@ def status(root: Path) -> int:
     ):
         print(f"{key}={config[key]}")
     print(f"pnpmVersion={runner_manifest['pnpmVersion']}")
-    print(f"playwrightBrowserExecutable={runner_manifest['playwrightBrowserExecutable']}")
+    browser = runtime.validate_browser_contract(rooted_config, runner, root)
+    print(f"browserContract={browser['name']}")
+    print(f"browserArchitecture={browser['architecture']}")
+    print(f"browserExecutablePath={browser['executablePath']}")
+    print(f"browserExecutableSha256={browser['executableSha256']}")
+    if browser["name"] == "system-chromium-v1":
+        print(f"browserLauncherPath={browser['launcherPath']}")
+        print(f"browserLauncherSha256={browser['launcherSha256']}")
     if root.resolve() != Path("/"):
         print("activation=not-queried")
         return 0
@@ -458,24 +517,41 @@ def main() -> int:
         default="dry-run",
     )
     parser.add_argument("--root", type=Path, default=Path("/"))
-    parser.add_argument("--revision", default="97ab09f13fb098de928a878bf1fe9b8d13032cb5")
-    parser.add_argument("--apply", action="store_true", help="authorize an explicit rollback")
+    parser.add_argument(
+        "--revision", default="97ab09f13fb098de928a878bf1fe9b8d13032cb5"
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="authorize an explicit rollback"
+    )
     parser.add_argument("--source", type=Path)
     parser.add_argument(
-        "--repository-identity", default="https://github.com/democratizedspace/dspace.git"
+        "--repository-identity",
+        default="https://github.com/democratizedspace/dspace.git",
     )
     parser.add_argument("--output", type=Path)
     parser.add_argument("--pnpm")
     parser.add_argument("--pnpm-version")
     parser.add_argument("--browser-bundle", type=Path)
+    parser.add_argument(
+        "--browser-contract",
+        choices=("runner-local-playwright-v1", "system-chromium-v1"),
+    )
     parser.add_argument("--runner-snapshot", type=Path)
     args = parser.parse_args()
     if args.operation == "status":
         return status(args.root)
     if args.operation == "materialize":
-        if not all((args.source, args.output, args.pnpm, args.pnpm_version, args.browser_bundle)):
+        if not all(
+            (
+                args.source,
+                args.output,
+                args.pnpm,
+                args.pnpm_version,
+                args.browser_contract,
+            )
+        ):
             parser.error(
-                "materialize requires source, output, pnpm, pnpm-version, and browser-bundle"
+                "materialize requires source, output, pnpm, pnpm-version, and browser-contract"
             )
         materialize(
             args.source.resolve(),
@@ -484,13 +560,16 @@ def main() -> int:
             args.output.resolve(),
             args.pnpm,
             args.pnpm_version,
-            args.browser_bundle.resolve(),
+            args.browser_contract,
+            args.browser_bundle.resolve() if args.browser_bundle else None,
         )
         return 0
     if args.operation == "rollback":
         if not ASSET_REVISION.fullmatch(args.revision):
             raise ValueError("revision must be a lowercase hexadecimal asset revision")
-        retained = args.root / "var/lib/sugarkube/dspace-chat-installations" / args.revision
+        retained = (
+            args.root / "var/lib/sugarkube/dspace-chat-installations" / args.revision
+        )
         validate(retained)
         if not args.apply:
             print("validation=passed mutation=none rollback=authorization-required")
@@ -504,9 +583,11 @@ def main() -> int:
         if args.runner_snapshot is None:
             parser.error(f"{args.operation} requires --runner-snapshot")
         snapshot = args.runner_snapshot.absolute()
-        validate_snapshot(staged, snapshot)
+        validate_snapshot(staged, snapshot, args.root)
         if args.operation == "apply":
-            asset_revision = hashlib.sha256((staged / "manifest.json").read_bytes()).hexdigest()
+            asset_revision = hashlib.sha256(
+                (staged / "manifest.json").read_bytes()
+            ).hexdigest()
             apply_installation(staged, snapshot, args.root, asset_revision)
         else:
             print("validation=passed mutation=none")

--- a/tests/test_dspace_chat_synthetic_producer.py
+++ b/tests/test_dspace_chat_synthetic_producer.py
@@ -29,6 +29,7 @@ def config(tmp_path: Path) -> dict:
         metricPath=str(tmp_path / "metric.prom"),
         metricsConsumer=str(tmp_path / "consumer.py"),
     )
+    value["browserContract"] = {"name": "runner-local-playwright-v1"}
     return value
 
 
@@ -44,18 +45,29 @@ def source_repo(tmp_path: Path) -> tuple[Path, str]:
     git("init", cwd=source)
     git("config", "user.email", "tests@example.invalid", cwd=source)
     git("config", "user.name", "Tests", cwd=source)
-    git("remote", "add", "origin", "https://github.com/democratizedspace/dspace.git", cwd=source)
+    git(
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/democratizedspace/dspace.git",
+        cwd=source,
+    )
     (source / "package.json").write_text("{}\n")
     git("add", "package.json", cwd=source)
     git("commit", "-m", "fixture", cwd=source)
     return source, git("rev-parse", "HEAD", cwd=source)
 
 
-def test_configuration_selects_contracts_and_exact_legacy_coordinate(tmp_path: Path) -> None:
+def test_configuration_selects_contracts_and_exact_legacy_coordinate(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "config.json"
     value = config(tmp_path)
     path.write_text(json.dumps(value))
-    assert runtime.load_config(path)["providerConfigContract"] == "legacy-no-default-provider-v1"
+    assert (
+        runtime.load_config(path)["providerConfigContract"]
+        == "legacy-no-default-provider-v1"
+    )
     for key in ("identityContract", "providerConfigContract"):
         broken = copy.deepcopy(value)
         broken.pop(key)
@@ -77,7 +89,11 @@ def test_configuration_selects_contracts_and_exact_legacy_coordinate(tmp_path: P
 @pytest.mark.parametrize(
     ("key", "replacement", "message"),
     [
-        ("repositoryIdentity", "https://example.invalid/dspace.git", "repository identity"),
+        (
+            "repositoryIdentity",
+            "https://example.invalid/dspace.git",
+            "repository identity",
+        ),
         ("tokenPlaceOrigin", "https://token.place", "token.place origin"),
         ("tokenPlaceModel", "different-model", "token.place model"),
         ("serviceAccount", "../../root", "service identifier"),
@@ -124,6 +140,98 @@ def test_configuration_rejects_remaining_invalid_contract_values(
         runtime.load_config(path)
 
 
+def system_browser_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[dict, Path]:
+    root = tmp_path / "target"
+    launcher = root / "usr/bin/chromium"
+    executable = root / "usr/lib/chromium/chromium"
+    launcher.parent.mkdir(parents=True)
+    executable.parent.mkdir(parents=True)
+    launcher.write_bytes(b'#!/bin/sh\nexec /usr/lib/chromium/chromium "$@"\n')
+    executable.write_bytes(b"ELF fixture")
+    launcher.chmod(0o755)
+    executable.chmod(0o755)
+    monkeypatch.setattr(runtime.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(
+        runtime.pwd, "getpwuid", lambda _uid: SimpleNamespace(pw_name="root")
+    )
+    monkeypatch.setattr(
+        runtime.grp, "getgrgid", lambda _gid: SimpleNamespace(gr_name="root")
+    )
+    value = config(tmp_path)
+    value["browserContract"] = {
+        "name": "system-chromium-v1",
+        "architecture": "aarch64",
+        "launcherPath": "/usr/bin/chromium",
+        "launcherRealpath": "/usr/bin/chromium",
+        "launcherSha256": runtime.sha256(launcher),
+        "launcherSymlink": False,
+        "executablePath": "/usr/lib/chromium/chromium",
+        "executableRealpath": "/usr/lib/chromium/chromium",
+        "executableSha256": runtime.sha256(executable),
+        "owner": "root",
+        "group": "root",
+        "mode": "0755",
+    }
+    return value, root
+
+
+def test_system_browser_contract_validates_exact_target_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, root = system_browser_fixture(tmp_path, monkeypatch)
+    provenance = runtime.validate_browser_contract(value, tmp_path / "unused", root)
+    assert provenance["name"] == "system-chromium-v1"
+    assert provenance["executablePath"] == "/usr/lib/chromium/chromium"
+
+
+@pytest.mark.parametrize(
+    ("fault", "message"),
+    [
+        ("architecture", "architecture"),
+        ("launcher-hash", "provenance"),
+        ("executable-hash", "provenance"),
+        ("mode", "provenance"),
+        ("owner", "provenance"),
+        ("executable-bit", "provenance"),
+        ("missing-launcher", "path"),
+        ("missing-executable", "path"),
+        ("not-regular", "provenance"),
+        ("realpath", "mismatch"),
+    ],
+)
+def test_system_browser_contract_fails_closed_on_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str, message: str
+) -> None:
+    value, root = system_browser_fixture(tmp_path, monkeypatch)
+    contract = value["browserContract"]
+    if fault == "architecture":
+        contract["architecture"] = "x86_64"
+    elif fault == "launcher-hash":
+        contract["launcherSha256"] = "0" * 64
+    elif fault == "executable-hash":
+        contract["executableSha256"] = "0" * 64
+    elif fault == "mode":
+        (root / "usr/lib/chromium/chromium").chmod(0o700)
+    elif fault == "owner":
+        contract["owner"] = "unexpected"
+    elif fault == "executable-bit":
+        (root / "usr/lib/chromium/chromium").chmod(0o644)
+    elif fault == "missing-launcher":
+        (root / "usr/bin/chromium").unlink()
+    elif fault == "missing-executable":
+        (root / "usr/lib/chromium/chromium").unlink()
+    elif fault == "not-regular":
+        executable = root / "usr/lib/chromium/chromium"
+        executable.unlink()
+        executable.mkdir()
+    else:
+        contract["executableRealpath"] = "/usr/lib/chromium/other"
+    with pytest.raises(runtime.Invalid, match=message):
+        runtime.validate_browser_contract(value, tmp_path / "unused", root)
+
+
 def test_runtime_main_reports_success_and_bounded_preflight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
@@ -133,7 +241,9 @@ def test_runtime_main_reports_success_and_bounded_preflight(
     monkeypatch.setattr(runtime, "run", lambda value: 7)
     assert runtime.main() == 7
 
-    monkeypatch.setattr(runtime, "run", lambda value: (_ for _ in ()).throw(runtime.Invalid("x")))
+    monkeypatch.setattr(
+        runtime, "run", lambda value: (_ for _ in ()).throw(runtime.Invalid("x"))
+    )
     assert runtime.main() == 1
     assert capsys.readouterr().out == "outcome=preserved reason=preflight\n"
 
@@ -179,8 +289,17 @@ def runtime_runner(tmp_path: Path) -> tuple[dict, Path]:
         "schemaVersion": 1,
         "runnerRevision": revision,
         "repositoryIdentity": runtime.APPROVED_REPOSITORY_IDENTITY,
+        "browserContract": "runner-local-playwright-v1",
         "playwrightBrowserExecutable": "playwright-browser/browser-executable",
-        "files": {relative: runtime.sha256(destination / relative) for relative in required},
+        "browserProvenance": {
+            "executablePath": "playwright-browser/browser-executable",
+            "executableSha256": runtime.sha256(
+                destination / "playwright-browser/browser-executable"
+            ),
+        },
+        "files": {
+            relative: runtime.sha256(destination / relative) for relative in required
+        },
     }
     (destination / "sugarkube-runner-manifest.json").write_text(json.dumps(manifest))
     return value, destination
@@ -309,12 +428,24 @@ def prepare_runtime_run(
     sibling = root / f"uid-1000-{'b' * 32}"
     sibling.mkdir()
     (sibling / "keep").write_text("untouched")
-    account = SimpleNamespace(pw_uid=os.getuid(), pw_gid=os.getgid(), pw_dir="/tmp", pw_name="pi")
+    account = SimpleNamespace(
+        pw_uid=os.getuid(), pw_gid=os.getgid(), pw_dir="/tmp", pw_name="pi"
+    )
     monkeypatch.setenv("INVOCATION_ID", "a" * 32)
     monkeypatch.setenv("SECRET_PARENT_TOKEN", "must-not-leak")
     monkeypatch.setattr(runtime.pwd, "getpwnam", lambda _name: account)
-    monkeypatch.setattr(runtime.grp, "getgrnam", lambda _name: SimpleNamespace(gr_gid=os.getgid()))
+    monkeypatch.setattr(
+        runtime.grp, "getgrnam", lambda _name: SimpleNamespace(gr_gid=os.getgid())
+    )
     monkeypatch.setattr(runtime, "validate_runner", lambda _config: runner)
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda _config, _runner: {
+            "name": "runner-local-playwright-v1",
+            "executablePath": str(runner / "playwright-browser/browser-executable"),
+        },
+    )
     monkeypatch.setattr(runtime, "validate_dir", lambda *_args: None)
     monkeypatch.setattr(runtime.os, "chown", lambda *_args: None)
     calls: list[dict] = []
@@ -324,7 +455,9 @@ def prepare_runtime_run(
         if argv[0] == "runuser":
             result = root / f"uid-{os.getuid()}-{'a' * 32}" / "result.json"
             if result_kind == "timeout":
-                raise subprocess.TimeoutExpired(argv, value["timeoutSeconds"], output=b"secret")
+                raise subprocess.TimeoutExpired(
+                    argv, value["timeoutSeconds"], output=b"secret"
+                )
             if result_kind == "oversized":
                 result.write_bytes(b"x" * (runtime.MAX_RESULT_BYTES + 1))
                 result.chmod(0o600)
@@ -339,7 +472,11 @@ def prepare_runtime_run(
                 result.chmod(0o600)
             else:
                 executed_at = (
-                    99 if result_kind == "stale" else 101 if result_kind == "future" else 100
+                    99
+                    if result_kind == "stale"
+                    else 101
+                    if result_kind == "future"
+                    else 100
                 )
                 payload = {
                     "schemaVersion": 1,
@@ -385,6 +522,40 @@ def test_runtime_run_uses_minimal_environment_and_cleans_direct_entries(
     assert (sibling / "keep").read_text() == "untouched"
 
 
+def test_runtime_plumbs_exact_system_executable_and_drift_prevents_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    value, metric, _sibling, calls = prepare_runtime_run(tmp_path, monkeypatch)
+    value["browserContract"] = {"name": "system-chromium-v1"}
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda *_args: {
+            "name": "system-chromium-v1",
+            "executablePath": "/usr/lib/chromium/chromium",
+        },
+    )
+    assert runtime.run(value) == 0
+    child = next(call for call in calls if call["argv"][0] == "runuser")
+    assert (
+        child["env"]["PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH"]
+        == "/usr/lib/chromium/chromium"
+    )
+    assert "PLAYWRIGHT_BROWSERS_PATH" not in child["env"]
+
+    calls.clear()
+    metric.write_bytes(b"previous metric\n")
+    monkeypatch.setattr(
+        runtime,
+        "validate_browser_contract",
+        lambda *_args: (_ for _ in ()).throw(runtime.Invalid("browser drift")),
+    )
+    with pytest.raises(runtime.Invalid, match="drift"):
+        runtime.run(value)
+    assert not any(call["argv"][0] == "runuser" for call in calls)
+    assert metric.read_bytes() == b"previous metric\n"
+
+
 @pytest.mark.parametrize(
     "result_kind",
     [
@@ -401,7 +572,9 @@ def test_runtime_run_uses_minimal_environment_and_cleans_direct_entries(
 def test_runtime_run_rejects_unbounded_or_replaced_result_without_publication(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, result_kind: str
 ) -> None:
-    value, metric, sibling, calls = prepare_runtime_run(tmp_path, monkeypatch, result_kind)
+    value, metric, sibling, calls = prepare_runtime_run(
+        tmp_path, monkeypatch, result_kind
+    )
 
     assert runtime.run(value) == 1
     assert metric.read_bytes() == b"previous metric\n"
@@ -415,7 +588,9 @@ def test_runtime_run_rejects_unbounded_or_replaced_result_without_publication(
 def test_runtime_timeout_is_bounded_single_launch_and_owner_scoped_cleanup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    value, metric, sibling, calls = prepare_runtime_run(tmp_path, monkeypatch, "timeout")
+    value, metric, sibling, calls = prepare_runtime_run(
+        tmp_path, monkeypatch, "timeout"
+    )
 
     assert runtime.run(value) == 1
     output = capsys.readouterr().out
@@ -464,13 +639,20 @@ def test_runtime_overlap_closes_lock_and_does_not_publish(
 
 def test_wrapper_safety() -> None:
     wrapper = (ROOT / "scripts/dspace_chat_synthetic_wrapper.sh").read_text()
-    assert "set +x\nset -Eeuo pipefail\numask 077\nexport PYTHONDONTWRITEBYTECODE=1" in wrapper
+    assert (
+        "set +x\nset -Eeuo pipefail\numask 077\nexport PYTHONDONTWRITEBYTECODE=1"
+        in wrapper
+    )
     source = (ROOT / "scripts/dspace_chat_synthetic_runtime.py").read_text()
     assert source.count("subprocess.DEVNULL") >= 4
 
 
-@pytest.mark.parametrize("condition", ["wrong-head", "dirty", "missing-object", "identity"])
-def test_source_verification_rejects_invalid_git_state(tmp_path: Path, condition: str) -> None:
+@pytest.mark.parametrize(
+    "condition", ["wrong-head", "dirty", "missing-object", "identity"]
+)
+def test_source_verification_rejects_invalid_git_state(
+    tmp_path: Path, condition: str
+) -> None:
     source, revision = source_repo(tmp_path)
     identity = "https://github.com/democratizedspace/dspace.git"
     if condition == "wrong-head":
@@ -547,6 +729,7 @@ def test_materialize_discovers_browser_and_is_source_independent(
         output,
         str(pnpm),
         "9.1.0",
+        "runner-local-playwright-v1",
         browser_bundle,
     )
     manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
@@ -571,12 +754,16 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
     validations = []
 
     class CanonicalRuntime:
+        BROWSER_CONTRACTS = {"runner-local-playwright-v1", "system-chromium-v1"}
+
         @staticmethod
         def discover_playwright_browser(runner: Path) -> Path:
             return runner / discovered
 
-    def validate_snapshot(snapshot: Path, expected_revision: str) -> None:
-        validations.append((snapshot, expected_revision))
+    def validate_snapshot(
+        snapshot: Path, expected_revision: str, contract: str
+    ) -> None:
+        validations.append((snapshot, expected_revision, contract))
         assert (snapshot / discovered).is_file()
 
     monkeypatch.setattr(installer, "runtime_module", lambda: CanonicalRuntime)
@@ -589,13 +776,47 @@ def test_materialize_orchestrates_complete_snapshot_without_host_node(
         output,
         str(pnpm),
         "9.1.0",
+        "runner-local-playwright-v1",
         browser_bundle,
     )
 
     manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
     assert manifest["playwrightBrowserExecutable"] == str(discovered)
     assert manifest["files"][str(discovered)] == runtime.sha256(output / discovered)
-    assert validations[-1] == (output, revision)
+    assert validations[-1] == (output, revision, "runner-local-playwright-v1")
+
+
+def test_materialize_system_contract_forbids_and_does_not_require_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, revision, _browser_bundle, pnpm = materialization_fixture(tmp_path)
+    output = tmp_path / "output" / revision
+    validations = []
+    monkeypatch.setattr(
+        installer,
+        "validate_runner",
+        lambda snapshot, expected, contract: validations.append(
+            (snapshot, expected, contract)
+        ),
+    )
+
+    installer.materialize(
+        source,
+        revision,
+        runtime.APPROVED_REPOSITORY_IDENTITY,
+        output,
+        str(pnpm),
+        "9.1.0",
+        "system-chromium-v1",
+        None,
+    )
+
+    manifest = json.loads((output / "sugarkube-runner-manifest.json").read_text())
+    assert manifest["browserContract"] == "system-chromium-v1"
+    assert manifest["browserProvenance"]["architecture"] == "aarch64"
+    assert "playwrightBrowserExecutable" not in manifest
+    assert not (output / "playwright-browser").exists()
+    assert validations[-1] == (output, revision, "system-chromium-v1")
 
 
 def test_materialize_cli_dispatches_complete_coordinates(
@@ -620,6 +841,8 @@ def test_materialize_cli_dispatches_complete_coordinates(
             "/fixture/pnpm",
             "--pnpm-version",
             "9.0.0",
+            "--browser-contract",
+            "runner-local-playwright-v1",
             "--browser-bundle",
             str(browser),
         ],
@@ -634,6 +857,7 @@ def test_materialize_cli_dispatches_complete_coordinates(
             output.resolve(),
             "/fixture/pnpm",
             "9.0.0",
+            "runner-local-playwright-v1",
             browser.resolve(),
         )
     ]
@@ -697,7 +921,9 @@ def test_playwright_browser_discovery_rejects_symlinked_root(
 
     def controlled_run(argv, *args, **kwargs):
         if argv[0] == "/usr/bin/node":
-            return subprocess.CompletedProcess(argv, 0, stdout=str(external_browser).encode())
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=str(external_browser).encode()
+            )
         if "status" in argv:
             return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
         return real_run(argv, *args, **kwargs)
@@ -791,13 +1017,19 @@ def test_runner_validation_rejects_coordinate_and_hash_mismatch(tmp_path: Path) 
     value = config(tmp_path)
     runner = Path(value["runnerRoot"]) / value["runnerRevision"]
     runner.mkdir(parents=True)
-    (runner / "sugarkube-runner-manifest.json").write_text(json.dumps({"runnerRevision": "0" * 40}))
+    (runner / "sugarkube-runner-manifest.json").write_text(
+        json.dumps({"runnerRevision": "0" * 40})
+    )
     with pytest.raises(runtime.Invalid, match="coordinate"):
         runtime.validate_runner(value)
 
 
-@pytest.mark.parametrize("files", [{}, {"../outside": "0" * 64}, {"package.json": "bad"}])
-def test_runner_validation_rejects_invalid_manifest_files(tmp_path: Path, files: dict) -> None:
+@pytest.mark.parametrize(
+    "files", [{}, {"../outside": "0" * 64}, {"package.json": "bad"}]
+)
+def test_runner_validation_rejects_invalid_manifest_files(
+    tmp_path: Path, files: dict
+) -> None:
     value = config(tmp_path)
     runner = Path(value["runnerRoot"]) / value["runnerRevision"]
     runner.mkdir(parents=True)
@@ -822,7 +1054,9 @@ def test_directory_mode_ownership_checks(tmp_path: Path) -> None:
         runtime.validate_dir(path, info.st_uid, info.st_gid, 0o710)
 
 
-def test_metrics_consumer_success_failure_malformed_and_atomic_preservation(tmp_path: Path) -> None:
+def test_metrics_consumer_success_failure_malformed_and_atomic_preservation(
+    tmp_path: Path,
+) -> None:
     from scripts.dspace_chat_synthetic_metrics import main as consumer_main
 
     revision = "9" * 40
@@ -858,15 +1092,18 @@ def test_metrics_consumer_success_failure_malformed_and_atomic_preservation(tmp_
         assert not list(tmp_path.glob(".dspace-chat.*"))
     previous = output.read_bytes()
     result.write_text('{"rawSecret":"do-not-print"}')
-    old, sys.argv = sys.argv, [
-        "consumer",
-        "--result",
-        str(result),
-        "--output",
-        str(output),
-        "--runner-revision",
-        revision,
-    ]
+    old, sys.argv = (
+        sys.argv,
+        [
+            "consumer",
+            "--result",
+            str(result),
+            "--output",
+            str(output),
+            "--runner-revision",
+            revision,
+        ],
+    )
     try:
         with pytest.raises(SystemExit):
             consumer_main()
@@ -875,7 +1112,9 @@ def test_metrics_consumer_success_failure_malformed_and_atomic_preservation(tmp_
     assert output.read_bytes() == previous
 
 
-def test_installer_dry_run_status_apply_and_exact_rollback(tmp_path: Path, capsys) -> None:
+def test_installer_dry_run_status_apply_and_exact_rollback(
+    tmp_path: Path, capsys
+) -> None:
     before = set(tmp_path.rglob("*"))
     with __import__("tempfile").TemporaryDirectory() as temporary:
         staged = Path(temporary)
@@ -904,11 +1143,15 @@ class StatusRuntime:
         return json.loads(path.read_text())
 
     @staticmethod
-    def validate_runner(value: dict) -> Path:
+    def validate_runner(value: dict, *_args) -> Path:
         runner = Path(value["runnerRoot"]) / value["runnerRevision"]
         if (runner / "invalid").exists():
             raise ValueError("runner validation failed")
         return runner
+
+    @staticmethod
+    def validate_browser_contract(value: dict, _runner: Path, _root: Path) -> dict:
+        return value["browserContract"]
 
 
 def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
@@ -918,13 +1161,17 @@ def status_installation(tmp_path: Path) -> tuple[Path, Path, str]:
     installer.render(staged)
     installer.install(staged, root, revision)
     config_value = json.loads(CONFIG.read_text())
-    runner = root / config_value["runnerRoot"].removeprefix("/") / config_value["runnerRevision"]
+    runner = (
+        root
+        / config_value["runnerRoot"].removeprefix("/")
+        / config_value["runnerRevision"]
+    )
     runner.mkdir(parents=True)
     (runner / "sugarkube-runner-manifest.json").write_text(
         json.dumps(
             {
                 "pnpmVersion": "9.0.0",
-                "playwrightBrowserExecutable": "playwright-browser/chromium/chrome",
+                "browserContract": "system-chromium-v1",
             }
         )
     )
@@ -963,7 +1210,8 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
     assert f"assetRevision={revision}" in output
     assert f"runnerRevision={config_value['runnerRevision']}" in output
     assert (
-        f"runnerManifestSha256={installer.sha(runner / 'sugarkube-runner-manifest.json')}" in output
+        f"runnerManifestSha256={installer.sha(runner / 'sugarkube-runner-manifest.json')}"
+        in output
     )
     for key in (
         "dspaceVersion",
@@ -978,7 +1226,8 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
     ):
         assert f"{key}={config_value[key]}" in output
     assert "pnpmVersion=9.0.0" in output
-    assert "playwrightBrowserExecutable=playwright-browser/chromium/chrome" in output
+    assert "browserContract=system-chromium-v1" in output
+    assert "browserExecutablePath=/usr/lib/chromium/chromium" in output
     assert "runnerValidation=passed" in output
     assert "activation=not-queried" in output
     assert tree_bytes(root) == before
@@ -986,7 +1235,13 @@ def test_status_reports_validated_provenance_without_mutation_or_systemctl(
 
 @pytest.mark.parametrize(
     "fault",
-    ["current-absolute", "current-traversal", "missing-retained", "retained-hash", "live-hash"],
+    [
+        "current-absolute",
+        "current-traversal",
+        "missing-retained",
+        "retained-hash",
+        "live-hash",
+    ],
 )
 def test_status_fails_closed_for_invalid_asset_provenance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str
@@ -996,11 +1251,15 @@ def test_status_fails_closed_for_invalid_asset_provenance(
     current = installations / "current"
     if fault in {"current-absolute", "current-traversal"}:
         current.unlink()
-        current.symlink_to("/tmp/external" if fault == "current-absolute" else "../escape")
+        current.symlink_to(
+            "/tmp/external" if fault == "current-absolute" else "../escape"
+        )
     elif fault == "missing-retained":
         __import__("shutil").rmtree(installations / revision)
     elif fault == "retained-hash":
-        (installations / revision / next(iter(installer.ASSETS))).write_bytes(b"tampered")
+        (installations / revision / next(iter(installer.ASSETS))).write_bytes(
+            b"tampered"
+        )
     else:
         (root / next(iter(installer.ASSETS))).write_bytes(b"tampered")
     monkeypatch.setattr(installer, "runtime_module", lambda: StatusRuntime())
@@ -1020,7 +1279,9 @@ def test_status_fails_closed_on_runner_validation_failure(
         installer.status(root)
 
 
-@pytest.mark.parametrize("fault", ["runner-symlink", "manifest-symlink", "missing-pnpm"])
+@pytest.mark.parametrize(
+    "fault", ["runner-symlink", "manifest-symlink", "missing-pnpm"]
+)
 def test_status_fails_closed_on_invalid_runner_provenance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str
 ) -> None:
@@ -1068,7 +1329,9 @@ def test_activation_status_inspects_active_and_enabled_without_mutation(
     assert "active=active enabled=active" in capsys.readouterr().out
 
 
-def test_failed_installer_preflight_leaves_installation_unchanged(tmp_path: Path) -> None:
+def test_failed_installer_preflight_leaves_installation_unchanged(
+    tmp_path: Path,
+) -> None:
     marker = tmp_path / "installed"
     marker.write_bytes(b"unchanged")
     staged = tmp_path / "bad-stage"
@@ -1103,7 +1366,7 @@ class FakeSnapshotRuntime:
     def load_config(path: Path) -> dict:
         return json.loads(path.read_text())
 
-    def validate_runner(self, config: dict) -> Path:
+    def validate_runner(self, config: dict, *_args) -> Path:
         runner = Path(config["runnerRoot"]) / config["runnerRevision"]
         self.validated.append(runner)
         if not (runner / ".git").is_dir():
@@ -1121,7 +1384,14 @@ class FakeSnapshotRuntime:
 
 @pytest.mark.parametrize(
     "fault",
-    ["absent", "wrong-revision", "symlink", "hash-mismatch", "incomplete-git", "dependency"],
+    [
+        "absent",
+        "wrong-revision",
+        "symlink",
+        "hash-mismatch",
+        "incomplete-git",
+        "dependency",
+    ],
 )
 def test_installer_snapshot_preflight_rejects_invalid_input_without_mutation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fault: str
@@ -1173,17 +1443,26 @@ def test_complete_installer_dry_run_is_byte_for_byte_non_mutating(
     root.mkdir()
     marker = root / "marker"
     marker.write_bytes(b"unchanged")
-    before = [(str(path.relative_to(root)), path.read_bytes()) for path in root.rglob("*")]
+    before = [
+        (str(path.relative_to(root)), path.read_bytes()) for path in root.rglob("*")
+    ]
     monkeypatch.setattr(installer, "runtime_module", lambda: FakeSnapshotRuntime())
 
     assert (
         run_installer_main(
-            monkeypatch, "dry-run", "--root", str(root), "--runner-snapshot", str(snapshot)
+            monkeypatch,
+            "dry-run",
+            "--root",
+            str(root),
+            "--runner-snapshot",
+            str(snapshot),
         )
         == 0
     )
 
-    after = [(str(path.relative_to(root)), path.read_bytes()) for path in root.rglob("*")]
+    after = [
+        (str(path.relative_to(root)), path.read_bytes()) for path in root.rglob("*")
+    ]
     assert after == before
 
 
@@ -1197,13 +1476,20 @@ def test_apply_installs_runner_only_after_copy_revalidation(
 
     assert (
         run_installer_main(
-            monkeypatch, "apply", "--root", str(root), "--runner-snapshot", str(snapshot)
+            monkeypatch,
+            "apply",
+            "--root",
+            str(root),
+            "--runner-snapshot",
+            str(snapshot),
         )
         == 0
     )
 
     installed = root / "var/lib/sugarkube/dspace-chat-runners" / revision
-    assert (installed / "dependency.ok").read_bytes() == (snapshot / "dependency.ok").read_bytes()
+    assert (installed / "dependency.ok").read_bytes() == (
+        snapshot / "dependency.ok"
+    ).read_bytes()
     assert any(".validate." in str(path) for path in fake.validated)
     assert os.readlink(root / "var/lib/sugarkube/dspace-chat-installations/current")
 
@@ -1236,7 +1522,9 @@ def test_apply_rejects_different_valid_existing_runner_without_mutation(
     root = tmp_path / "root"
     destination = root / "var/lib/sugarkube/dspace-chat-runners" / revision
     __import__("shutil").copytree(snapshot, destination)
-    (destination / "sugarkube-runner-manifest.json").write_text("different-valid-manifest\n")
+    (destination / "sugarkube-runner-manifest.json").write_text(
+        "different-valid-manifest\n"
+    )
     live_asset = root / next(iter(installer.ASSETS))
     live_asset.parent.mkdir(parents=True)
     live_asset.write_bytes(b"live asset")
@@ -1251,7 +1539,9 @@ def test_apply_rejects_different_valid_existing_runner_without_mutation(
         installer, "install", lambda *args: pytest.fail("asset activation was invoked")
     )
 
-    with pytest.raises(ValueError, match="existing runner manifest does not match snapshot"):
+    with pytest.raises(
+        ValueError, match="existing runner manifest does not match snapshot"
+    ):
         installer.apply_installation(staged, snapshot, root, "2" * 64)
 
     assert live_asset.read_bytes() == b"live asset"
@@ -1279,12 +1569,19 @@ def test_apply_failure_preserves_prior_state_and_removes_only_new_paths(
     monkeypatch.setattr(installer, "runtime_module", lambda: fake)
     if failure == "asset-activation":
         monkeypatch.setattr(
-            installer, "install", lambda *args: (_ for _ in ()).throw(OSError("injected"))
+            installer,
+            "install",
+            lambda *args: (_ for _ in ()).throw(OSError("injected")),
         )
 
     with pytest.raises((OSError, ValueError)):
         run_installer_main(
-            monkeypatch, "apply", "--root", str(root), "--runner-snapshot", str(snapshot)
+            monkeypatch,
+            "apply",
+            "--root",
+            str(root),
+            "--runner-snapshot",
+            str(snapshot),
         )
 
     assert (prior_runner / "kept").read_bytes() == b"runner"
@@ -1341,11 +1638,15 @@ def test_rollback_rejects_symlinked_retained_asset_before_mutation(
     asset.symlink_to(external)
     before = tree_bytes(tmp_path)
     monkeypatch.setattr(
-        installer, "activate", lambda *args: pytest.fail("invalid rollback was activated")
+        installer,
+        "activate",
+        lambda *args: pytest.fail("invalid rollback was activated"),
     )
 
     with pytest.raises(ValueError):
-        run_installer_main(monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision)
+        run_installer_main(
+            monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision
+        )
 
     assert tree_bytes(tmp_path) == before
 
@@ -1390,11 +1691,15 @@ def test_rollback_cli_rejects_invalid_retained_revision_without_mutation(
     monkeypatch.setattr(
         installer,
         "activate",
-        lambda *args: pytest.fail("rollback activated before retained assets validated"),
+        lambda *args: pytest.fail(
+            "rollback activated before retained assets validated"
+        ),
     )
 
     with pytest.raises((FileNotFoundError, ValueError)):
-        run_installer_main(monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision)
+        run_installer_main(
+            monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision
+        )
 
     assert marker.read_bytes() == b"unchanged"
     assert not (retained.parent / "current").exists()
@@ -1424,7 +1729,9 @@ def test_rollback_cli_validates_dry_run_without_activation(
     )
 
     assert (
-        run_installer_main(monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision)
+        run_installer_main(
+            monkeypatch, "rollback", "--root", str(tmp_path), "--revision", revision
+        )
         == 0
     )
     assert capsys.readouterr().out == (
@@ -1460,7 +1767,9 @@ def test_rollback_cli_apply_activates_only_after_validation(
     assert calls == [(retained, tmp_path, revision)]
 
 
-def test_install_rejects_invalid_asset_revision_without_mutation(tmp_path: Path) -> None:
+def test_install_rejects_invalid_asset_revision_without_mutation(
+    tmp_path: Path,
+) -> None:
     staged = tmp_path / "staged"
     installer.render(staged)
     root = tmp_path / "root"
@@ -1495,7 +1804,10 @@ def test_lifecycle_is_single_shot_owner_scoped_bounded_and_redacted() -> None:
     assert 'f"uid-{account.pw_uid}-{invocation}"' in source
     assert 'timeout=config["timeoutSeconds"]' in source
     assert "cleanup_invocation(invocation_dir)" in source
-    assert "entry.is_dir(follow_symlinks=False)" in source and "invocation_dir.rmdir()" in source
+    assert (
+        "entry.is_dir(follow_symlinks=False)" in source
+        and "invocation_dir.rmdir()" in source
+    )
     assert "glob(" not in source and "rmtree" not in source
     for forbidden in ("retry", "systemctl", "rollback", "restart"):
         assert forbidden not in source.lower()


### PR DESCRIPTION
### Motivation
- ARM64 staging rehearsal requires a repository-owned, fail-closed option to use the OS Chromium instead of relying on Playwright browser downloads that can fail on that platform. 
- The producer must never infer a browser contract from the environment and must validate exact architecture, paths, hashes, realpath semantics, ownership, and mode before any mutation or launch.

### Description
- Introduce an explicit browser-contract model and two supported contracts: `runner-local-playwright-v1` (preserves existing runner-local Playwright bundle behavior) and `system-chromium-v1` (strict system Chromium validation); see `scripts/dspace_chat_synthetic_runtime.py` for `validate_browser_contract` and contract enforcement. 
- Add repository staging selection for the proven ARM64 coordinates and provenance in `config/dspace-chat-synthetic.json`, and record browser provenance into runner manifests as `browserProvenance` during materialize in `scripts/install_dspace_chat_synthetic.py`. 
- Extend the installer to accept `--browser-contract` and to enforce that `system-chromium-v1` forbids supplying or copying a browser bundle while `runner-local-playwright-v1` still requires the explicit bundle, and confine system-path resolution to an explicit target root (no `$PATH` probing). Files changed include `config/dspace-chat-synthetic.json`, `scripts/dspace_chat_synthetic_runtime.py`, `scripts/install_dspace_chat_synthetic.py`, `tests/test_dspace_chat_synthetic_producer.py`, and `docs/dspace-chat-synthetic-producer.md`. 
- Ensure runtime revalidates the selected contract before every execution and plumbs the exact selected executable into the runner environment using either `PLAYWRIGHT_BROWSERS_PATH` (runner-local) or `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` (system), with no fallback between contracts.

### Testing
- Ran the focused unit tests for the producer: `pytest -q tests/test_dspace_chat_synthetic_producer.py` which passed `119 passed, 1 skipped`; these tests were extended to cover contract selection, system contract success/failure modes, metadata provenance, installer dry-run/non-mutating behavior, and launch plumbing. 
- Ran static/format checks: `ruff format`/`ruff check` and repository checks used in `scripts/checks.sh` locally (formatting applied where required); `linkchecker --no-warnings README.md docs/` completed with no errors; `pyspelling` failed in this environment due to missing `aspell` and `pre-commit` was not available to run here. 
- Commit and branch: changes were committed on branch `codex/system-chromium-contract` as `0c3f1c4b0c9dc7fc2ab858fe3a4954786a6fc969`, but `git push`/PR creation failed due to missing GitHub authentication in the environment so no draft PR was opened here. 

Remaining concerns before private-host rehearsal: provide GitHub credentials to push/open the PR, and perform a private preflight on the target host to confirm the `launcherSymlink` and realpath semantics for `/usr/bin/chromium` and `/usr/lib/chromium/chromium` before attempting rehearsal so the system contract will validate successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8890055528832f8fc23abcf629a1db)