### PR TITLE
Add credential-free Ansible staging validation foundation

### DIFF
--- a/.github/workflows/ansible-validate.yml
+++ b/.github/workflows/ansible-validate.yml
@@ -39,8 +39,7 @@ jobs:
         run: ansible-lint infra/ansible/playbooks/staging_preflight.yml
       - name: Parse and display staging inventory
         run: |
-          ansible-inventory \
-            --inventory infra/ansible/inventories/staging/hosts.yml --graph
+          ansible-inventory --graph
           ansible-inventory \
             --inventory infra/ansible/inventories/staging/hosts.yml --list
       - name: Check preflight syntax without connecting to hosts

--- a/.github/workflows/ansible-validate.yml
+++ b/.github/workflows/ansible-validate.yml
@@ -1,0 +1,50 @@
+name: Ansible validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+  pull_request:
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+
+permissions:
+  contents: read
+
+env:
+  ANSIBLE_CONFIG: ${{ github.workspace }}/infra/ansible/ansible.cfg
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: infra/ansible/requirements.txt
+      - name: Install pinned validation dependencies
+        run: python -m pip install --requirement infra/ansible/requirements.txt
+      - name: Inspect effective configuration
+        run: ansible-config dump --only-changed
+      - name: Lint YAML
+        run: yamllint infra/ansible
+      - name: Lint preflight playbook
+        run: ansible-lint infra/ansible/playbooks/staging_preflight.yml
+      - name: Parse and display staging inventory
+        run: |
+          ansible-inventory \
+            --inventory infra/ansible/inventories/staging/hosts.yml --graph
+          ansible-inventory \
+            --inventory infra/ansible/inventories/staging/hosts.yml --list
+      - name: Check preflight syntax without connecting to hosts
+        run: |
+          ansible-playbook \
+            --inventory infra/ansible/inventories/staging/hosts.yml \
+            --syntax-check infra/ansible/playbooks/staging_preflight.yml

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ infra/terraform/**/*.tfvars
 infra/terraform/**/*.tfvars.json
 infra/terraform/**/*.auto.tfvars
 infra/terraform/**/*.auto.tfvars.json
+
+# Ansible generated and local-only files (infra/ansible only)
+infra/ansible/**/.ansible/
+infra/ansible/**/.cache/
+infra/ansible/**/.venv/
+infra/ansible/**/venv/
+infra/ansible/**/*.retry
+infra/ansible/**/inventory.local.*
+infra/ansible/**/inventories/**/*.local.*
+infra/ansible/**/vault*pass*
+infra/ansible/**/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ infra/ansible/**/*.retry
 infra/ansible/**/inventory.local.*
 infra/ansible/**/inventories/**/*.local.*
 infra/ansible/**/vault*pass*
+infra/ansible/**/.vault*pass*
 infra/ansible/**/*.log

--- a/docs/design/terraform-ansible-integration.md
+++ b/docs/design/terraform-ansible-integration.md
@@ -11,6 +11,10 @@ personas:
 
 ## Overview and current status
 
+> **Phase B status:** The credential-free Terraform and Ansible validation foundations now exist.
+> Live Ansible preflight, node convergence, Terraform state/backend selection, DNS resources,
+> Cloudflare adoption, and every production implementation remain unimplemented and unauthorized.
+
 Terraform and Ansible address different layers. Terraform manages stateful external resources through
 provider APIs and makes proposed changes, applies, and drift visible. Ansible manages idempotent
 post-boot host configuration over SSH. They complement the existing platform rather than replacing it.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,9 +1,10 @@
 # Infra Helpers
 
 This directory contains the credential-free [Terraform validation foundation](terraform/README.md)
