### PR TITLE
infra: add credential-free Ansible staging validation scaffold

### DIFF
--- a/.github/workflows/ansible-validate.yml
+++ b/.github/workflows/ansible-validate.yml
@@ -1,0 +1,47 @@
+name: Ansible validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+  pull_request:
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+
+permissions:
+  contents: read
+
+env:
+  ANSIBLE_CONFIG: ${{ github.workspace }}/infra/ansible/ansible.cfg
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install pinned validation dependencies
+        run: python -m pip install --requirement infra/ansible/requirements.txt
+      - name: Inspect effective configuration
+        run: ansible-config dump --only-changed
+      - name: Lint Ansible YAML
+        run: yamllint infra/ansible
+      - name: Lint the preflight playbook
+        run: ansible-lint infra/ansible/playbooks/staging_preflight.yml
+      - name: Parse and display the staging inventory
+        run: |
+          ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+          ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+      - name: Check playbook syntax without connecting to hosts
+        run: >-
+          ansible-playbook
+          --inventory infra/ansible/inventories/staging/hosts.yml
+          --syntax-check
+          infra/ansible/playbooks/staging_preflight.yml

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,15 @@ infra/terraform/**/*.tfvars
 infra/terraform/**/*.tfvars.json
 infra/terraform/**/*.auto.tfvars
 infra/terraform/**/*.auto.tfvars.json
+
+# Ansible generated and local-only files (infra/ansible only)
+infra/ansible/**/.ansible/
+infra/ansible/**/.cache/
+infra/ansible/**/.venv/
+infra/ansible/**/venv/
+infra/ansible/**/*.retry
+infra/ansible/**/inventory.local.yml
+infra/ansible/**/inventory.local.yaml
+infra/ansible/**/vault-password*
+infra/ansible/**/vault_password*
+infra/ansible/**/*.log

--- a/docs/design/terraform-ansible-integration.md
+++ b/docs/design/terraform-ansible-integration.md
@@ -11,6 +11,11 @@ personas:
 
 ## Overview and current status
 
+**Phase B status:** The credential-free Terraform and Ansible validation foundations now exist.
+They authorize static validation only. Live Ansible preflight, node convergence, Terraform
+state/backend selection, DNS resources, Cloudflare adoption, and every production implementation
+remain unimplemented.
+
 Terraform and Ansible address different layers. Terraform manages stateful external resources through
 provider APIs and makes proposed changes, applies, and drift visible. Ansible manages idempotent
 post-boot host configuration over SSH. They complement the existing platform rather than replacing it.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,9 +1,10 @@
 # Infra Helpers
 
 This directory contains the credential-free [Terraform validation foundation](terraform/README.md)
