### PR TITLE
infra: add credential-free Ansible staging validation foundation

### DIFF
--- a/.github/workflows/ansible-validate.yml
+++ b/.github/workflows/ansible-validate.yml
@@ -1,0 +1,47 @@
+name: Ansible validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+  pull_request:
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+
+permissions:
+  contents: read
+
+env:
+  ANSIBLE_CONFIG: ${{ github.workspace }}/infra/ansible/ansible.cfg
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install pinned validation dependencies
+        run: python -m pip install --requirement infra/ansible/requirements.txt
+      - name: Inspect Ansible configuration
+        run: ansible-config dump --only-changed
+      - name: Lint YAML
+        run: yamllint infra/ansible
+      - name: Lint preflight playbook
+        run: ansible-lint infra/ansible/playbooks/staging_preflight.yml
+      - name: Parse and display staging inventory
+        run: |
+          ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+          ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+      - name: Check preflight syntax without contacting hosts
+        run: >-
+          ansible-playbook
+          --inventory infra/ansible/inventories/staging/hosts.yml
+          --syntax-check
+          infra/ansible/playbooks/staging_preflight.yml

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,13 @@ infra/terraform/**/*.tfvars
 infra/terraform/**/*.tfvars.json
 infra/terraform/**/*.auto.tfvars
 infra/terraform/**/*.auto.tfvars.json
+
+# Ansible generated and local-only files (infra/ansible only)
+infra/ansible/**/.ansible/
+infra/ansible/**/.cache/
+infra/ansible/**/.venv/
+infra/ansible/**/venv/
+infra/ansible/**/*.retry
+infra/ansible/**/inventory.local.*
+infra/ansible/**/vault*password*
+infra/ansible/**/*.log

--- a/docs/design/terraform-ansible-integration.md
+++ b/docs/design/terraform-ansible-integration.md
@@ -11,6 +11,11 @@ personas:
 
 ## Overview and current status
 
+**Phase B status:** The credential-free Terraform and Ansible validation foundations now exist.
+Live Ansible preflight and node convergence, Terraform state/backend selection, DNS resources,
+Cloudflare adoption, and every production configuration or operation remain unimplemented and
+require separate review and authorization.
+
 Terraform and Ansible address different layers. Terraform manages stateful external resources through
 provider APIs and makes proposed changes, applies, and drift visible. Ansible manages idempotent
 post-boot host configuration over SSH. They complement the existing platform rather than replacing it.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,9 +1,10 @@
 # Infra Helpers
 
 This directory contains the credential-free [Terraform validation foundation](terraform/README.md)
