### PR TITLE
infra: add credential-free Ansible staging validation foundation

### DIFF
--- a/.github/workflows/ansible-validate.yml
+++ b/.github/workflows/ansible-validate.yml
@@ -1,0 +1,49 @@
+name: Ansible validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+  pull_request:
+    paths:
+      - 'infra/ansible/**'
+      - '.github/workflows/ansible-validate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      ANSIBLE_CONFIG: ${{ github.workspace }}/infra/ansible/ansible.cfg
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: infra/ansible/requirements.txt
+      - name: Install pinned validation dependencies
+        run: python -m pip install --requirement infra/ansible/requirements.txt
+      - name: Inspect effective Ansible configuration
+        run: ansible-config dump --only-changed
+      - name: Lint YAML
+        run: yamllint infra/ansible
+      - name: Lint the staging preflight
+        run: ansible-lint infra/ansible/playbooks/staging_preflight.yml
+      - name: Parse and display the staging inventory
+        run: |
+          inventory=infra/ansible/inventories/staging/hosts.yml
+          ansible-inventory --inventory "$inventory" --graph
+          ansible-inventory --inventory "$inventory" --list
+      - name: Check playbook syntax without contacting hosts
+        run: >-
+          ansible-playbook
+          --inventory infra/ansible/inventories/staging/hosts.yml
+          --syntax-check
+          infra/ansible/playbooks/staging_preflight.yml

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ infra/terraform/**/*.tfvars
 infra/terraform/**/*.tfvars.json
 infra/terraform/**/*.auto.tfvars
 infra/terraform/**/*.auto.tfvars.json
+
+# Ansible generated and local-only files (infra/ansible only)
+infra/ansible/**/.ansible/
+infra/ansible/**/.cache/
+infra/ansible/**/.venv/
+infra/ansible/**/venv/
+infra/ansible/**/*.retry
+infra/ansible/inventories/**/*local*.yml
+infra/ansible/inventories/**/*local*.yaml
+infra/ansible/**/vault*password*
+infra/ansible/**/*.log

--- a/docs/design/terraform-ansible-integration.md
+++ b/docs/design/terraform-ansible-integration.md
@@ -11,6 +11,11 @@ personas:
 
 ## Overview and current status
 
+**Phase B status (2026-08-22):** The credential-free Terraform and Ansible validation foundations
+now exist. Live Ansible preflight, node convergence, Terraform state/backend selection, DNS
+resources, Cloudflare adoption, and every production implementation remain unimplemented and require
+separate review and authorization.
+
 Terraform and Ansible address different layers. Terraform manages stateful external resources through
 provider APIs and makes proposed changes, applies, and drift visible. Ansible manages idempotent
 post-boot host configuration over SSH. They complement the existing platform rather than replacing it.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,9 +1,10 @@
 # Infra Helpers
 
 This directory contains the credential-free [Terraform validation foundation](terraform/README.md)