-and is reserved for operational helpers such as future Terraform modules, Ansible playbooks,
-bootstrap helpers, and non-secret bootstrap metadata. Terraform state and saved plans are sensitive
-remote artifacts and must not be committed beneath `infra/`.
+and [Ansible staging validation foundation](ansible/README.md). It is reserved for operational
+helpers such as future Terraform modules, Ansible roles, bootstrap helpers, and non-secret bootstrap
+metadata. Terraform state and saved plans are sensitive remote artifacts and must not be committed
+beneath `infra/`.
 
 The [Terraform and Ansible integration design](../docs/design/terraform-ansible-integration.md)
 defines the ownership and safety boundaries that this foundation and any future automation must

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,78 @@
+# Ansible staging validation foundation
+
+This directory is the credential-free Ansible half of Phase B in the
+[Terraform and Ansible integration design](../../docs/design/terraform-ansible-integration.md).
+Ansible's future boundary is post-boot host configuration. Terraform owns only separately adopted
+external provider resources, while Helm/Just and Flux retain their existing application and
+Kubernetes ownership. Every individual resource has exactly one authoritative writer: Ansible may
+adopt a responsibility only through a separately reviewed handoff that retires its previous writer.
+
+## Current scope and safety boundary
+
+This scaffold provides a static three-host staging inventory, strict configuration, pinned validation
+tools, credential-free CI, and a future facts-based read-only preflight. It provides no production
+inventory, roles, variables, secrets, dynamic inventory, persistent fact cache, logs, or mutable
+playbook. Neither this task nor CI authorizes a host connection or live playbook run.
+
+The aliases `sugarkube3`, `sugarkube4`, and `sugarkube5` contain no topology or connection settings.
+During a separately authorized future run, the operator's existing SSH configuration must resolve
+them. Host-key checking remains enabled; validate every fingerprint out of band before connecting.
+Never bypass host-key or certificate verification.
+
+Pi imaging and bootstrap scripts remain authoritative for the base image and bootstrap. Existing
+`just ha3` procedures and `/etc/rancher/k3s/config.yaml` ownership remain unchanged. Helm/Just, Flux,
+and existing application workflows continue to own their current Kubernetes and application
+resources.
+
+## Install and validate locally
+
+The repository supports Python `3.x`. Install only the exact validation dependencies in an isolated
+environment, then point Ansible explicitly at the checked-in configuration:
+
+```bash
+python3 -m venv /tmp/sugarkube-ansible-validate
+/tmp/sugarkube-ansible-validate/bin/python -m pip install \
+  --requirement infra/ansible/requirements.txt
+export PATH="/tmp/sugarkube-ansible-validate/bin:$PATH"
+export ANSIBLE_CONFIG="$PWD/infra/ansible/ansible.cfg"
+```
+
+Inspect the inventory and configuration, lint the files, and perform syntax validation only:
+
+```bash
+ansible-config dump --only-changed
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+yamllint infra/ansible
+ansible-lint infra/ansible/playbooks/staging_preflight.yml
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --syntax-check infra/ansible/playbooks/staging_preflight.yml
+```
+
+`requirements.txt` pins mutually tested releases so CI and operators validate with the same tools.
+To update them, review the current stable releases and their supported Python/Ansible ranges, change
+all affected exact pins together, install them in a fresh virtual environment, and rerun every command
+above. Review dependency release notes rather than updating a single package in isolation.
+
+## Future live milestones (not authorized here)
+
+The first live milestone is fact gathering and this read-only Linux/ARM64 preflight across staging.
+That establishes reachability and a known baseline without claiming ownership or changing nodes. A
+future operator may eventually use this canary command, but **this task does not authorize or execute
+it**:
+
+```bash
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --limit sugarkube3 --check --diff infra/ansible/playbooks/staging_preflight.yml
+```
+
+After all staging nodes pass a separately authorized read-only milestone, the first mutable role must
+arrive in another PR and adopt exactly one low-risk, reversible responsibility. Mutable work must use
+a canary and then serial execution, enforce cluster-readiness gates before and after each node, and
+stop on degraded readiness. Its reviewed rollback must restore the previous known-good state, and a
+second convergence run must report `changed=0` before promotion.
+
+Secrets do not belong in Git, inventory, cached facts, or logs. Never store SSH keys, passwords,
+tokens, vault passwords, kubeconfigs, or privilege-escalation credentials here. Supply any future
+approved authentication at runtime through the established operator mechanism; ignore rules are only
+defense in depth and are not a secret-storage policy.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = inventories/staging/hosts.yml
+roles_path = roles
+host_key_checking = True
+retry_files_enabled = False
+fact_caching = memory

--- a/infra/ansible/inventories/staging/hosts.yml
+++ b/infra/ansible/inventories/staging/hosts.yml
@@ -1,0 +1,6 @@
+---
+staging:
+  hosts:
+    sugarkube3:
+    sugarkube4:
+    sugarkube5:

--- a/infra/ansible/playbooks/staging_preflight.yml
+++ b/infra/ansible/playbooks/staging_preflight.yml
@@ -1,0 +1,31 @@
+---
+- name: Validate the staging node baseline without making changes
+  hosts: staging
+  gather_facts: true
+  become: false
+
+  tasks:
+    - name: Require Linux on every staging node
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.system == "Linux"
+        fail_msg: >-
+          {{ inventory_hostname }} must run Linux; detected
+          {{ ansible_facts.system | default('an unknown operating system') }}.
+        success_msg: >-
+          {{ inventory_hostname }} reports the required Linux operating system.
+
+    - name: Require an ARM64 machine architecture
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.architecture in ['aarch64', 'arm64']
+        fail_msg: >-
+          {{ inventory_hostname }} must use ARM64; detected
+          {{ ansible_facts.architecture | default('an unknown architecture') }}.
+        success_msg: >-
+          {{ inventory_hostname }} reports a supported ARM64 architecture.
+
+    - name: Report the validated non-sensitive baseline
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} passed the Linux and ARM64 staging baseline.