-and is reserved for operational helpers such as future Terraform modules, Ansible playbooks,
-bootstrap helpers, and non-secret bootstrap metadata. Terraform state and saved plans are sensitive
-remote artifacts and must not be committed beneath `infra/`.
+and [Ansible staging validation foundation](ansible/README.md). It is reserved for operational
+helpers such as future Terraform modules, Ansible playbooks, bootstrap helpers, and non-secret
+bootstrap metadata. Terraform state and saved plans are sensitive remote artifacts and must not be
+committed beneath `infra/`.
 
 The [Terraform and Ansible integration design](../docs/design/terraform-ansible-integration.md)
 defines the ownership and safety boundaries that this foundation and any future automation must

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,78 @@
+# Ansible staging validation foundation
+
+This directory is the credential-free Ansible half of Phase B in the
+[Terraform and Ansible integration design](../../docs/design/terraform-ansible-integration.md).
+Ansible is reserved for explicitly adopted post-boot host configuration. Terraform manages selected
+external provider resources, while Helm/Just and Flux retain their existing application and
+Kubernetes ownership. Every individual resource has exactly one authoritative writer; merely
+describing a future responsibility here does not transfer ownership.
+
+## Current scope and boundaries
+
+The scaffold contains one static staging inventory, local configuration, pinned validation tools,
+and a facts-based, read-only preflight playbook. It creates no production inventory, roles, host or
+group variables, secrets, vaults, dynamic inventory, or mutable tasks. It neither authorizes nor
+performs a host connection.
+
+Pi imaging, bootstrap scripts, `just ha3`, `/etc/rancher/k3s/config.yaml`, Helm/Just, Flux, and
+existing application workflows retain their current ownership. Ansible does not deploy applications,
+write Kubernetes resources, or alter external infrastructure.
+
+The inventory names `sugarkube3`, `sugarkube4`, and `sugarkube5` as aliases only. A future authorized
+operator's existing SSH configuration must resolve those aliases. Host-key checking is explicitly
+enabled. Validate each fingerprint through a trusted out-of-band channel before any first connection;
+never accept an unexpected key or disable strict verification.
+
+## Install and validate locally
+
+Use the repository-supported Python 3.12 in an isolated environment, from the repository root:
+
+```bash
+python3.12 -m venv /tmp/sugarkube-ansible-validate
+/tmp/sugarkube-ansible-validate/bin/python -m pip install \
+  --requirement infra/ansible/requirements.txt
+export PATH="/tmp/sugarkube-ansible-validate/bin:$PATH"
+export ANSIBLE_CONFIG="$PWD/infra/ansible/ansible.cfg"
+
+ansible-config dump --only-changed
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+yamllint infra/ansible
+ansible-lint infra/ansible/playbooks/staging_preflight.yml
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --syntax-check infra/ansible/playbooks/staging_preflight.yml
+```
+
+The exact pins in `requirements.txt` keep local and CI validation reproducible. To update them,
+review the current stable `ansible-core`, `ansible-lint`, and `yamllint` releases for Python 3.12 and
+mutual compatibility, change all relevant exact pins together, install them in a new environment,
+and rerun every command above. No Galaxy collection is needed because the playbook uses only
+`ansible.builtin` modules.
+
+## Future live milestone (not authorized by this scaffold)
+
+The first live milestone will gather facts and perform only read-only baseline checks across staging.
+An operator may later begin with this canary command **only after separate review and authorization**:
+
+```bash
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --limit sugarkube3 --check --diff \
+  infra/ansible/playbooks/staging_preflight.yml
+```
+
+This task and its CI do **not** execute that command. Check mode is not permission to connect to a
+host. Facts and read-only assertions come first so operators can validate assumptions without taking
+ownership or changing a node.
+
+The first mutable role will be a separate PR that adopts exactly one low-risk, reversible
+responsibility and retires its prior writer. That rollout must use a canary and serial execution,
+cluster readiness and quorum gates before and after each step, a tested rollback, and a second
+convergence run reporting `changed=0` before promotion.
+
+## Secrets policy
+
+Never put SSH keys, login or vault-decryption passphrases, tokens, kubeconfigs,
+privilege-escalation credentials, private topology, cached facts, or secret-bearing logs in Git or
+inventory. Supply any future authorized authentication through approved runtime mechanisms. Ignore
+rules reduce accidental local artifact commits but are not a substitute for reviewing content and
+scanning for secrets.

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -35,13 +35,17 @@ export PATH="/tmp/sugarkube-ansible-validate/bin:$PATH"
 export ANSIBLE_CONFIG="$PWD/infra/ansible/ansible.cfg"
 
 ansible-config dump --only-changed
-ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+ansible-inventory --graph
 ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
 yamllint infra/ansible
 ansible-lint infra/ansible/playbooks/staging_preflight.yml
 ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
   --syntax-check infra/ansible/playbooks/staging_preflight.yml
 ```
+
+Ansible resolves the relative inventory and roles paths in `ansible.cfg` from the configuration
+file's directory. Consequently, `ansible-inventory --graph` uses the checked-in staging inventory
+when the command is run from the repository root with `ANSIBLE_CONFIG` set as shown above.
 
 The exact pins in `requirements.txt` keep local and CI validation reproducible. To update them,
 review the current stable `ansible-core`, `ansible-lint`, and `yamllint` releases for Python 3.12 and

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
-inventory = {{CWD}}/infra/ansible/inventories/staging/hosts.yml
-roles_path = {{CWD}}/infra/ansible/roles
+inventory = inventories/staging/hosts.yml
+roles_path = roles
 host_key_checking = True
 retry_files_enabled = False
 fact_caching = memory

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = inventories/staging/hosts.yml
+roles_path = roles
+host_key_checking = True
+retry_files_enabled = False
+fact_caching = memory

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
-inventory = inventories/staging/hosts.yml
-roles_path = roles
+inventory = {{CWD}}/infra/ansible/inventories/staging/hosts.yml
+roles_path = {{CWD}}/infra/ansible/roles
 host_key_checking = True
 retry_files_enabled = False
 fact_caching = memory

--- a/infra/ansible/inventories/staging/hosts.yml
+++ b/infra/ansible/inventories/staging/hosts.yml
@@ -1,0 +1,6 @@
+---
+staging:
+  hosts:
+    sugarkube3:
+    sugarkube4:
+    sugarkube5:

--- a/infra/ansible/playbooks/staging_preflight.yml
+++ b/infra/ansible/playbooks/staging_preflight.yml
@@ -1,0 +1,30 @@
+---
+- name: Validate the staging node baseline without making changes
+  hosts: staging
+  gather_facts: true
+  become: false
+
+  tasks:
+    - name: Require Linux on every staging node
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.system == "Linux"
+        fail_msg: >-
+          {{ inventory_hostname }} must run Linux; detected
+          {{ ansible_facts.system | default('an unknown system') }}.
+        success_msg: >-
+          {{ inventory_hostname }} reports the required Linux system.
+
+    - name: Require an ARM64 machine architecture
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.architecture in ['aarch64', 'arm64']
+        fail_msg: >-
+          {{ inventory_hostname }} must use ARM64 (aarch64 or arm64); detected
+          {{ ansible_facts.architecture | default('an unknown architecture') }}.
+        success_msg: >-
+          {{ inventory_hostname }} reports a supported ARM64 architecture.
+
+    - name: Report successful baseline validation
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} passed the read-only staging baseline."

--- a/infra/ansible/requirements.txt
+++ b/infra/ansible/requirements.txt
@@ -1,0 +1,3 @@
+ansible-core==2.21.3
+ansible-lint==26.8.0
+yamllint==1.38.0


### PR DESCRIPTION
### Motivation

- Implement the Ansible half of Phase B from the Terraform/Ansible design with a credential-free, validation-only scaffold for staging Raspberry Pi hosts.
- Provide a future read-only preflight that can be run by an operator (separately authorized) to gather facts and assert baseline requirements without connecting, mutating, or storing secrets.

### Description

- Add a minimal Ansible foundation under `infra/ansible/` including `README.md`, `ansible.cfg`, `requirements.txt`, a static staging inventory `inventories/staging/hosts.yml`, and a read-only preflight playbook `playbooks/staging_preflight.yml` that uses only `ansible.builtin` modules and asserts Linux + ARM64.
- Pin validation dependencies exactly in `infra/ansible/requirements.txt` to `ansible-core==2.21.3`, `ansible-lint==26.8.0`, and `yamllint==1.38.0` and document how to update them in the README.
- Configure `infra/ansible/ansible.cfg` to default to the checked-in staging inventory, point to a local `roles` path, enable strict SSH host-key checking, disable retry-file generation, and use in-memory fact caching only.
- Provide a static YAML inventory with exactly three aliases — `sugarkube3`, `sugarkube4`, `sugarkube5` — and no addresses, usernames, ports, keys, passwords, or application variables.
- Create a read-only playbook `playbooks/staging_preflight.yml` that sets `gather_facts: true`, `become: false`, and performs only assertions and sanitized reporting via `ansible.builtin.assert` and `ansible.builtin.debug` (no mutable modules, no `shell`/`command` usage).
- Add a focused CI workflow `.github/workflows/ansible-validate.yml` that runs on PRs and `main` for `infra/ansible/**`, uses Python 3.12, installs only the pinned requirements, runs `yamllint`, `ansible-lint`, `ansible-inventory` display, and `ansible-playbook --syntax-check` without connecting to hosts or using secrets.
- Add narrowly scoped `.gitignore` exclusions under `infra/ansible/` for local-only artifacts (virtualenvs, `.ansible/`, `.cache/`, retry files, local inventories, vault passphrase files, logs) while keeping canonical scaffold files checked in.
- Update `infra/README.md` to link the new Ansible foundation and add a brief status line to `docs/design/terraform-ansible-integration.md` noting that credential-free Phase B foundations now exist while live preflight, node convergence, backend/state selection, DNS/Cloudflare adoption, and production remain unimplemented.

### Testing

- Pinned packages: `ansible-core==2.21.3`, `ansible-lint==26.8.0`, `yamllint==1.38.0` were installed successfully into an isolated venv created with the repository Python (tested with Python 3.12).
- Local validation commands executed and passed: `ansible --version` (shows Ansible Core 2.21.3), `ansible-config dump --only-changed`, `ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph`, `ansible-inventory --list`, `yamllint infra/ansible`, `ansible-lint infra/ansible/playbooks/staging_preflight.yml`, and `ansible-playbook --syntax-check infra/ansible/playbooks/staging_preflight.yml` all succeeded.
- Inventory structure and exact aliases were programmatically verified with a Python YAML check to contain one group `staging` with `sugarkube3`, `sugarkube4`, and `sugarkube5`.
- Static safety audits passed: greps for forbidden inventory/playbook content (no `become: true`, no `ansible_host`/credentials, no mutable modules) returned none, and tracked-artifact checks confirmed no local artifacts are being committed under `infra/ansible/`.
- `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were run during verification; `pyspelling` required the system `aspell` binary which was installed in the test environment before the run and then passed; `linkchecker` passed with zero errors.
- `pre-commit run --all-files` was attempted but failed due to pre-existing, unrelated repository-wide YAML parsing and Python lint issues outside the scope of this PR; any tool-generated edits outside `infra/ansible/` were restored during verification.
- Secret scan and diff checks passed for the patch (no credentials or sensitive topology added).
- No live connections were made and no playbook was executed against hosts (`--syntax-check` only); no mutable modules, credentials, private topology, production inventory, Terraform state/backend changes, DNS/Cloudflare, or application/observability changes were introduced.
- Note: creating a GitHub pull request from the environment was not performed because remote authentication was unavailable; the local branch and changes are ready for a standard PR from an authenticated environment.

If reviewers want, next steps are a quick pass over the pinned versions (update all three pins together when upgrading), a review of the preflight assertions to add or refine read-only checks, and a later PR that implements a single, well-scoped mutable role once operator authorization and rollout plans are approved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89384ba8f8832fa4e810ba8800f387)