-and is reserved for operational helpers such as future Terraform modules, Ansible playbooks,
-bootstrap helpers, and non-secret bootstrap metadata. Terraform state and saved plans are sensitive
-remote artifacts and must not be committed beneath `infra/`.
+and [Ansible staging validation foundation](ansible/README.md). It is reserved for operational
+helpers such as future Terraform modules, Ansible playbooks, bootstrap helpers, and non-secret
+bootstrap metadata. Terraform state and saved plans are sensitive remote artifacts and must not be
+committed beneath `infra/`.
 
 The [Terraform and Ansible integration design](../docs/design/terraform-ansible-integration.md)
 defines the ownership and safety boundaries that this foundation and any future automation must

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,72 @@
+# Ansible staging validation foundation
+
+This directory is the credential-free Ansible half of Phase B in the
+[Terraform and Ansible integration design](../../docs/design/terraform-ansible-integration.md).
+Ansible is reserved for carefully adopted post-boot host configuration. Terraform may own selected
+external provider resources, while Helm/Just and Flux retain their existing application and
+Kubernetes ownership. Every individual resource has one authoritative writer; its current writer
+remains authoritative until a reviewed handoff retires that writer.
+
+## Current scope and safety boundary
+
+This scaffold supplies a static staging inventory, local configuration, pinned validation tools,
+credential-free CI, and a future facts-based, read-only preflight. It supplies no roles, production
+inventory, secrets, dynamic inventory, mutable tasks, live connection, or node convergence. In
+particular, Pi imaging, bootstrap scripts, `just ha3`, `/etc/rancher/k3s/config.yaml`, Helm/Just,
+Flux, and existing app workflows retain their current ownership.
+
+The inventory contains aliases only. `sugarkube3`, `sugarkube4`, and `sugarkube5` must resolve via an
+operator's existing SSH configuration when a later review authorizes live use. Host-key checking is
+explicitly enabled. Before any connection, validate each fingerprint through an independent,
+trusted channel; never accept an unexpected or unverified key.
+
+Do not commit SSH keys, passwords, tokens, vault passwords, kubeconfigs, privilege-escalation
+credentials, or private topology. They also must not enter inventory, cached facts, or logs. Ignore
+rules are defense in depth, not permission to create secret material in this tree.
+
+## Install and validate locally
+
+The repository's supported Python 3.12 can install the exact validation dependencies in an isolated
+environment. Run from the repository root:
+
+```bash
+python3.12 -m venv /tmp/sugarkube-ansible-validate
+/tmp/sugarkube-ansible-validate/bin/python -m pip install \
+  --requirement infra/ansible/requirements.txt
+export PATH="/tmp/sugarkube-ansible-validate/bin:$PATH"
+export ANSIBLE_CONFIG="$PWD/infra/ansible/ansible.cfg"
+
+ansible-config dump --only-changed
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+yamllint infra/ansible
+ansible-lint infra/ansible/playbooks/staging_preflight.yml
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --syntax-check infra/ansible/playbooks/staging_preflight.yml
+```
+
+The three exact pins in `requirements.txt` are intentionally reviewed together. To update them,
+identify current stable releases compatible with Python 3.12, change all necessary pins, install
+them together in a fresh virtual environment, and repeat every validation command above. Exact pins
+keep local and CI validation reproducible; no Galaxy collection is needed because the playbook uses
+only `ansible.builtin` modules.
+
+## Future live milestones (not authorized here)
+
+> **Warning:** The following operator command is documentation for a later, separately authorized
+> live canary. This task and CI do not run it or connect to any staging node.
+
+```bash
+ansible-playbook --inventory infra/ansible/inventories/staging/hosts.yml \
+  --limit sugarkube3 --check --diff infra/ansible/playbooks/staging_preflight.yml
+```
+
+The first live milestone gathers facts and performs only read-only baseline validation across
+staging because reachability and durable host assumptions must be established before ownership or
+configuration changes are considered. A separate PR may then introduce the first mutable role, but
+it must adopt exactly one low-risk, reversible responsibility from its current writer.
+
+That later convergence must start with a canary and proceed serially, with cluster readiness and
+quorum gates before and after each node. Its review must define rollback, stop on degraded health,
+and require a second run to report `changed=0`. Check mode and diff output aid review but never by
+themselves authorize a live connection or mutation.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = ./inventories/staging/hosts.yml
+roles_path = ./roles
+host_key_checking = True
+retry_files_enabled = False
+fact_caching = memory

--- a/infra/ansible/inventories/staging/hosts.yml
+++ b/infra/ansible/inventories/staging/hosts.yml
@@ -1,0 +1,6 @@
+---
+staging:
+  hosts:
+    sugarkube3:
+    sugarkube4:
+    sugarkube5:

--- a/infra/ansible/playbooks/staging_preflight.yml
+++ b/infra/ansible/playbooks/staging_preflight.yml
@@ -1,0 +1,26 @@
+---
+- name: Validate the staging node baseline
+  hosts: staging
+  gather_facts: true
+  become: false
+
+  tasks:
+    - name: Require Linux on an ARM64 architecture
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.system == "Linux"
+          - ansible_facts.architecture in ["aarch64", "arm64"]
+        fail_msg: >-
+          Staging nodes must run Linux on ARM64;
+          {{ inventory_hostname }} reported
+          {{ ansible_facts.system | default('unknown') }} on
+          {{ ansible_facts.architecture | default('unknown') }}.
+        success_msg: >-
+          {{ inventory_hostname }} satisfies the Linux ARM64 baseline.
+
+    - name: Report the validated operating-system baseline
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: {{ ansible_facts.distribution }}
+          {{ ansible_facts.distribution_version }} on
+          {{ ansible_facts.architecture }}