--- a/infra/ansible/requirements.txt
+++ b/infra/ansible/requirements.txt
@@ -1,0 +1,3 @@
+ansible-core==2.21.3
+ansible-lint==26.8.0
+yamllint==1.38.0


### PR DESCRIPTION
### Motivation

- Provide the Ansible half of Phase B as a credential-free, validation-only scaffold for the staging Raspberry Pi nodes.
- Enable a future read-only preflight (facts-only) canary run without encoding credentials, topology, or any mutable operations in the repository.
- Offer repeatable, pinned tooling and CI so operators can validate configuration and inventory locally before any live, operator-authorised run.

### Description

- Add `infra/ansible/requirements.txt` with exact pins for `ansible-core==2.21.3`, `ansible-lint==26.8.0`, and `yamllint==1.38.0` so CI and local validation use the same toolset.
- Add `infra/ansible/ansible.cfg` that points to the checked-in `inventories/staging/hosts.yml`, sets `roles_path = roles`, keeps `host_key_checking = True`, disables retry files, and uses memory-only fact caching.
- Add a static YAML inventory `infra/ansible/inventories/staging/hosts.yml` containing exactly the three staging aliases `sugarkube3`, `sugarkube4`, and `sugarkube5` with no connection variables or secrets.
- Add a read-only preflight playbook `infra/ansible/playbooks/staging_preflight.yml` that targets `staging`, uses `gather_facts: true` and `become: false`, and performs only safe `ansible.builtin.assert` checks for `ansible_facts.system == "Linux"` and `ansible_facts.architecture in ['aarch64', 'arm64']`, then reports a limited non-sensitive success message.
- Add `infra/ansible/README.md` documenting scope, safety boundaries, local installation in an isolated Python environment, the unauthorized future canary command, secrets policy, and how/why to update pinned tools.
- Add a focused workflow `.github/workflows/ansible-validate.yml` that runs on PRs/pushes touching `infra/ansible/**`, sets `ANSIBLE_CONFIG` to the checked-in config, installs only the pinned requirements, runs `yamllint`, `ansible-lint`, `ansible-inventory` (graph and list), and `ansible-playbook --syntax-check` (no host connections).
- Add narrowly scoped `.gitignore` entries under `infra/ansible/` for generated/local-only artifacts such as `.ansible/`, `.cache/`, virtualenvs, `*.retry`, local inventory overrides, vault-password files, and logs.

### Testing

- Installed pinned tools into a fresh venv with `python3 -m venv /tmp/sugarkube-ansible-validate` and `pip install --requirement infra/ansible/requirements.txt`, which completed successfully.
- Verified runtime checks using `ANSIBLE_CONFIG=infra/ansible/ansible.cfg` and `PATH` pointing at the venv: `ansible --version`, `ansible-config dump --only-changed`, `ansible-inventory --graph` and `--list`, `yamllint infra/ansible`, `ansible-lint infra/ansible/playbooks/staging_preflight.yml`, and `ansible-playbook --syntax-check` all succeeded without attempting connections to hosts.
- Documentation and link/spelling checks: `pyspelling -c .spellcheck.yaml` and `linkchecker --no-warnings README.md docs/` were run; linkchecker returned no errors and pyspelling completed in the environment (system spellchecker binary was installed as part of validation).
- Safety and audit scans passed: automated grep checks for forbidden inventory/credential patterns and for mutable modules returned no matches, and the repository audit confirmed no tracked generated/local-only Ansible artifacts.
- Known repository-wide pre-existing checks: `pre-commit run --all-files` surfaced unrelated, pre-existing repository issues (YAML multi-document and other lint errors) which are outside the scope of this PR and were not introduced by these changes; the workflow and local validation avoid executing playbooks against hosts and make no mutable changes.

If you want, I can open a pull request with this branch and the changeset description, or adjust any file content (pins, playbook checks, or CI steps) before requesting review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a893860e750832fb1bcba6a2788f718)