-and is reserved for operational helpers such as future Terraform modules, Ansible playbooks,
-bootstrap helpers, and non-secret bootstrap metadata. Terraform state and saved plans are sensitive
-remote artifacts and must not be committed beneath `infra/`.
+and [Ansible staging validation foundation](ansible/README.md). It is reserved for operational
+helpers such as future Terraform modules, Ansible roles, bootstrap helpers, and non-secret bootstrap
+metadata. Terraform state and saved plans are sensitive remote artifacts and must not be committed
+beneath `infra/`.
 
 The [Terraform and Ansible integration design](../docs/design/terraform-ansible-integration.md)
 defines the ownership and safety boundaries that this foundation and any future automation must

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -1,0 +1,82 @@
+# Ansible staging validation foundation
+
+This directory is the credential-free Ansible half of Phase B in the
+[Terraform and Ansible integration design](../../docs/design/terraform-ansible-integration.md).
+Ansible is intended for explicitly adopted post-boot host configuration. Terraform owns only
+separately adopted external provider resources, while Helm/Just and Flux retain their existing
+application and Kubernetes ownership. **Every individual resource has one authoritative writer.**
+An Ansible role may take responsibility only after a reviewed handoff retires the previous writer.
+
+## Current scope and safety boundary
+
+This scaffold provides a static staging inventory, safe local configuration, pinned validation
+tools, a read-only future preflight, and static CI. It has no production inventory, roles, host or
+group variables, secrets, vault, dynamic inventory, persistent fact cache, repository log, or
+mutable playbook. Validation does not contact a host.
+
+The aliases `sugarkube3`, `sugarkube4`, and `sugarkube5` contain no connection data. During a later,
+separately authorized live run, the operator's existing SSH configuration must resolve them. Ansible
+keeps strict SSH host-key checking enabled. Validate every host fingerprint out of band before a
+first connection; never accept a changed or unknown key merely to continue.
+
+Pi imaging and bootstrap scripts retain their current ownership, as do `just ha3`,
+`/etc/rancher/k3s/config.yaml`, Helm/Just, Flux, and existing application workflows. This scaffold
+does not install packages, configure nodes or k3s, deploy applications, or mutate infrastructure.
+
+## Install and validate locally
+
+Use the repository-supported Python 3.12 in an isolated environment, from the repository root:
+
+```bash
+python3.12 -m venv /tmp/sugarkube-ansible-validate
+/tmp/sugarkube-ansible-validate/bin/python -m pip install \
+  --requirement infra/ansible/requirements.txt
+export PATH="/tmp/sugarkube-ansible-validate/bin:$PATH"
+export ANSIBLE_CONFIG="$PWD/infra/ansible/ansible.cfg"
+```
+
+Inspect and statically validate the checked-in content without connecting to a node:
+
+```bash
+ansible-config dump --only-changed
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --graph
+ansible-inventory --inventory infra/ansible/inventories/staging/hosts.yml --list
+yamllint infra/ansible
+ansible-lint infra/ansible/playbooks/staging_preflight.yml
+ansible-playbook \
+  --inventory infra/ansible/inventories/staging/hosts.yml \
+  --syntax-check infra/ansible/playbooks/staging_preflight.yml
+```
+
+`requirements.txt` pins exact, mutually compatible releases so local and CI validation agree. To
+update them, review the current stable releases and Python requirements for all three packages,
+change all affected pins together, install them in a fresh Python 3.12 environment, review transitive
+dependency resolution, and rerun every command above before committing.
+
+## Future operator milestone — not authorized here
+
+The first live milestone will gather facts and run this read-only baseline across staging. That
+limited step establishes reachability and platform evidence before Ansible owns any node setting.
+The following future canary command is documentation only: **this task and its CI do not authorize or
+execute it.**
+
+```bash
+ansible-playbook \
+  --inventory infra/ansible/inventories/staging/hosts.yml \
+  --limit sugarkube3 \
+  --check \
+  --diff \
+  infra/ansible/playbooks/staging_preflight.yml
+```
+
+The first mutable role must be a separate PR adopting exactly one low-risk, reversible
+responsibility from its current writer. Its rollout must use a canary and serial execution, enforce
+cluster readiness and quorum gates before and after each node, document rollback, and require a
+second convergence run with `changed=0` before promotion.
+
+## Secrets policy
+
+Never put SSH keys, passwords, tokens, vault passwords, kubeconfigs, privilege-escalation
+credentials, or private topology in Git, inventory, cached facts, or logs. Ignore rules are only a
+backstop for local artifacts, not a secret-storage mechanism. Supply any credentials for a future
+authorized operation through an approved runtime mechanism and keep their values out of output.

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = inventories/staging/hosts.yml
+roles_path = roles
+host_key_checking = True
+retry_files_enabled = False
+fact_caching = memory

--- a/infra/ansible/inventories/staging/hosts.yml
+++ b/infra/ansible/inventories/staging/hosts.yml
@@ -1,0 +1,6 @@
+---
+staging:
+  hosts:
+    sugarkube3:
+    sugarkube4:
+    sugarkube5:

--- a/infra/ansible/playbooks/staging_preflight.yml
+++ b/infra/ansible/playbooks/staging_preflight.yml
@@ -1,0 +1,22 @@
+---
+- name: Validate the staging node baseline without making changes
+  hosts: staging
+  gather_facts: true
+  become: false
+
+  tasks:
+    - name: Require Linux on an ARM64 architecture
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.system == "Linux"
+          - ansible_facts.architecture in ["aarch64", "arm64"]
+        fail_msg: >-
+          This staging node must report Linux on ARM64; it reported
+          {{ ansible_facts.system }} on {{ ansible_facts.architecture }}.
+        success_msg: "The node reports the required Linux ARM64 baseline."
+
+    - name: Report the validated non-sensitive baseline
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} passed the read-only operating-system and
+          architecture preflight.

--- a/infra/ansible/requirements.txt
+++ b/infra/ansible/requirements.txt
@@ -1,0 +1,3 @@
+ansible-core==2.21.3
+ansible-lint==26.8.0
+yamllint==1.38.0


### PR DESCRIPTION
### Motivation

- Implement the Ansible half of Phase B from the Terraform/Ansible integration design as a credential-free, validation-only scaffold for staging Raspberry Pi nodes. 
- Provide a safe, read-only preflight that gathers facts and asserts platform expectations without connecting to hosts or mutating any infrastructure. 
- Surface a minimal operator workflow and CI for static validation so future live runs are explicitly authorized and auditable. 

### Description

- Add pinned validation dependencies in `infra/ansible/requirements.txt` with `ansible-core==2.21.3`, `ansible-lint==26.8.0`, and `yamllint==1.38.0`. 
- Add `infra/ansible/ansible.cfg` that defaults to the checked-in staging inventory, points `roles_path` to a local `roles` directory, enables strict SSH host-key checking, disables retry files, and uses in-memory fact caching. 
- Add a static YAML inventory `infra/ansible/inventories/staging/hosts.yml` with exactly the three aliases `sugarkube3`, `sugarkube4`, and `sugarkube5` and no addresses, credentials, or topology. 
- Add a read-only preflight `infra/ansible/playbooks/staging_preflight.yml` that uses `gather_facts: true`, `become: false`, and only `ansible.builtin` modules to assert Linux on ARM64 and report a non-sensitive pass message. 
- Add operator documentation `infra/ansible/README.md` describing scope, safety rules, dependency installation, static validation commands, the unauthorized future canary command, and secrets policy. 
- Add a focused CI workflow `.github/workflows/ansible-validate.yml` that runs on PRs and `main` changes to `infra/ansible`, installs only the pinned validation requirements, sets `ANSIBLE_CONFIG` to the checked-in config, runs `yamllint`, `ansible-lint`, `ansible-inventory` parsing, and `ansible-playbook --syntax-check` without contacting hosts. 
- Add narrowly scoped `.gitignore` entries under `infra/ansible/` for local-only artifacts such as `.ansible/`, `.cache/`, virtualenvs, retry files, local inventory overrides, vault-password files, and local logs. 
- Record Phase B status in `docs/design/terraform-ansible-integration.md` and add a short link from `infra/README.md` to the new Ansible foundation. 

### Testing

- Created an isolated Python 3.12 virtualenv and successfully installed `infra/ansible/requirements.txt` together, verifying pinned package compatibility. 
- Confirmed `ansible --version` reports `ansible-core 2.21.3` running on Python `3.12.13`, and ran `ansible-config dump --only-changed` to verify the checked-in config is effective. 
- Verified inventory parsing with `ansible-inventory --graph` and `--list`, validated YAML with `yamllint`, linted the playbook with `ansible-lint`, and ran `ansible-playbook --syntax-check` against the preflight — all succeeded. 
- Ran doc checks `pyspelling` and `linkchecker` (installed `aspell` in the environment where required) which completed successfully; a full `pre-commit run --all-files` exposed unrelated, pre-existing repository lint issues and made auto-fixes that were restored so the commit remains focused. 
- Ran the repository secret scanner which returned a nonzero code because the new `.gitignore` wording contains the word `password`; the diff was manually audited and contains only ignore/policy text with no credential values. 

Residual notes: the change is intentionally static and non-mutative (no SSH, no playbook execution beyond `--syntax-check`, no credentials, no production inventory, and no Terraform or application changes were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a893856741c832f831503b7a89047af)