--- a/infra/ansible/requirements.txt
+++ b/infra/ansible/requirements.txt
@@ -1,0 +1,3 @@
+ansible-core==2.21.3
+ansible-lint==26.8.0
+yamllint==1.38.0


### PR DESCRIPTION
### Motivation

- Provide the Ansible half of Phase B from the Terraform/Ansible integration design as a credential-free, read-only validation scaffold for staging nodes.
- Supply minimal, reviewable repository scaffolding so operators can later run a facts-only, non-mutating preflight against `sugarkube3/4/5` once authorized.
- Preserve safety: do not connect to hosts, mutate infrastructure, or introduce credentials; CI must be static and syntax/lint-only.

### Description

- Add a minimal Ansible scaffold under `infra/ansible/` including `ansible.cfg`, pinned Python validation requirements in `requirements.txt`, a static staging inventory `inventories/staging/hosts.yml`, a read-only preflight `playbooks/staging_preflight.yml`, and a concise `README.md` documenting scope, usage and safety.
- `ansible.cfg` defaults to the checked-in staging inventory, points `roles_path` to a local `roles/` path for future roles, enables strict SSH host-key checking, disables retry files, and uses in-memory fact caching only.
- The inventory contains exactly three aliases and no connection details: `sugarkube3`, `sugarkube4`, `sugarkube5` (aliases only; no `ansible_host`, usernames, ports, keys, tokens, or topology).
- The preflight playbook is facts-based and read-only (`gather_facts: true`, `become: false`) using only `ansible.builtin` modules to assert a Linux on ARM64 baseline and report distribution/version; it contains no mutable or shell/command tasks.
- Add a focused GitHub Actions workflow `.github/workflows/ansible-validate.yml` that installs the pinned validation dependencies, sets `ANSIBLE_CONFIG` to the checked-in config, runs `yamllint`, `ansible-lint`, `ansible-inventory` (graph/list) and `ansible-playbook --syntax-check` without contacting any hosts.
- Add narrowly scoped ignore rules in `.gitignore` for local/generated Ansible artifacts (e.g. `.ansible/`, virtualenvs, `.retry`, local inventory overrides, vault-password files, logs).  Update `infra/README.md` and `docs/design/terraform-ansible-integration.md` with a short status link to the new scaffold.

### Testing

- Created an isolated environment and installed pinned validators: `python3 -m venv /tmp/sugarkube-ansible-validate` and `/tmp/sugarkube-ansible-validate/bin/python -m pip install --requirement infra/ansible/requirements.txt` completed successfully and installed `ansible-core==2.21.3`, `ansible-lint==26.8.0`, `yamllint==1.38.0`.
- Verified Ansible configuration and static inventory parsing: `ansible --version` reported `ansible-core 2.21.3` on Python `3.12.13`; `ansible-config dump --only-changed` respected the checked-in `ansible.cfg`; `ansible-inventory --graph` and `--list` showed the `staging` group with `sugarkube3`, `sugarkube4`, `sugarkube5`.
- Lint and syntax checks passed: `yamllint infra/ansible`, `ansible-lint infra/ansible/playbooks/staging_preflight.yml`, and `ansible-playbook --syntax-check --inventory infra/ansible/inventories/staging/hosts.yml infra/ansible/playbooks/staging_preflight.yml` all succeeded after a line-wrapping fix in the playbook to satisfy `ansible-lint`.
- Documentation and link checks: `pyspelling -c .spellcheck.yaml` initially required system `aspell` and then passed after installing it; `linkchecker --no-warnings README.md docs/` ran and reported 0 warnings/errors over 220 internal URLs.
- Project checks: `pre-commit` run across the whole repository exposed pre-existing repository-wide issues unrelated to this PR; targeted pre-commit hooks for the new files (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`) passed for the changed Ansible files and workflow; unrelated tool-generated edits were restored before commit.
- Safety audits passed: repository searches for credentials or mutable modules in `infra/ansible` returned no matches; tracked-artifact scan found no committed local caches, retry files, logs, or vault-password files in `infra/ansible`.

All automated validation steps above completed without contacting any staging host, performing any live changes, or adding credentials or production inventory. The change set is limited to the Ansible scaffold, its CI workflow and ignore rules, and the minimal infra/docs updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8938636fdc832fa2754e617d180dd3)